### PR TITLE
Animate cancel

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,15 @@ Drag and drop with react-beautiful-dnd is supposed to feel physical and natural 
 
 Drop shadows are useful in an environment where items and their destinations snap around. However, with react-beautiful-dnd it should be obvious where things will be dropping based on the movement of items. This might be changed in the future - but the experiment is to see how far we can get without any of these affordances.
 
+#### Application 3: no dead zones
+
+react-beautiful-dnd works really hard to avoid any periods of time where the user cannot fully engage with the application (no 'dead zones'). However, there is a balance that needs to be done between correctness and power in order to make everybody's lives more sane. Here are the only situations where some things are not interactive:
+
+1. From when a user cancels a drag to when the drop animation completes. On cancel there are lots of things moving back to where they should be. If you grab an item in a location that is not its true home then the following drag will be incorrect.
+2. Starting a drag on an item that is animating its own drop. For simplicity this is the case - it is actually quite hard to grab something while it is animating home. It could be coded around - but it seems like an edge case that would add a lot of complexity.
+
+Keep in mind that these dead zones may not always exist.
+
 ### Sloppy clicks and click blocking 🐱🎁
 
 A drag will not start until a user has dragged their mouse past a small threshold. If this threshold is not exceeded then the library will not impact the mouse click and will release the event to the browser.

--- a/src/state/get-new-home-client-offset.js
+++ b/src/state/get-new-home-client-offset.js
@@ -12,7 +12,8 @@ type NewHomeArgs = {|
   movement: DragMovement,
   clientOffset: Position,
   pageOffset: Position,
-  scrollDiff: Position,
+  droppableScrollDiff: Position,
+  windowScrollDiff: Position,
   draggables: DraggableDimensionMap,
 |}
 
