### PR TITLE
installing rimraf before deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ node_js:
 script:
 - yarn run validate
 - yarn run test
+# yarn run build:clean was failiing as it could not find rimraf - so strange
+before_deploy:
+  yarn global add rimraf
 deploy:
   provider: npm
   email: alexreardon@gmail.com


### PR DESCRIPTION
We are getting this error when attempting to release on travis:

```
travis_fold:end:dpl.1
travis_fold:start:dpl.2
[33mPreparing deploy[0m
NPM version: 5.3.0
Authenticated with email alexreardon@gmail.com
Cleaning up git repository with `git stash --all`. If you need build artifacts for deployment, set `deploy.skip_cleanup: true`. See https://docs.travis-ci.com/user/deployment/#Uploading-Files.
warning: CRLF will be replaced by LF in node_modules/chain-function/.gitattributes.
The file will have its original line endings in your working directory.
warning: CRLF will be replaced by LF in node_modules/chain-function/.npmignore.
The file will have its original line endings in your working directory.
warning: CRLF will be replaced by LF in node_modules/chain-function/index.js.
The file will have its original line endings in your working directory.
warning: CRLF will be replaced by LF in node_modules/chain-function/test.js.
The file will have its original line endings in your working directory.
Saved working directory and index state WIP on (no branch): 87e3d81 bumping version
NPM API key format changed recently. If your deployment fails, check your API key in ~/.npmrc.
http://docs.travis-ci.com/user/deployment/npm/
~/.npmrc size: 48

travis_fold:end:dpl.2
travis_fold:start:dpl.3
[33mDeploying application[0m
npm WARN prepublish-on-install As of npm@5, `prepublish` scripts are deprecated.
npm WARN prepublish-on-install Use `prepare` for build steps and `prepublishOnly` for upload-only.
npm WARN prepublish-on-install See the deprecation note in `npm help scripts` for more information.

> react-beautiful-dnd@2.6.3 prepublish .
> yarn run build

yarn run v0.27.5
$ yarn run build:clean && yarn run build:lib && yarn run build:flow
sh: 1: rimraf: not found
error Command failed with exit code 127.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! react-beautiful-dnd@2.6.3 prepublish: `yarn run build`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the react-beautiful-dnd@2.6.3 prepublish script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm WARN Local package.json exists, but node_modules missing, did you mean to install?

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/travis/.npm/_logs/2017-11-20T05_43_42_675Z-debug.log
```

Super strange. This is a brutal solution: install `rimraf` globally first 🙃 