### PR TITLE
fixing error in dist build when process.env is not available

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,8 @@ class App extends React.Component {
 
 ## Installation
 
+### Package manager
+
 ```bash
 # yarn
 yarn add react-beautiful-dnd
@@ -385,6 +387,34 @@ yarn add react-beautiful-dnd
 # npm
 npm install react-beautiful-dnd --save
 ```
+
+### UMD
+
+You can use the UMD to run `react-beautiful-dnd` directly in the browser
+
+```html
+<!-- peer dependency -->
+<script src="https://unpkg.com/react@15.6.0/dist/react.js"></script>
+<!-- lib -->
+<script src="https://unpkg.com/react-dom@x.x.x/dist/react-beautiful-dnd.js"></script>
+<!-- needed to mount your react app -->
+<script src="https://unpkg.com/react-dom@15.6.0/dist/react-dom.js"></script>
+
+<script>
+  const React = window.React;
+  const ReactDOM = window.ReactDOM;
+  const { DragDropContext, Draggable, Droppable } = window.ReactBeautifulDnd;
+
+  class App extends React.Component {
+    //...
+  }
+
+  // You can use JSX if your environment supports it
+  ReactDOM.render(React.createElement(App), document.getElementById('app'));
+</script>
+```
+
+There is also an [example codepen](https://codepen.io/alexreardon/project/editor/ZyNMPo) you can use to play with this technique.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ You can use the UMD to run `react-beautiful-dnd` directly in the browser
 ```html
 <!-- peer dependency -->
 <script src="https://unpkg.com/react@15.6.0/dist/react.js"></script>
-<!-- lib -->
+<!-- lib (change x.x.x for the version you would like) -->
 <script src="https://unpkg.com/react-dom@x.x.x/dist/react-beautiful-dnd.js"></script>
 <!-- needed to mount your react app -->
 <script src="https://unpkg.com/react-dom@15.6.0/dist/react-dom.js"></script>

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint": "eslint .",
     "typecheck": "flow check",
     "build": "yarn run build:clean && yarn run build:lib && yarn run build:flow && yarn run build:dist",
-    "build:clean": "rimraf lib",
+    "build:clean": "rimraf lib && rimraf dist",
     "build:dist": "rollup -c && rollup -c --min",
     "build:lib": "babel src -d lib",
     "build:flow": "flow-copy-source --verbose src lib",

--- a/package.json
+++ b/package.json
@@ -3,19 +3,28 @@
   "version": "2.6.4",
   "description": "Beautiful, accessible drag and drop for lists with React.js",
   "author": "Alex Reardon <areardon@atlassian.com>",
-  "keywords": ["drag and drop", "dnd", "react", "react.js", "natural", "beautiful"],
+  "keywords": [
+    "drag and drop",
+    "dnd",
+    "react",
+    "react.js",
+    "natural",
+    "beautiful"
+  ],
   "bugs": {
     "url": "https://github.com/atlassian/react-beautiful-dnd/issues"
   },
   "main": "lib/index.js",
-  "files": ["/lib", "/dist"],
+  "files": [
+    "/lib",
+    "/dist"
+  ],
   "scripts": {
     "test": "jest --config ./jest.config.js",
     "validate": "yarn run lint && yarn run typecheck",
     "lint": "eslint .",
     "typecheck": "flow check",
-    "build":
-      "yarn run build:clean && yarn run build:lib && yarn run build:flow && yarn run build:dist",
+    "build": "yarn run build:clean && yarn run build:lib && yarn run build:flow && yarn run build:dist",
     "build:clean": "rimraf lib",
     "build:dist": "rollup -c && rollup -c --min",
     "build:lib": "babel src -d lib",
@@ -68,6 +77,7 @@
     "rollup-plugin-babel": "^3.0.2",
     "rollup-plugin-commonjs": "^8.2.6",
     "rollup-plugin-node-resolve": "^3.0.0",
+    "rollup-plugin-replace": "^2.0.0",
     "rollup-plugin-uglify": "^2.0.1",
     "styled-components": "^2.2.3"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,7 +10,7 @@ const args = yargs.argv;
 export default {
   input: './lib/index.js',
   output: {
-    file: `dist/index${args.min ? '.min' : ''}.js`,
+    file: `dist/react-beautiful-dnd${args.min ? '.min' : ''}.js`,
     format: 'umd',
   },
   name: 'ReactBeautifulDnd',

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,10 +2,10 @@ import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
 import uglify from 'rollup-plugin-uglify';
 import babel from 'rollup-plugin-babel';
+import replace from 'rollup-plugin-replace';
 import yargs from 'yargs';
 
 const args = yargs.argv;
-const external = ['react'];
 
 export default {
   input: './lib/index.js',
@@ -14,10 +14,17 @@ export default {
     format: 'umd',
   },
   name: 'ReactBeautifulDnd',
-  plugins: [babel({ exclude: 'node_modules/**', babelrc: false }), resolve(), commonjs()].concat(
+  plugins: [
+    babel({ exclude: 'node_modules/**', babelrc: false }),
+    resolve(),
+    commonjs(),
+    replace({
+      'process.env.NODE_ENV': JSON.stringify('production'),
+    }),
+  ].concat(
     args.min ? uglify() : []
   ),
   sourceMap: false,
-  external,
+  external: ['react'],
   globals: { react: 'React' },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5880,6 +5880,14 @@ rollup-plugin-node-resolve@^3.0.0:
     is-module "^1.0.0"
     resolve "^1.1.6"
 
+rollup-plugin-replace@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-replace/-/rollup-plugin-replace-2.0.0.tgz#19074089c8ed57184b8cc64e967a03d095119277"
+  dependencies:
+    magic-string "^0.22.4"
+    minimatch "^3.0.2"
+    rollup-pluginutils "^2.0.1"
+
 rollup-plugin-uglify@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/rollup-plugin-uglify/-/rollup-plugin-uglify-2.0.1.tgz#67b37ad1efdafbd83af4c36b40c189ee4866c969"


### PR DESCRIPTION
Fixing a minor issue @vinifala where the script would 💥 if `process.env` was not set. Just setting it to production for simplicity 