### PR TITLE
explicitly importing react types to avoid deprecation warnings

### DIFF
--- a/src/view/drag-drop-context/drag-drop-context.jsx
+++ b/src/view/drag-drop-context/drag-drop-context.jsx
@@ -1,5 +1,5 @@
 // @flow
-import * as React from 'react';
+import React, { type Node } from 'react';
 import PropTypes from 'prop-types';
 import createStore from '../../state/create-store';
 import fireHooks from '../../state/fire-hooks';
@@ -12,7 +12,7 @@ import { storeKey } from '../context-keys';
 
 type Props = {|
   ...Hooks,
-  children: ?React.Node,
+  children: ?Node,
 |}
 
 type Context = {

--- a/src/view/draggable-dimension-publisher/draggable-dimension-publisher-types.js
+++ b/src/view/draggable-dimension-publisher/draggable-dimension-publisher-types.js
@@ -1,5 +1,5 @@
 // @flow
-import * as React from 'react';
+import type { Node } from 'react';
 import {
   publishDraggableDimension,
 } from '../../state/action-creators';
@@ -22,7 +22,7 @@ export type OwnProps = {|
   droppableId: DroppableId,
   type: TypeId,
   targetRef: ?HTMLElement,
-  children: React.Node,
+  children: Node,
 |}
 
 export type Props = {|

--- a/src/view/draggable/draggable-types.js
+++ b/src/view/draggable/draggable-types.js
@@ -1,5 +1,5 @@
 // @flow
-import * as React from 'react';
+import type { Node } from 'react';
 import type {
   DraggableId,
   DraggableDimension,
@@ -99,7 +99,7 @@ export type Provided = {|
   innerRef: (?HTMLElement) => void,
   draggableStyle: ?DraggableStyle,
   dragHandleProps: ?DragHandleProvided,
-  placeholder: ?React.Node,
+  placeholder: ?Node,
 |}
 
 export type StateSnapshot = {|
@@ -133,7 +133,7 @@ export type MapProps = {|
 
 export type OwnProps = {|
   draggableId: DraggableId,
-  children: (Provided, StateSnapshot) => ?React.Node,
+  children: (Provided, StateSnapshot) => ?Node,
   type: TypeId,
   isDragDisabled: boolean,
 |}

--- a/src/view/droppable-dimension-publisher/droppable-dimension-publisher-types.js
+++ b/src/view/droppable-dimension-publisher/droppable-dimension-publisher-types.js
@@ -1,5 +1,5 @@
 // @flow
-import * as React from 'react';
+import type { Node } from 'react';
 import {
   publishDroppableDimension,
   updateDroppableDimensionIsEnabled,
@@ -28,7 +28,7 @@ export type OwnProps = {|
   type: TypeId,
   targetRef: ?HTMLElement,
   ignoreContainerClipping: boolean,
-  children: React.Node,
+  children: Node,
 |}
 
 export type Props = {|

--- a/src/view/droppable/droppable-types.js
+++ b/src/view/droppable/droppable-types.js
@@ -1,5 +1,5 @@
 // @flow
-import * as React from 'react';
+import type { Node } from 'react';
 import type {
   DroppableId,
   TypeId,
@@ -13,7 +13,7 @@ export type Placeholder = {|
 
 export type Provided = {|
   innerRef: (?HTMLElement) => void,
-  placeholder: ?React.Node,
+  placeholder: ?Node,
 |}
 
 export type StateSnapshot = {|
@@ -29,7 +29,7 @@ export type MapProps = {|
 |}
 
 export type OwnProps = {|
-  children: (Provided, StateSnapshot) => ?React.Node,
+  children: (Provided, StateSnapshot) => ?Node,
   droppableId: DroppableId,
   type: TypeId,
   isDropDisabled: boolean,

--- a/src/view/moveable/moveable-types.js
+++ b/src/view/moveable/moveable-types.js
@@ -1,5 +1,5 @@
 // @flow
-import * as React from 'react';
+import type { Node } from 'react';
 import type { Position } from '../../types';
 
 export type Speed = 'INSTANT' | 'STANDARD' | 'FAST';
@@ -12,7 +12,7 @@ export type Props = {|
   speed: Speed,
   destination: Position,
   onMoveEnd: () => void,
-  children: (Style) => React.Node,
+  children: (Style) => Node,
 |}
 
 export type DefaultProps = {|


### PR DESCRIPTION
This was caused by using the recommended flow pattern:

`import * as React from 'react';`

However, doing this causes deprecation warnings to fire.

https://github.com/facebook/flow/issues/4673

Now [explicitly importing required types](https://github.com/facebook/flow/issues/4673#issuecomment-323850646) from react rather than using the `import *` method.