### PR TITLE
Allow boolean fields to be draggable

### DIFF
--- a/src/view/drag-handle/util/should-allow-dragging-from-target.js
+++ b/src/view/drag-handle/util/should-allow-dragging-from-target.js
@@ -35,6 +35,14 @@ const isContentEditable = (parent: Element, current: ?Element): boolean => {
   return isContentEditable(parent, current.parentElement);
 };
 
+const isBooleanTag = (current: ?Element): boolean => {
+  if (current == null) {
+    return false;
+  }
+
+  return current.type === 'checkbox' || current.type === 'radio';
+};
+
 export default (event: Event, props: Props): boolean => {
   // Allowing drag with all element types
   if (props.canDragInteractiveElements) {
@@ -51,7 +59,7 @@ export default (event: Event, props: Props): boolean => {
   const isTargetInteractive: boolean =
     interactiveTagNames.indexOf(target.tagName.toLowerCase()) !== -1;
 
-  if (isTargetInteractive) {
+  if (isTargetInteractive && !isBooleanTag(target)) {
     return false;
   }
 

--- a/stories/src/interactive-elements/interactive-elements-app.jsx
+++ b/stories/src/interactive-elements/interactive-elements-app.jsx
@@ -47,6 +47,14 @@ const initial: ItemType[] = [
     ),
   },
   {
+    id: 'checkbox',
+    component: (
+      <label>
+        <input type="checkbox" />
+      </label>
+    )
+  },
+  {
     id: 'content editable',
     component: (
       <div


### PR DESCRIPTION
`MouseDown` event is fired when the user taps on the checkbox. This works fine until the user drags the row and then once they do they have to click on the checkbox twice before it will show as checked.

Instead of creating an issue, I figured I would open with one with a PR to fix. **Note:** I'm not sure this is the best route or even the most scalable. The part I'm not crazy about is that it adds further validation logic based to find out what type of specific element it is. This was my first pass and thought it would best to get feedback before digging deeper.

I haven't created any new tests yet until it's determined if this is the route the project would like to take.

### Expected behavior
After dragging the item and then checking the checkbox I expect to see the checkbox checked. 😄 

### Actual behavior
If drag an element and then check the checkbox, it fires an event that it was checked. However, the UI is not showing as checked. If I click on the checkbox again it then shows up properly.

### Workaround
Until we find a solution I can set `disableInteractiveElementBlocking` to `true`.

### Steps to reproduce
1. Toggle the checkbox to see it works properly
2. Drag any element
3. Try toggling the checkbox to either uncheck/check and see that the check is not showing.
4. Click on checkbox again and see that it was properly propagated.

### Browser version
Tried in Latest Safari, Firefox, Chrome

### Demo
https://codesandbox.io/s/8lk2wo0809

![checkbox-issue](https://user-images.githubusercontent.com/1427854/34474760-73f30546-ef38-11e7-8737-6ba7b76da96f.gif)