### PR TITLE
base what droppable you are over is based on center position of draggable

### DIFF
--- a/src/state/reducer.js
+++ b/src/state/reducer.js
@@ -125,7 +125,7 @@ const move = ({
   };
 
   const newImpact: DragImpact = (impact || getDragImpact({
-    page: page.selection,
+    page: page.center,
     withinDroppable,
     draggableId: current.id,
     draggables: state.dimension.draggable,


### PR DESCRIPTION
Previously which draggable you where over was based on the mouse selection position. Are more natural way is to base it on the center position of the draggable.

I found this as part of #92 but I wanted to get this change in so people can start using it before the refactor is done