### PR TITLE
dimension clipping now considers margins

### DIFF
--- a/src/state/dimension.js
+++ b/src/state/dimension.js
@@ -123,6 +123,13 @@ const add = (spacing1: Spacing, spacing2: Spacing): Spacing => ({
   bottom: spacing1.bottom + spacing2.bottom,
 });
 
+const equal = (spacing1: Spacing, spacing2: Spacing): boolean => (
+  spacing1.top === spacing2.top &&
+  spacing1.right === spacing2.right &&
+  spacing1.bottom === spacing2.bottom &&
+  spacing1.left === spacing2.left
+);
+
 export const getDroppableDimension = ({
   id,
   clientRect,
@@ -136,8 +143,12 @@ export const getDroppableDimension = ({
 }: GetDroppableArgs): DroppableDimension => {
   const withMargin = getWithSpacing(clientRect, margin);
   const withWindowScroll = getWithPosition(clientRect, windowScroll);
-  // If no containerRect is provided, the clientRect is the container
-  const containerRectWithWindowScroll = getWithPosition(containerRect || clientRect, windowScroll);
+  // If no containerRect is provided, or if the clientRect matches the containerRect, this
+  // droppable is its own container. In that case we include margin in the container dimension.
+  const droppableIsContainer = !containerRect || equal(containerRect, clientRect);
+  const containerRectWithWindowScroll = droppableIsContainer
+    ? getWithPosition(withMargin, windowScroll)
+    : getWithPosition(containerRect || withMargin, windowScroll);
 
   const dimension: DroppableDimension = {
     id,
@@ -161,7 +172,6 @@ export const getDroppableDimension = ({
       },
       page: {
         withoutMargin: getFragment(containerRectWithWindowScroll),
-        withMargin: getFragment(getWithSpacing(containerRectWithWindowScroll, margin)),
       },
     },
   };

--- a/src/state/dimension.js
+++ b/src/state/dimension.js
@@ -161,6 +161,7 @@ export const getDroppableDimension = ({
       },
       page: {
         withoutMargin: getFragment(containerRectWithWindowScroll),
+        withMargin: getFragment(getWithSpacing(containerRectWithWindowScroll, margin)),
       },
     },
   };

--- a/src/state/dimension.js
+++ b/src/state/dimension.js
@@ -134,9 +134,10 @@ export const getDroppableDimension = ({
   // droppable is its own container. In this case we include its margin in the container bounds.
   // Otherwise, the container is a scrollable parent. In this case we don't care about margins
   // in the container bounds.
-  const containerRectWithWindowScroll = !containerRect || isEqual(containerRect, clientRect)
-    ? getWithPosition(withMargin, windowScroll)
-    : getWithPosition(containerRect, windowScroll);
+  const containerRectWithWindowScroll: ClientRect =
+    !containerRect || isEqual(containerRect, clientRect)
+      ? getWithPosition(withMargin, windowScroll)
+      : getWithPosition(containerRect, windowScroll);
 
   const dimension: DroppableDimension = {
     id,

--- a/src/state/is-within-visible-bounds-of-droppable.js
+++ b/src/state/is-within-visible-bounds-of-droppable.js
@@ -20,7 +20,7 @@ export const isPointWithin = (droppable: DroppableDimension) => {
   // Clip the droppable's bounds by the scroll container's bounds
   // This gives us the droppable's true visible area
   // Note: if the droppable doesn't have a scroll parent droppableBounds === container.page
-  const containerBounds = droppable.container.page.withMargin;
+  const containerBounds = droppable.container.page.withoutMargin;
   const clippedBounds: Spacing = {
     top: Math.max(droppableBounds.top, containerBounds.top),
     right: Math.min(droppableBounds.right, containerBounds.right),

--- a/src/state/is-within-visible-bounds-of-droppable.js
+++ b/src/state/is-within-visible-bounds-of-droppable.js
@@ -20,7 +20,7 @@ export const isPointWithin = (droppable: DroppableDimension) => {
   // Clip the droppable's bounds by the scroll container's bounds
   // This gives us the droppable's true visible area
   // Note: if the droppable doesn't have a scroll parent droppableBounds === container.page
-  const containerBounds = droppable.container.page.withoutMargin;
+  const containerBounds = droppable.container.page.withMargin;
   const clippedBounds: Spacing = {
     top: Math.max(droppableBounds.top, containerBounds.top),
     right: Math.min(droppableBounds.right, containerBounds.right),

--- a/src/state/is-within-visible-bounds-of-droppable.js
+++ b/src/state/is-within-visible-bounds-of-droppable.js
@@ -1,6 +1,7 @@
 // @flow
 import isWithin from './is-within';
-import { subtract, offsetSpacing } from './position';
+import { subtract } from './position';
+import { offset } from './spacing';
 import type {
   Position,
   DraggableDimension,
@@ -10,17 +11,17 @@ import type {
 } from '../types';
 
 export const isPointWithin = (droppable: DroppableDimension) => {
+  const { scroll, bounds: containerBounds } = droppable.container;
+
   // Calculate the mid-drag scroll ∆ of the scroll container
-  const scroll = droppable.container.scroll;
   const containerScrollDiff: Position = subtract(scroll.initial, scroll.current);
 
   // Calculate the droppable's bounds, accounting for the container's scroll
-  const droppableBounds: Spacing = offsetSpacing(droppable.page.withMargin, containerScrollDiff);
+  const droppableBounds: Spacing = offset(droppable.page.withMargin, containerScrollDiff);
 
   // Clip the droppable's bounds by the scroll container's bounds
   // This gives us the droppable's true visible area
   // Note: if the droppable doesn't have a scroll parent droppableBounds === container.page
-  const containerBounds = droppable.container.page.withoutMargin;
   const clippedBounds: Spacing = {
     top: Math.max(droppableBounds.top, containerBounds.top),
     right: Math.min(droppableBounds.right, containerBounds.right),
@@ -38,7 +39,7 @@ export const isPointWithin = (droppable: DroppableDimension) => {
 };
 
 export const isDraggableWithin = (droppable: DroppableDimension) => {
-  const { top, right, bottom, left } = droppable.container.page.withoutMargin;
+  const { top, right, bottom, left } = droppable.container.bounds;
 
   // There are some extremely minor inaccuracy in the calculations of margins (~0.001)
   // To allow for this inaccuracy we make the dimension slightly bigger for this calculation

--- a/src/state/move-cross-axis/get-best-cross-axis-droppable.js
+++ b/src/state/move-cross-axis/get-best-cross-axis-droppable.js
@@ -77,9 +77,9 @@ export default ({
     })
     .filter((droppable: DroppableDimension) => (
       (droppable.page.withoutMargin[axis.crossAxisStart] >=
-        droppable.container.page.withoutMargin[axis.crossAxisStart]) &&
+        droppable.container.bounds[axis.crossAxisStart]) &&
       (droppable.page.withoutMargin[axis.crossAxisEnd] <=
-        droppable.container.page.withoutMargin[axis.crossAxisEnd])
+        droppable.container.bounds[axis.crossAxisEnd])
     ))
     // Sort on the cross axis
     .sort((a: DroppableDimension, b: DroppableDimension) => {

--- a/src/state/position.js
+++ b/src/state/position.js
@@ -1,5 +1,5 @@
 // @flow
-import type { Position, Spacing } from '../types';
+import type { Position } from '../types';
 
 export const add = (point1: Position, point2: Position): Position => ({
   x: point1.x + point2.x,
@@ -51,10 +51,3 @@ export const distance = (point1: Position, point2: Position): number =>
 // When given a list of points, it finds the smallest distance to any point
 export const closest = (target: Position, points: Position[]): number =>
   Math.min(...points.map((point: Position) => distance(target, point)));
-
-export const offsetSpacing = (spacing: Spacing, position: Position): Spacing => ({
-  top: spacing.top + position.y,
-  right: spacing.right + position.x,
-  bottom: spacing.bottom + position.y,
-  left: spacing.left + position.x,
-});

--- a/src/state/spacing.js
+++ b/src/state/spacing.js
@@ -1,0 +1,22 @@
+import type { Position, Spacing } from '../types';
+
+export const add = (spacing1: Spacing, spacing2: Spacing): Spacing => ({
+  top: spacing1.top + spacing2.top,
+  left: spacing1.left + spacing2.left,
+  right: spacing1.right + spacing2.right,
+  bottom: spacing1.bottom + spacing2.bottom,
+});
+
+export const isEqual = (spacing1: Spacing, spacing2: Spacing): boolean => (
+  spacing1.top === spacing2.top &&
+  spacing1.right === spacing2.right &&
+  spacing1.bottom === spacing2.bottom &&
+  spacing1.left === spacing2.left
+);
+
+export const offset = (spacing: Spacing, position: Position): Spacing => ({
+  top: spacing.top + position.y,
+  right: spacing.right + position.x,
+  bottom: spacing.bottom + position.y,
+  left: spacing.left + position.x,
+});

--- a/src/types.js
+++ b/src/types.js
@@ -106,7 +106,6 @@ export type DroppableDimension = {|
     |},
     page: {|
       withoutMargin: DimensionFragment,
-      withMargin: DimensionFragment,
     |},
   |},
 |}

--- a/src/types.js
+++ b/src/types.js
@@ -104,9 +104,7 @@ export type DroppableDimension = {|
       initial: Position,
       current: Position,
     |},
-    page: {|
-      withoutMargin: DimensionFragment,
-    |},
+    bounds: DimensionFragment,
   |},
 |}
 export type DraggableLocation = {|

--- a/src/types.js
+++ b/src/types.js
@@ -106,6 +106,7 @@ export type DroppableDimension = {|
     |},
     page: {|
       withoutMargin: DimensionFragment,
+      withMargin: DimensionFragment,
     |},
   |},
 |}

--- a/stories/src/primatives/quote-list.jsx
+++ b/stories/src/primatives/quote-list.jsx
@@ -76,7 +76,7 @@ export default class QuoteList extends Component {
                   />
                   {dragProvided.placeholder}
                 </div>
-            )}
+              )}
             </Draggable>
           ))}
           {dropProvided.placeholder}

--- a/test/unit/state/dimension.spec.js
+++ b/test/unit/state/dimension.spec.js
@@ -332,7 +332,7 @@ describe('dimension', () => {
           margin: noMargin,
         });
 
-        expect(droppableDimension.container.page.withoutMargin)
+        expect(droppableDimension.container.bounds)
           .toEqual(droppableDimension.page.withoutMargin);
       });
 
@@ -354,7 +354,7 @@ describe('dimension', () => {
           center: getCenter(container),
         };
 
-        expect(droppableDimension.container.page.withoutMargin)
+        expect(droppableDimension.container.bounds)
           .toEqual(expected);
       });
 
@@ -384,9 +384,9 @@ describe('dimension', () => {
           width: expectedSpacing.right - expectedSpacing.left,
         };
 
-        expect(droppableDimension.container.page.withoutMargin)
+        expect(droppableDimension.container.bounds)
           .toEqual(expected);
-        expect(droppableDimensionNoContainerProvided.container.page.withoutMargin)
+        expect(droppableDimensionNoContainerProvided.container.bounds)
           .toEqual(expected);
       });
     });

