### PR TITLE
Add example for `stick to bottom`

### DIFF
--- a/stories/3-board-story.js
+++ b/stories/3-board-story.js
@@ -18,4 +18,7 @@ storiesOf('board', module)
   ))
   .add('long lists in a short container', () => (
     <Board initial={data.medium} containerHeight="300px" />
+  ))
+  .add('stick to bottom', () => (
+    <Board initial={authorQuoteMap} stickToBottom />
   ));

--- a/stories/src/board/board.jsx
+++ b/stories/src/board/board.jsx
@@ -31,9 +31,17 @@ const Container = styled.div`
   display: inline-flex;
 `;
 
+const stickToBottomStyle = {
+  display: 'flex',
+  flexDirection: 'row',
+  alignContent: 'flex-start',
+  alignItems: 'flex-end',
+};
+
 type Props = {|
   initial: QuoteMap,
   containerHeight?: string,
+  stickToBottom?: boolean,
 |}
 
 type State = {|
@@ -111,6 +119,7 @@ export default class Board extends Component<Props, State> {
     const columns: QuoteMap = this.state.columns;
     const ordered: string[] = this.state.ordered;
     const { containerHeight } = this.props;
+    const containerStyle = this.props.stickToBottom ? stickToBottomStyle : null;
 
     const board = (
       <Droppable
@@ -120,7 +129,7 @@ export default class Board extends Component<Props, State> {
         ignoreContainerClipping={Boolean(containerHeight)}
       >
         {(provided: DroppableProvided) => (
-          <Container innerRef={provided.innerRef}>
+          <Container innerRef={provided.innerRef} style={containerStyle}>
             {ordered.map((key: string, index: number) => (
               <Column
                 key={key}


### PR DESCRIPTION
There are some glitches to resolve around such usage but this simple change works fine in most interactions.

![bottom-based-lists-drag](https://user-images.githubusercontent.com/163636/35120642-744342ec-fca1-11e7-9f11-f39e9967ced7.gif)

Drop position calculations:
- are fine while container is larger than existing and incoming content
- are broken while content occupies the full container
- are fine again while content is larger than visible container 

The last point could be the key to fix also the second case.

Keyboard dragging has the same fine/broken scenarios.

