### PR TITLE
Decrease minimal react version ( closed #84 )

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "flow-copy-source": "1.2.1",
     "jest": "20.0.4",
     "raf-stub": "2.0.1",
-    "react": "15.4.0",
+    "react": "15.6.1",
     "react-dom": "15.6.1",
     "react-test-renderer": "15.6.1",
     "styled-components": "2.1.2"

--- a/package.json
+++ b/package.json
@@ -64,13 +64,13 @@
     "flow-copy-source": "1.2.1",
     "jest": "20.0.4",
     "raf-stub": "2.0.1",
-    "react": "15.6.1",
+    "react": "15.4.0",
     "react-dom": "15.6.1",
     "react-test-renderer": "15.6.1",
     "styled-components": "2.1.2"
   },
   "peerDependencies": {
-    "react": "15.6.1"
+    "react": ">=15.4.0"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2181,14 +2181,6 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-react-class@^15.6.0:
-  version "15.6.0"
-  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.0.tgz#ab448497c26566e1e29413e883207d57cfe7bed4"
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.3.1"
-    object-assign "^4.1.1"
-
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -3012,6 +3004,18 @@ fb-watchman@^2.0.0:
 fbjs@^0.8.12, fbjs@^0.8.5, fbjs@^0.8.7, fbjs@^0.8.9:
   version "0.8.14"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.14.tgz#d1dbe2be254c35a91e09f31f9cd50a40b2a0ed1c"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
+
+fbjs@^0.8.4:
+  version "0.8.15"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.15.tgz#4f0695fdfcc16c37c0b07facec8cb4c4091685b9"
   dependencies:
     core-js "^1.0.0"
     isomorphic-fetch "^2.1.1"
@@ -5643,15 +5647,13 @@ react-treebeard@^2.0.3:
     shallowequal "^0.2.2"
     velocity-react "^1.3.1"
 
-react@15.6.1:
-  version "15.6.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.6.1.tgz#baa8434ec6780bde997cdc380b79cd33b96393df"
+react@15.4.0:
+  version "15.4.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-15.4.0.tgz#736c1c7c542e8088127106e1f450b010f86d172b"
   dependencies:
-    create-react-class "^15.6.0"
-    fbjs "^0.8.9"
+    fbjs "^0.8.4"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
-    prop-types "^15.5.10"
 
 read-file-async@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
All cli tests passed.
Hand tests is ok.
- Chrome, Firefox, Safari (mac)
- IE 11 (win7 in VirtualBox)

I did't change `react-dom` version, because `react-dom/test-utils` used in tests (since 15.5)
But I made hand tests with `react-dom 15.4.0`