@@ -24,12 +25,13 @@ export default ({
   movement,
   clientOffset,
   pageOffset,
-  scrollDiff,
+  droppableScrollDiff,
+  windowScrollDiff,
   draggables,
 }: NewHomeArgs): ClientOffset => {
   // Just animate back to where it started
   if (!movement.draggables.length) {
-    return scrollDiff;
+    return add(droppableScrollDiff, windowScrollDiff);
   }
 
   // Currently not considering horizontal movement
@@ -55,7 +57,7 @@ export default ({
   const client: Position = add(verticalDiff, clientOffset);
 
   // Accounting for container scroll
-  const withScroll: Position = add(client, scrollDiff);
+  const withScroll: Position = add(client, droppableScrollDiff);
 
   return withScroll;
 };

--- a/src/state/hook-middleware.js
+++ b/src/state/hook-middleware.js
@@ -33,12 +33,13 @@ const getFireHooks = (hooks: Hooks) => memoizeOne((current: State, previous: Sta
 
     const { source, destination, draggableId } = current.drop.result;
 
+    // Could be a cancel or a drop nowhere
     if (!destination) {
       onDragEnd(current.drop.result);
       return;
     }
 
-    // Do not publish a result where nothing moved
+    // Do not publish a result.destination where nothing moved
     const didMove: boolean = source.droppableId !== destination.droppableId ||
                               source.index !== destination.index;
 
@@ -56,7 +57,7 @@ const getFireHooks = (hooks: Hooks) => memoizeOne((current: State, previous: Sta
     onDragEnd(muted);
   }
 
-  // Drag cancelled while dragging
+  // Drag ended while dragging
   if (currentPhase === 'IDLE' && previousPhase === 'DRAGGING') {
     if (!previous.drag) {
       console.error('cannot fire onDragEnd for cancel because cannot find previous drag');
@@ -70,7 +71,7 @@ const getFireHooks = (hooks: Hooks) => memoizeOne((current: State, previous: Sta
     onDragEnd(result);
   }
 
-  // Drag cancelled during a drop animation. Not super sure how this can even happen.
+  // Drag ended during a drop animation. Not super sure how this can even happen.
   // This is being really safe
   if (currentPhase === 'IDLE' && previousPhase === 'DROP_ANIMATING') {
     if (!previous.drop || !previous.drop.pending) {

--- a/src/state/reducer.js
+++ b/src/state/reducer.js
@@ -434,7 +434,7 @@ export default (state: State = clean('IDLE'), action: Action): State => {
   }
 
   if (action.type === 'DROP_ANIMATE') {
-    const { newHomeOffset, result } = action.payload;
+    const { type, newHomeOffset, impact, result } = action.payload;
 
     if (state.phase !== 'DRAGGING') {
       console.error('cannot animate drop while not dragging', action);
@@ -447,9 +447,10 @@ export default (state: State = clean('IDLE'), action: Action): State => {
     }
 
     const pending: PendingDrop = {
+      type,
       newHomeOffset,
       result,
-      last: state.drag,
+      impact,
     };
 
     return {
@@ -477,7 +478,7 @@ export default (state: State = clean('IDLE'), action: Action): State => {
     };
   }
 
-  if (action.type === 'CANCEL') {
+  if (action.type === 'CLEAN') {
     return clean();
   }
 

--- a/src/types.js
+++ b/src/types.js
@@ -90,8 +90,11 @@ export type InitialDrag = {|
 |}
 
 export type CurrentDragLocation = {|
+  // where the user initially selected
   selection: Position,
+  // the current center of the item
   center: Position,
+  // how far the item has moved from its original position
   offset: Position,
 |}
 
@@ -123,9 +126,12 @@ export type DragState = {|
   impact: DragImpact,
 |}
 
+export type DropType = 'DROP' | 'CANCEL';
+
 export type PendingDrop = {|
+  type: DropType,
   newHomeOffset: Position,
-  last: DragState,
+  impact: DragImpact,
   result: DropResult,
 |}
 
@@ -149,6 +155,8 @@ export type State = {
   dimension: DimensionState,
   // null if not dragging
   drag: ?DragState,
+
+  // available when dropping or cancelling
   drop: ?DropState,
 };
 

--- a/src/view/drag-handle/drag-handle-types.js
+++ b/src/view/drag-handle/drag-handle-types.js
@@ -36,6 +36,9 @@ export type Props = {|
   isEnabled: boolean,
   // whether the application thinks a drag is occurring
   isDragging: boolean,
+
+  // dragging is otherwise enabled - but cannot lift at this time
+  canLift: boolean,
   callbacks: Callbacks,
   children: (?Provided) => void,
 |}

--- a/src/view/drag-handle/drag-handle.jsx
+++ b/src/view/drag-handle/drag-handle.jsx
@@ -81,6 +81,11 @@ export default class DragHandle extends Component {
     this.props.callbacks.onCancel();
   }
 
+  // TODO: there is a scenario where events will not be unbound:
+  // - listeners are bound
+  // - drag is cancelled during the COLLECTING_DIMENSION phase
+  // FIX: need to know when a drag is cancelled / cleaned during the
+  // COLLECTING_DIMENSIONS phase.
   componentWillReceiveProps(nextProps: Props) {
     // if the application cancels a drag we need to unbind the handlers
     const isDragStopping: boolean = (this.props.isDragging && !nextProps.isDragging);
@@ -206,6 +211,10 @@ export default class DragHandle extends Component {
       return;
     }
 
+    if (!this.props.canLift) {
+      return;
+    }
+
     const { button, clientX, clientY } = event;
 
     if (button !== primaryButton) {
@@ -287,7 +296,10 @@ export default class DragHandle extends Component {
 
   // the on element keydown is only for lifting - otherwise using the window keydown
   onKeyDown = (event: KeyboardEvent): void => {
-    if (!this.props.isEnabled || this.state.pending || this.state.draggingWith) {
+    if (!this.props.isEnabled ||
+      this.state.pending ||
+      this.state.draggingWith ||
+      !this.props.canLift) {
       return;
     }
 

--- a/src/view/draggable/draggable-types.js
+++ b/src/view/draggable/draggable-types.js
@@ -81,7 +81,7 @@ export type DispatchProps = {
 export type MapProps = {|
   isDragging: boolean,
   isDropAnimating: boolean,
-  isAnotherDragging: boolean,
+  canLift: boolean,
   canAnimate: boolean,
   offset: Position,
   dimension: ?DraggableDimension,

--- a/src/view/draggable/draggable.jsx
+++ b/src/view/draggable/draggable.jsx
@@ -175,13 +175,13 @@ export default class Draggable extends Component {
 
   onDrop = () => {
     this.throwIfCannotDrag();
-    this.props.drop(this.props.draggableId);
+    this.props.drop();
   }
 
   onCancel = () => {
     // Not checking if drag is enabled.
     // Cancel is an escape mechanism
-    this.props.cancel(this.props.draggableId);
+    this.props.cancel();
   }
 
   // React calls ref callback twice for every render
@@ -240,12 +240,12 @@ export default class Draggable extends Component {
     (
       canAnimate: boolean,
       movementStyle: MovementStyle,
-      isAnotherDragging: boolean,
+      canLift: boolean,
     ): NotDraggingStyle => {
       const style: NotDraggingStyle = {
         transition: canAnimate ? css.outOfTheWay : null,
         transform: movementStyle.transform,
-        pointerEvents: isAnotherDragging ? 'none' : 'auto',
+        pointerEvents: canLift ? 'auto' : 'none',
       };
       return style;
     }
@@ -255,7 +255,7 @@ export default class Draggable extends Component {
     (
       isDragging: boolean,
       isDropAnimating: boolean,
-      isAnotherDragging: boolean,
+      canLift: boolean,
       canAnimate: boolean,
       dimension: ?DraggableDimension,
       dragHandleProps: ?DragHandleProvided,
@@ -268,7 +268,7 @@ export default class Draggable extends Component {
           return this.getNotDraggingStyle(
             canAnimate,
             movementStyle,
-            isAnotherDragging,
+            canLift,
           );
         }
         invariant(dimension, 'draggable dimension required for dragging');
@@ -318,7 +318,7 @@ export default class Draggable extends Component {
       offset,
       isDragging,
       isDropAnimating,
-      isAnotherDragging,
+      canLift,
       canAnimate,
       isDragDisabled,
       dimension,
@@ -343,6 +343,7 @@ export default class Draggable extends Component {
             <DragHandle
               isDragging={isDragging}
               isEnabled={!isDragDisabled}
+              canLift={canLift}
               callbacks={this.callbacks}
               draggableRef={this.state.ref}
             >
@@ -351,7 +352,7 @@ export default class Draggable extends Component {
                   this.getProvided(
                     isDragging,
                     isDropAnimating,
-                    isAnotherDragging,
+                    canLift,
                     canAnimate,
                     dimension,
                     dragHandleProps,

--- a/src/view/draggable/placeholder.jsx
+++ b/src/view/draggable/placeholder.jsx
@@ -11,6 +11,7 @@ export default class Placeholder extends PureComponent {
     const style = {
       width: this.props.width,
       height: this.props.height,
+      pointerEvents: 'none',
     };
     return (
       <div style={style} />

--- a/src/view/droppable/connected-droppable.js
+++ b/src/view/droppable/connected-droppable.js
@@ -70,7 +70,7 @@ export const makeSelector = () => {
           return getMapProps(false);
         }
 
-        const isDraggingOver = getIsDraggingOver(id, pending.last.impact.destination);
+        const isDraggingOver = getIsDraggingOver(id, pending.impact.destination);
         return getMapProps(isDraggingOver);
       }
 
@@ -88,7 +88,9 @@ const makeMapStateToProps = () => {
 // that `connect` provides.
 // It avoids needing to do it own within `Droppable`
 export default connect(
-  makeMapStateToProps(),
+  // returning a function to ensure each
+  // Droppable gets its own selector
+  makeMapStateToProps,
   null,
   null,
   { storeKey },

--- a/stories/components/quote-item.jsx
+++ b/stories/components/quote-item.jsx
@@ -11,7 +11,8 @@ const Container = styled.a`
   border: 1px solid grey;
   background-color: ${({ isDragging }) => (isDragging ? 'rgb(185, 244, 188)' : 'white')};
 
-  cursor: ${({ isDragging }) => (isDragging ? 'grabbing' : 'grab')};
+  /* cursor: grabbing is handled by app */
+  cursor: grab;
   box-shadow: ${({ isDragging }) => (isDragging ? `2px 2px 1px ${colors.shadow}` : 'none')};
   padding: ${grid}px;
   min-height: 40px;

--- a/test/unit/integration/hooks-integration.spec.js
+++ b/test/unit/integration/hooks-integration.spec.js
@@ -138,9 +138,7 @@ describe('hooks integration', () => {
       requestAnimationFrame.step();
     };
 
-    const stop = () => {
-      windowMouseUp();
-
+    const waitForReturnToHome = () => {
       // flush the return to home animation
       requestAnimationFrame.flush();
 
@@ -148,8 +146,14 @@ describe('hooks integration', () => {
       jest.runOnlyPendingTimers();
     };
 
+    const stop = () => {
+      windowMouseUp();
+      waitForReturnToHome();
+    };
+
     const cancel = () => {
       cancelWithKeyboard();
+      waitForReturnToHome();
     };
 
     const perform = () => {

--- a/test/unit/state/get-new-home-client-offset.spec.js
+++ b/test/unit/state/get-new-home-client-offset.spec.js
@@ -57,25 +57,30 @@ const draggables: DraggableDimensionMap = {
 };
 
 describe('get new home client offset', () => {
-  it('should return to the scrollDiff if nothing has moved', () => {
+  it('should return to the total scroll diff if nothing has moved', () => {
     const offset: Position = {
       x: 100,
       y: 200,
     };
-    const scrollDiff: Position = {
+    const droppableScrollDiff: Position = {
       x: 20,
       y: 10,
+    };
+    const windowScrollDiff: Position = {
+      x: 30,
+      y: 20,
     };
 
     const result: Position = getNewHomeClientOffset({
       movement: noImpact.movement,
       clientOffset: offset,
       pageOffset: offset,
-      scrollDiff,
+      droppableScrollDiff,
+      windowScrollDiff,
       draggables,
     });
 
-    expect(result).toEqual(scrollDiff);
+    expect(result).toEqual(add(droppableScrollDiff, windowScrollDiff));
   });
 
   describe('moving forward', () => {
@@ -116,7 +121,8 @@ describe('get new home client offset', () => {
         movement,
         clientOffset,
         pageOffset,
-        scrollDiff: origin,
+        droppableScrollDiff: origin,
+        windowScrollDiff: origin,
         draggables,
       });
 
@@ -127,7 +133,10 @@ describe('get new home client offset', () => {
     it('should account for any changes in the droppables scroll container', () => {
       const clientOffset: Position = origin;
       const pageOffset: Position = origin;
-      const scrollDiff: Position = subtract(selection, draggable1.page.withoutMargin.center);
+      const droppableScrollDiff: Position = subtract(
+        selection,
+        draggable1.page.withoutMargin.center
+      );
       const movement: DragMovement = {
         draggables: [draggable2.id, draggable3.id],
         amount: draggable1.page.withMargin.height,
@@ -141,13 +150,50 @@ describe('get new home client offset', () => {
       // this is how far away it is from where it needs to end up
       const diff: Position = subtract(verticalChange, pageOffset);
       // this is the final client offset
-      const expected = add(diff, scrollDiff);
+      const expected = add(diff, droppableScrollDiff);
 
       const newHomeOffset = getNewHomeClientOffset({
         movement,
         clientOffset,
         pageOffset,
-        scrollDiff,
+        droppableScrollDiff,
+        windowScrollDiff: origin,
+        draggables,
+      });
+
+      expect(newHomeOffset).toEqual(expected);
+    });
+
+    // moving the first item down past the third using only window scroll
+    it('should account for any changes in the window scroll', () => {
+      const clientOffset: Position = origin;
+      const pageOffset: Position = {
+        x: 10,
+        y: 200,
+      };
+      const droppableScrollDiff = origin;
+      const windowScrollDiff = pageOffset;
+      const movement: DragMovement = {
+        draggables: [draggable2.id, draggable3.id],
+        amount: draggable1.page.withMargin.height,
+        isMovingForward: true,
+      };
+      // this is where it needs to end up
+      const verticalChange = {
+        x: 0,
+        y: draggable2.page.withMargin.height + draggable3.page.withMargin.height,
+      };
+      // this is how far away it is from where it needs to end up
+      const diff: Position = subtract(verticalChange, pageOffset);
+      // this is the final client offset
+      const expected = add(diff, droppableScrollDiff);
+
+      const newHomeOffset = getNewHomeClientOffset({
+        movement,
+        clientOffset,
+        pageOffset,
+        droppableScrollDiff: origin,
+        windowScrollDiff,
         draggables,
       });
 
@@ -193,7 +239,8 @@ describe('get new home client offset', () => {
         movement,
         clientOffset,
         pageOffset,
-        scrollDiff: origin,
+        droppableScrollDiff: origin,
+        windowScrollDiff: origin,
         draggables,
       });
 
@@ -226,7 +273,8 @@ describe('get new home client offset', () => {
         movement,
         clientOffset,
         pageOffset,
-        scrollDiff: origin,
+        droppableScrollDiff: origin,
+        windowScrollDiff: origin,
         draggables,
       });
 
@@ -237,7 +285,10 @@ describe('get new home client offset', () => {
     it('should account for any changes in the droppables scroll container', () => {
       const clientOffset: Position = origin;
       const pageOffset: Position = origin;
-      const scrollDiff: Position = subtract(selection, draggable3.page.withoutMargin.center);
+      const droppableScrollDiff: Position = subtract(
+        selection,
+        draggable3.page.withoutMargin.center
+      );
       const movement: DragMovement = {
         draggables: [draggable1.id, draggable2.id],
         amount: draggable3.page.withMargin.height,
@@ -251,13 +302,14 @@ describe('get new home client offset', () => {
       // this is how far away it is from where it needs to end up
       const diff: Position = subtract(verticalChange, pageOffset);
       // this is the final client offset
-      const expected = add(diff, scrollDiff);
+      const expected = add(diff, droppableScrollDiff);
 
       const newHomeOffset = getNewHomeClientOffset({
         movement,
         clientOffset,
         pageOffset,
-        scrollDiff,
+        droppableScrollDiff,
+        windowScrollDiff: origin,
         draggables,
       });
 

--- a/test/unit/view/connected-droppable.spec.js
+++ b/test/unit/view/connected-droppable.spec.js
@@ -153,9 +153,10 @@ const perform = (() => {
     };
 
     const pending: PendingDrop = {
+      type: 'DROP',
       newHomeOffset,
+      impact: isDraggingOver ? dragOverImpact : noImpact,
       result,
-      last: drag({ isDraggingOver }),
     };
 
     return pending;

--- a/test/unit/view/drag-handle.spec.js
+++ b/test/unit/view/drag-handle.spec.js
@@ -98,8 +98,9 @@ describe('drag handle', () => {
     wrapper = mount(
       <DragHandle
         callbacks={callbacks}
-        isEnabled
         isDragging={false}
+        isEnabled
+        canLift
       >
         {(dragHandleProps: Provided) => (
           <Child dragHandleProps={dragHandleProps} />
@@ -131,8 +132,9 @@ describe('drag handle', () => {
           const customWrapper = mount(
             <DragHandle
               callbacks={customCallbacks}
-              isEnabled
               isDragging={false}
+              isEnabled
+              canLift
             >
               {(dragHandleProps: Provided) => (
                 <Child dragHandleProps={dragHandleProps} />
@@ -166,6 +168,20 @@ describe('drag handle', () => {
 
       it('should not start a drag if not using the primary mouse button', () => {
         mouseDown(wrapper, 0, 0, auxiliaryButton);
+        windowMouseMove(0, sloppyClickThreshold);
+
+        expect(callbacksCalled(callbacks)({
+          onLift: 0,
+        })).toBe(true);
+      });
+
+      it('should not start a drag if cannot lift', () => {
+        wrapper.setProps({
+          canLift: false,
+        });
+
+        // lift
+        mouseDown(wrapper);
         windowMouseMove(0, sloppyClickThreshold);
 
         expect(callbacksCalled(callbacks)({
@@ -823,6 +839,18 @@ describe('drag handle', () => {
 
         expect(preventDefault).toHaveBeenCalled();
         expect(stopPropagation).toHaveBeenCalled();
+      });
+
+      it('should not lift if told it cannot lift', () => {
+        wrapper.setProps({
+          canLift: false,
+        });
+
+        pressSpacebar(wrapper);
+
+        expect(callbacksCalled(callbacks)({
+          onKeyLift: 0,
+        })).toBe(true);
       });
     });
 

--- a/test/unit/view/unconnected-draggable.spec.js
+++ b/test/unit/view/unconnected-draggable.spec.js
@@ -99,7 +99,7 @@ const disabledOwnProps: OwnProps = {
 const defaultMapProps: MapProps = {
   isDropAnimating: false,
   isDragging: false,
-  isAnotherDragging: false,
+  canLift: true,
   canAnimate: true,
   offset: origin,
   dimension: null,
@@ -108,7 +108,7 @@ const defaultMapProps: MapProps = {
 const somethingElseDraggingMapProps: MapProps = {
   isDropAnimating: false,
   isDragging: false,
-  isAnotherDragging: true,
+  canLift: false,
   canAnimate: true,
   offset: origin,
   dimension: null,
@@ -117,7 +117,7 @@ const somethingElseDraggingMapProps: MapProps = {
 const draggingMapProps: MapProps = {
   isDropAnimating: false,
   isDragging: true,
-  isAnotherDragging: false,
+  canLift: false,
   canAnimate: false,
   dimension,
   offset: { x: 75, y: 75 },
@@ -127,14 +127,15 @@ const dropAnimatingMapProps: MapProps = {
   isDragging: false,
   isDropAnimating: true,
   canAnimate: true,
-  isAnotherDragging: false,
+  // cannot lift while dropping
+  canLift: false,
   dimension,
   offset: { x: 75, y: 75 },
 };
 
 const dropCompleteMapProps: MapProps = {
   offset: origin,
-  isAnotherDragging: false,
+  canLift: true,
   isDropAnimating: false,
   isDragging: false,
   canAnimate: false,
@@ -555,7 +556,7 @@ describe('Draggable - unconnected', () => {
 
           wrapper.find(DragHandle).props().callbacks.onDrop();
 
-          expect(dispatchProps.drop).toBeCalledWith(draggableId);
+          expect(dispatchProps.drop).toBeCalled();
         });
       });
 
@@ -713,9 +714,9 @@ describe('Draggable - unconnected', () => {
             dispatchProps,
           });
 
-          wrapper.find(DragHandle).props().callbacks.onCancel(draggableId);
+          wrapper.find(DragHandle).props().callbacks.onCancel();
 
-          expect(dispatchProps.cancel).toBeCalledWith(draggableId);
+          expect(dispatchProps.cancel).toBeCalled();
         });
 
         it('should allow the action even if dragging is disabled', () => {
@@ -726,9 +727,9 @@ describe('Draggable - unconnected', () => {
             dispatchProps,
           });
 
-          wrapper.find(DragHandle).props().callbacks.onCancel(draggableId);
+          wrapper.find(DragHandle).props().callbacks.onCancel();
 
-          expect(dispatchProps.cancel).toBeCalledWith(draggableId);
+          expect(dispatchProps.cancel).toBeCalled();
         });
 
         it('should allow the action even when not attached to the dom', () => {
@@ -738,9 +739,9 @@ describe('Draggable - unconnected', () => {
             dispatchProps,
           });
 
-          wrapper.find(DragHandle).props().callbacks.onCancel(draggableId);
+          wrapper.find(DragHandle).props().callbacks.onCancel();
 
-          expect(dispatchProps.cancel).toBeCalledWith(draggableId);
+          expect(dispatchProps.cancel).toBeCalled();
         });
       });
 


### PR DESCRIPTION
Currently drag 'cancel' actions are not animated. This behaviour was accounted for a one point before this library was public. It must have regressed when I made some serious changes to draggable and drag handle around animations and pointer events

- [x] squash into single commit
- [x] review the hooks tests
- [x]  ensure animations work with window and container scrolling

This PR also improves a few minor performance issues
- selectors are no longer partially shared across connected components
- `user-select: none` on placeholder