### PR TITLE
disabling partially implementated experimental behaviour

### DIFF
--- a/src/state/dimension-marshal/dimension-marshal.js
+++ b/src/state/dimension-marshal/dimension-marshal.js
@@ -99,13 +99,6 @@ export default (callbacks: Callbacks) => {
     }
 
     console.warn('Adding a draggable during a drag is currently not supported');
-
-    // const homeEntry: ?DroppableEntry = state.droppables[entry.descriptor.droppableId];
-    // console.error('Cannot add Draggable during a drag - Droppable not found');
-    // const droppable: DroppableDimension = homeEntry.callbacks.getDimension();
-    // const dimension: DraggableDimension = entry.getDimension();
-    // callbacks.publishDroppables([droppable]);
-    // callbacks.publishDraggables([dimension]);
   };
 
   const registerDroppable = (
@@ -137,11 +130,6 @@ export default (callbacks: Callbacks) => {
     }
 
     console.warn('Currently not supporting updating Droppables during a drag');
-
-    // if a droppable is published while collecting - publishing it immediately
-    // const dimension: DroppableDimension = entry.callbacks.getDimension();
-    // callbacks.publishDroppables([dimension]);
-    // entry.callbacks.watchScroll();
   };
 
   const updateDroppableIsEnabled = (id: DroppableId, isEnabled: boolean) => {

--- a/src/state/dimension-marshal/dimension-marshal.js
+++ b/src/state/dimension-marshal/dimension-marshal.js
@@ -98,10 +98,14 @@ export default (callbacks: Callbacks) => {
       return;
     }
 
-    // if a draggable is published while collecting - publishing it immediately
+    console.warn('Adding a draggable during a drag is currently not supported');
 
-    const dimension: DraggableDimension = entry.getDimension();
-    callbacks.publishDraggables([dimension]);
+    // const homeEntry: ?DroppableEntry = state.droppables[entry.descriptor.droppableId];
+    // console.error('Cannot add Draggable during a drag - Droppable not found');
+    // const droppable: DroppableDimension = homeEntry.callbacks.getDimension();
+    // const dimension: DraggableDimension = entry.getDimension();
+    // callbacks.publishDroppables([droppable]);
+    // callbacks.publishDraggables([dimension]);
   };
 
   const registerDroppable = (
@@ -132,10 +136,12 @@ export default (callbacks: Callbacks) => {
       return;
     }
 
+    console.warn('Currently not supporting updating Droppables during a drag');
+
     // if a droppable is published while collecting - publishing it immediately
-    const dimension: DroppableDimension = entry.callbacks.getDimension();
-    callbacks.publishDroppables([dimension]);
-    entry.callbacks.watchScroll();
+    // const dimension: DroppableDimension = entry.callbacks.getDimension();
+    // callbacks.publishDroppables([dimension]);
+    // entry.callbacks.watchScroll();
   };
 
   const updateDroppableIsEnabled = (id: DroppableId, isEnabled: boolean) => {

--- a/src/view/draggable-dimension-publisher/draggable-dimension-publisher.jsx
+++ b/src/view/draggable-dimension-publisher/draggable-dimension-publisher.jsx
@@ -18,12 +18,9 @@ import type {
 import type { DimensionMarshal } from '../../state/dimension-marshal/dimension-marshal-types';
 
 type Props = {|
-  // (it is being used)
-  /* eslint-disable react/no-unused-prop-types */
   draggableId: DraggableId,
   droppableId: DroppableId,
   index: number,
-  /* eslint-enable react/no-unused-prop-types */
   targetRef: ?HTMLElement,
   children: Node,
 |}
@@ -36,20 +33,21 @@ export default class DraggableDimensionPublisher extends Component<Props> {
 
   publishedDescriptor: ?DraggableDescriptor = null
 
-  getDescriptor(props: Props): DraggableDescriptor {
-    const { draggableId, droppableId, index } = props;
+  componentWillReceiveProps(nextProps: Props) {
+    const { draggableId, droppableId, index, targetRef } = nextProps;
+
+    if (!targetRef) {
+      console.error('Updating draggable dimension handler without a targetRef');
+      return;
+    }
+
+    // Note: not publishing it on componentDidMount as we do not have a ref at that point
+
     const descriptor: DraggableDescriptor = this.getMemoizedDescriptor(
       draggableId, droppableId, index
     );
-    return descriptor;
-  }
 
-  componentWillMount() {
-    this.publish(this.getDescriptor(this.props));
-  }
-
-  componentWillReceiveProps(nextProps: Props) {
-    this.publish(this.getDescriptor(nextProps));
+    this.publish(descriptor);
   }
 
   componentWillUnmount() {

--- a/src/view/droppable-dimension-publisher/droppable-dimension-publisher.jsx
+++ b/src/view/droppable-dimension-publisher/droppable-dimension-publisher.jsx
@@ -26,8 +26,6 @@ import type {
 
 type Props = {|
   droppableId: DroppableId,
-  // (it is being used)
-  // eslint-disable-next-line react/no-unused-prop-types
   type: TypeId,
   direction: Direction,
   isDropDisabled: boolean,
@@ -59,15 +57,6 @@ export default class DroppableDimensionPublisher extends Component<Props> {
   static contextTypes = {
     [dimensionMarshalKey]: PropTypes.object.isRequired,
   };
-
-  getDescriptor(props: Props) {
-    const { droppableId, type } = props;
-    const descriptor: DroppableDescriptor = this.getMemoizedDescriptor(
-      droppableId, type,
-    );
-
-    return descriptor;
-  }
 
   getScrollOffset = (): Position => {
     if (!this.closestScrollable) {
@@ -140,12 +129,23 @@ export default class DroppableDimensionPublisher extends Component<Props> {
     this.closestScrollable.removeEventListener('scroll', this.onClosestScroll);
   }
 
-  componentWillMount() {
-    this.publish(this.getDescriptor(this.props));
-  }
-
   componentWillReceiveProps(nextProps: Props) {
-    this.publish(this.getDescriptor(nextProps));
+    if (!nextProps.targetRef) {
+      console.error('Cannot update droppable dimension publisher without a target ref');
+      return;
+    }
+
+    // 1. Update the descriptor
+    // Note: not publishing it on componentDidMount as we do not have a ref at that point
+
+    const { droppableId, type } = nextProps;
+    const descriptor: DroppableDescriptor = this.getMemoizedDescriptor(
+      droppableId, type,
+    );
+
+    this.publish(descriptor);
+
+    // 2. Update is enabled
 
     if (this.props.isDropDisabled === nextProps.isDropDisabled) {
       return;

--- a/test/unit/view/dimension-marshal.spec.js
+++ b/test/unit/view/dimension-marshal.spec.js
@@ -1016,10 +1016,11 @@ describe('dimension marshal', () => {
     });
   });
 
+  // Behaviour currently unsupported
   describe('registration change while collecting', () => {
     describe('dimension added', () => {
       describe('draggable', () => {
-        it('should immediately publish the draggable', () => {
+        it('should log an unsupported warning', () => {
           const callbacks = getCallbackStub();
           const marshal = createDimensionMarshal(callbacks);
           populateMarshal(marshal);
@@ -1032,10 +1033,14 @@ describe('dimension marshal', () => {
             client: fakeArea,
           });
 
+          // start a collection
           marshal.onPhaseChange(state.requesting(preset.inHome1.descriptor.id));
-
+          callbacks.publishDraggables.mockReset();
+          // now registering
           marshal.registerDraggable(fake.descriptor, () => fake);
-          expect(callbacks.publishDraggables).toHaveBeenCalledWith([fake]);
+
+          expect(callbacks.publishDraggables).not.toHaveBeenCalled();
+          expect(console.warn).toHaveBeenCalled();
         });
       });
 
@@ -1057,12 +1062,17 @@ describe('dimension marshal', () => {
             unwatchScroll: () => { },
           };
 
+          // starting collection
           marshal.onPhaseChange(state.requesting(preset.inHome1.descriptor.id));
+          callbacks.publishDroppables.mockReset();
 
+          // updating registration
           marshal.registerDroppable(fake.descriptor, droppableCallbacks);
-          expect(callbacks.publishDroppables).toHaveBeenCalledWith([fake]);
-          // should subscribe to scrolling immediately
-          expect(droppableCallbacks.watchScroll).toHaveBeenCalled();
+
+          // warning should have been logged and nothing updated
+          expect(console.warn).toHaveBeenCalled();
+          expect(callbacks.publishDroppables).not.toHaveBeenCalled();
+          expect(droppableCallbacks.watchScroll).not.toHaveBeenCalled();
         });
       });
     });

--- a/test/unit/view/draggable-dimension-publisher.spec.js
+++ b/test/unit/view/draggable-dimension-publisher.spec.js
@@ -81,6 +81,14 @@ const getMarshalStub = (): DimensionMarshal => ({
 });
 
 describe('DraggableDimensionPublisher', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => { });
+  });
+
+  afterEach(() => {
+    console.error.mockRestore();
+  });
+
   describe('dimension registration', () => {
     it('should register itself when mounting', () => {
       const marshal: DimensionMarshal = getMarshalStub();
@@ -89,6 +97,27 @@ describe('DraggableDimensionPublisher', () => {
 
       expect(marshal.registerDraggable).toHaveBeenCalledTimes(1);
       expect(marshal.registerDraggable.mock.calls[0][0]).toEqual(preset.inHome1.descriptor);
+    });
+
+    it('should log an error if no targetRef is provided', () => {
+      const marshal: DimensionMarshal = getMarshalStub();
+
+      const wrapper = mount(
+        <DraggableDimensionPublisher
+          draggableId={preset.inHome1.descriptor.id}
+          droppableId={preset.inHome1.descriptor.droppableId}
+          index={preset.inHome1.descriptor.index}
+          targetRef={null}
+        >
+          <div>hi</div>
+        </DraggableDimensionPublisher>,
+        withDimensionMarshal(marshal)
+      );
+
+      forceUpdate(wrapper);
+
+      expect(marshal.registerDraggable).not.toHaveBeenCalled();
+      expect(console.error).toHaveBeenCalled();
     });
 
     it('should unregister itself when unmounting', () => {

--- a/test/unit/view/droppable-dimension-publisher.spec.js
+++ b/test/unit/view/droppable-dimension-publisher.spec.js
@@ -105,6 +105,14 @@ describe('DraggableDimensionPublisher', () => {
     y: window.pageYOffset,
   };
 
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => { });
+  });
+
+  afterEach(() => {
+    console.error.mockRestore();
+  });
+
   afterEach(() => {
     // clean up any stubs
     if (Element.prototype.getBoundingClientRect.mockRestore) {
@@ -124,6 +132,34 @@ describe('DraggableDimensionPublisher', () => {
 
       expect(marshal.registerDroppable).toHaveBeenCalledTimes(1);
       expect(marshal.registerDroppable.mock.calls[0][0]).toEqual(preset.home.descriptor);
+    });
+
+    it('should log an error if no targetRef is provided', () => {
+      const marshal: DimensionMarshal = getMarshalStub();
+
+      const wrapper = mount(
+        <DroppableDimensionPublisher
+          droppableId={preset.home.descriptor.id}
+          type={preset.home.descriptor.type}
+          direction={preset.home.axis.direction}
+          isDropDisabled={false}
+          ignoreContainerClipping={false}
+          targetRef={null}
+        >
+          <div
+            className="scroll-container"
+            style={{ overflowY: 'auto' }}
+          >
+            hi
+          </div>
+        </DroppableDimensionPublisher>
+      );
+
+      // updating without a targetRef
+      forceUpdate(wrapper);
+
+      expect(console.error).toHaveBeenCalled();
+      expect(marshal.registerDroppable).not.toHaveBeenCalled();
     });
 
     it('should unregister itself when unmounting', () => {


### PR DESCRIPTION
Closes #260.

Removes error in experimental behaviour by just removing it altogether. It was documented as not supported.

There are lots of scenarios that are not catered for in the current implementation so I think it best to remove it and work on adding support for it when we move towards #68 