### PR TITLE
Update .npmignore, fixes #16

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,27 @@
-# Ignoring nothing. Publishing both src and lib to npm
+# editors
+.idea
+.vscode
+
+# library
+node_modules/
+
+# MacOS
+.DS_Store
+
+# generated site & stories
+site/
+.storybook/
+
+# coverage reports
+coverage/
+
+# yarn
+yarn.lock
+
+# CI
+.travis.yml
+
+# logs
+yarn-error.log
+npm-debug.log
+npm-debug.log.*


### PR DESCRIPTION
I brought exclusions forward from the `.gitignore` file and tweaked it to be appropriate for npm.

re: @bengummer's list, imo the babel and eslint configs *should* be published to npm since we're publishing source, and they describe how it should be interpreted.