### PR TITLE
⬆️ Upgrade raf-schd to 2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "memoize-one": "3.0.1",
     "prop-types": "15.5.10",
     "prop-types-extra": "1.0.1",
-    "raf-schd": "2.0.1",
+    "raf-schd": "2.0.2",
     "react-motion": "0.5.0",
     "react-redux": "5.0.6",
     "redux": "3.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5528,9 +5528,9 @@ radium@^0.19.0:
     inline-style-prefixer "^2.0.5"
     prop-types "^15.5.8"
 
-raf-schd@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-2.0.1.tgz#c5094a080344edb7fee00de48adf023686f9c915"
+raf-schd@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-2.0.2.tgz#7cf60f260c2d97ba2ba2a448c73604c5bed8cf08"
 
 raf-stub@2.0.1:
   version "2.0.1"


### PR DESCRIPTION
I have recently started to use react-beautiful-dnd, and found that I was getting flow errors from raf-schd:

```
Error: node_modules/raf-schd/test/index.spec.js:2
  2: import { replaceRaf } from 'raf-stub';
                                ^^^^^^^^^^ raf-stub. Required module not found
```

It seems that version 2.0.1 was publishing its test files to npm.  This version fixes that problem.