### PR TITLE
Update README.md to match WebpackBin example

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ const getItemStyle = (draggableStyle, isDragging) => ({
   // some basic styles to make the items look a bit nicer
   userSelect: 'none',
   padding: grid * 2,
-  marginBottom: grid,
+  margin: `0 0 ${grid}px 0`,
 
   // change background colour if dragging
   background: isDragging ? 'lightgreen' : 'grey',


### PR DESCRIPTION
The `getItemStyle` in README.md had a bug when I tried it but the one in the WebpackBin code worked perfectly. This commit brings the change in the WebpackBin example to README.md.