--- a/test/unit/state/dimension.spec.js
+++ b/test/unit/state/dimension.spec.js
@@ -313,5 +313,82 @@ describe('dimension', () => {
         expect(dimension.page.withMarginAndPadding).toEqual(fragment);
       });
     });
+
+    describe('calculating container dimension', () => {
+      const id = 'droppable';
+      const droppableRect = getClientRect({
+        top: 0,
+        right: 90,
+        bottom: 90,
+        left: 10,
+      });
+      const droppableMargin = { top: 10, right: 10, bottom: 10, left: 10 };
+      const noMargin = { top: 0, right: 0, bottom: 0, left: 0 };
+
+      it('should default to the droppable\'s dimension if none is provided', () => {
+        const droppableDimension = getDroppableDimension({
+          id,
+          clientRect: droppableRect,
+          margin: noMargin,
+        });
+
+        expect(droppableDimension.container.page.withoutMargin)
+          .toEqual(droppableDimension.page.withoutMargin);
+      });
+
+      it('should not include margins if the container is different from the droppable\'s spacing', () => {
+        const container = getClientRect({
+          top: 0,
+          right: 10,
+          bottom: 10,
+          left: 0,
+        });
+        const droppableDimension = getDroppableDimension({
+          id,
+          clientRect: droppableRect,
+          containerRect: container,
+          margin: noMargin,
+        });
+        const expected = {
+          ...container,
+          center: getCenter(container),
+        };
+
+        expect(droppableDimension.container.page.withoutMargin)
+          .toEqual(expected);
+      });
+
+      it('should include margins if the container is the same as the droppable\'s spacing', () => {
+        const container = droppableRect;
+        const droppableDimension = getDroppableDimension({
+          id,
+          clientRect: droppableRect,
+          containerRect: container,
+          margin: droppableMargin,
+        });
+        const droppableDimensionNoContainerProvided = getDroppableDimension({
+          id,
+          clientRect: droppableRect,
+          margin: droppableMargin,
+        });
+        const expectedSpacing = {
+          top: container.top - droppableMargin.top,
+          right: container.right + droppableMargin.right,
+          bottom: container.bottom + droppableMargin.bottom,
+          left: container.left - droppableMargin.left,
+        };
+        const expected = {
+          ...expectedSpacing,
+          center: getCenter(expectedSpacing),
+          height: expectedSpacing.bottom - expectedSpacing.top,
+          width: expectedSpacing.right - expectedSpacing.left,
+        };
+
+        expect(droppableDimension.container.page.withoutMargin)
+          .toEqual(expected);
+        expect(droppableDimensionNoContainerProvided.container.page.withoutMargin)
+          .toEqual(expected);
+      });
+    });
   });
 });

