### PR TITLE
using recommended packages to avoid deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,8 +62,8 @@
     "jest": "20.0.4",
     "raf-stub": "2.0.1",
     "react": "15.6.1",
-    "react-addons-test-utils": "15.6.0",
     "react-dom": "15.6.1",
+    "react-test-renderer": "15.6.1",
     "styled-components": "2.1.2"
   },
   "peerDependencies": {

--- a/src/view/draggable/draggable.jsx
+++ b/src/view/draggable/draggable.jsx
@@ -1,5 +1,6 @@
 // @flow
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import memoizeOne from 'memoize-one';
 import invariant from 'invariant';
 import type {

--- a/src/view/droppable/droppable.jsx
+++ b/src/view/droppable/droppable.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import type { Props, Provided, StateSnapshot, DefaultProps } from './droppable-types';
 import type { DroppableId, HTMLElement } from '../../types';
 import DroppableDimensionPublisher from '../droppable-dimension-publisher/';

--- a/test/unit/view/drag-drop-context.spec.js
+++ b/test/unit/view/drag-drop-context.spec.js
@@ -1,7 +1,7 @@
 // @flow
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 import { DragDropContext } from '../../../src/';
 import { storeKey } from '../../../src/view/context-keys';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5304,10 +5304,6 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-addons-test-utils@15.6.0:
-  version "15.6.0"
-  resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.6.0.tgz#062d36117fe8d18f3ba5e06eb33383b0b85ea5b9"
-
 react-docgen@^2.15.0:
   version "2.17.0"
   resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-2.17.0.tgz#b0f3e85af955714e1067593c1043cb82611a93d1"
@@ -5431,6 +5427,13 @@ react-style-proptype@^3.0.0:
   resolved "https://registry.yarnpkg.com/react-style-proptype/-/react-style-proptype-3.0.0.tgz#89e0b646f266c656abb0f0dd8202dbd5036c31e6"
   dependencies:
     prop-types "^15.5.4"
+
+react-test-renderer@15.6.1:
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.6.1.tgz#026f4a5bb5552661fd2cc4bbcd0d4bc8a35ebf7e"
+  dependencies:
+    fbjs "^0.8.9"
+    object-assign "^4.1.0"
 
 react-transition-group@^1.1.2:
   version "1.2.0"


### PR DESCRIPTION
This is in anticipation of #8 
This removes all the yuck deprecation warnings in the tests and development environments.

It also opens the way to React 16! I bumped to React 16 and everything looks good! I will not to React 16 until it is stable - but it good to know we are ready to go

(how I checked react 16: https://github.com/facebook/react/issues/10294)

It was not a super in depth analysis - but it looks good on initial pass.

Some of the tests break moving to React 16 - but it looks like jest was throwing and error because the enzyme React dependency was not met correct - which makes sense. 