--- a/test/unit/state/dimension.spec.js
+++ b/test/unit/state/dimension.spec.js
@@ -38,7 +38,7 @@ const windowScroll: Position = {
   y: 80,
 };
 
-const getCenter = (rect: ClientRect): Position => ({
+const getCenter = (rect: ClientRect | Spacing): Position => ({
   x: (rect.left + rect.right) / 2,
   y: (rect.top + rect.bottom) / 2,
 });

--- a/test/unit/state/is-within-visible-bounds-of-droppable.spec.js
+++ b/test/unit/state/is-within-visible-bounds-of-droppable.spec.js
@@ -6,18 +6,25 @@ import getClientRect from '../../../src/state/get-client-rect';
 import getDroppableWithDraggables from '../../utils/get-droppable-with-draggables';
 import type { Result } from '../../utils/get-droppable-with-draggables';
 import type {
+  Spacing,
   Position,
   DraggableDimension,
 } from '../../../src/types';
 
+const margin: Spacing = {
+  top: 10, left: 10, right: 10, bottom: 10,
+};
+
 describe('is within visible bounds of a droppable', () => {
   const getDroppableDimensionArgs = {
     id: 'droppable',
+    margin,
+    // 100 x 100 box with margin's
     clientRect: getClientRect({
-      top: 0,
-      left: 0,
-      right: 100,
-      bottom: 100,
+      top: 10,
+      left: 10,
+      right: 90,
+      bottom: 90,
     }),
   };
   const droppable = getDroppableDimension(getDroppableDimensionArgs);
@@ -99,10 +106,10 @@ describe('is within visible bounds of a droppable', () => {
         const fullyContainedDroppable = getDroppableDimension({
           ...getDroppableDimensionArgs,
           containerRect: getClientRect({
-            top: -10,
-            right: 110,
-            bottom: 110,
-            left: -10,
+            top: 0,
+            right: 100,
+            bottom: 100,
+            left: 0,
           }),
         });
         const isPointWithinDroppable = isPointWithin(fullyContainedDroppable);

--- a/test/unit/state/position.spec.js
+++ b/test/unit/state/position.spec.js
@@ -7,7 +7,6 @@ import {
   patch,
   distance,
   closest,
-  offsetSpacing,
 } from '../../../src/state/position';
 import type { Position } from '../../../src/types';
 
@@ -48,7 +47,7 @@ describe('position', () => {
       expect(isEqual(point1, copy)).toBe(true);
     });
 
-    it('should return value when two objects have different values', () => {
+    it('should return false when two objects have different values', () => {
       expect(isEqual(point1, point2)).toBe(false);
     });
   });
@@ -124,24 +123,6 @@ describe('position', () => {
       const option2 = { x: 2, y: 2 };
 
       expect(closest(origin, [option1, option2])).toEqual(distance(origin, option1));
-    });
-  });
-
-  describe('offsetSpacing', () => {
-    it('should add x/y values to top/right/bottom/left dimensions', () => {
-      const spacing = {
-        top: 8,
-        right: 16,
-        bottom: 23,
-        left: 5,
-      };
-      const expected = {
-        top: 13,
-        right: 26,
-        bottom: 28,
-        left: 15,
-      };
-      expect(offsetSpacing(spacing, point1)).toEqual(expected);
     });
   });
 });

--- a/test/unit/state/spacing.spec.js
+++ b/test/unit/state/spacing.spec.js
@@ -1,0 +1,66 @@
+// @flow
+import {
+  add,
+  isEqual,
+  offset,
+} from '../../../src/state/spacing';
+import type { Position, Spacing } from '../../../src/types';
+
+const spacing1: Spacing = {
+  top: 8,
+  right: 16,
+  bottom: 23,
+  left: 5,
+};
+
+const spacing2: Spacing = {
+  top: 3,
+  right: 10,
+  bottom: 14,
+  left: 9,
+};
+
+describe('spacing', () => {
+  describe('add', () => {
+    it('should add two spacing boxes together', () => {
+      const expected: Spacing = {
+        top: 11,
+        right: 26,
+        bottom: 37,
+        left: 14,
+      };
+      expect(add(spacing1, spacing2)).toEqual(expected);
+    });
+  });
+
+  describe('isEqual', () => {
+    it('should return true when two spacings are the same', () => {
+      expect(isEqual(spacing1, spacing1)).toBe(true);
+    });
+
+    it('should return true when two spacings share the same values', () => {
+      const copy = { ...spacing1 };
+      expect(isEqual(spacing1, copy)).toBe(true);
+    });
+
+    it('should return value when two spacings have different values', () => {
+      expect(isEqual(spacing1, spacing2)).toBe(false);
+    });
+  });
+
+  describe('offset', () => {
+    it('should add x/y values to top/right/bottom/left dimensions', () => {
+      const offsetPosition: Position = {
+        x: 10,
+        y: 5,
+      };
+      const expected: Spacing = {
+        top: 13,
+        right: 26,
+        bottom: 28,
+        left: 15,
+      };
+      expect(offset(spacing1, offsetPosition)).toEqual(expected);
+    });
+  });
+});

--- a/test/utils/dimension.js
+++ b/test/utils/dimension.js
@@ -232,7 +232,7 @@ export const updateDroppableScroll = (
         initial: droppable.container.scroll.initial,
         current: newScroll,
       },
-      page: droppable.container.page,
+      bounds: droppable.container.bounds,
     },
   };
 


### PR DESCRIPTION
Fixes #122. 

@jaredcrowe can you please verify that this is what we want to be doing. I think it is. I had a play with the storybooks and and it yields the expected results. 

This PR is not quite done - I have not finished fixing all of the tests in `is-within-visible-bounds-of-droppable.spec`. Can you please update the remaining ones?

Cheers