### PR TITLE
Upgrade flow

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,11 @@
     "node": true,
     "jest/globals": true
   },
+  "globals": {
+    "TimeoutID": true,
+    "IntervalID": true,
+    "AnimationFrameID": true
+  },
   // custom rules
   "rules": {
     // http://eslint.org/docs/rules/comma-dangle

--- a/flow-typed/npm/@storybook/react_v3.x.x.js
+++ b/flow-typed/npm/@storybook/react_v3.x.x.js
@@ -1,0 +1,37 @@
+// flow-typed signature: c2e1b132d2729c977d6b3e54e0134de5
+// flow-typed version: 1709d3212d/@storybook/react_v3.x.x/flow_>=v0.28.x
+
+type NodeModule = typeof module;
+
+declare module '@storybook/react' {
+  declare type Renderable = React$Element<any>;
+  declare type RenderFunction = () => Renderable;
+
+  declare type StoryDecorator = (
+    story: RenderFunction,
+    context: { kind: string, story: string }
+  ) => Renderable | null;
+
+  declare interface Story {
+    add(storyName: string, callback: RenderFunction): Story,
+    addDecorator(decorator: StoryDecorator): Story,
+  }
+
+  declare interface StoryObject {
+    name: string,
+    render: RenderFunction,
+  }
+
+  declare interface StoryBucket {
+    kind: string,
+    stories: Array<StoryObject>,
+  }
+
+  declare function addDecorator(decorator: StoryDecorator): void;
+  declare function configure(fn: () => void, module: NodeModule): void;
+  declare function setAddon(addon: Object): void;
+  declare function storiesOf(name: string, module: NodeModule): Story;
+  declare function storiesOf<T>(name: string, module: NodeModule): Story & T;
+
+  declare function getStorybook(): Array<StoryBucket>;
+}

--- a/flow-typed/npm/enzyme_v3.x.x.js
+++ b/flow-typed/npm/enzyme_v3.x.x.js
@@ -1,5 +1,5 @@
-// flow-typed signature: a18e8395a43c22fe55906624f2a7ddb9
-// flow-typed version: e351e417db/enzyme_v3.x.x/flow_>=v0.53.x
+// flow-typed signature: 7be2af8800fdadaea6ac0404d256bafc
+// flow-typed version: 6ce6a0467c/enzyme_v3.x.x/flow_>=v0.53.x
 
 import * as React from "react";
 
@@ -20,12 +20,14 @@ declare module "enzyme" {
     findWhere(predicate: PredicateFunction<this>): this,
     filter(selector: EnzymeSelector): this,
     filterWhere(predicate: PredicateFunction<this>): this,
+    hostNodes(): this,
     contains(nodeOrNodes: NodeOrNodes): boolean,
     containsMatchingElement(node: React.Node): boolean,
     containsAllMatchingElements(nodes: NodeOrNodes): boolean,
     containsAnyMatchingElements(nodes: NodeOrNodes): boolean,
     dive(option?: { context?: Object }): this,
     exists(): boolean,
+    isEmptyRender(): boolean,
     matchesElement(node: React.Node): boolean,
     hasClass(className: string): boolean,
     is(selector: EnzymeSelector): boolean,
@@ -41,7 +43,6 @@ declare module "enzyme" {
     text(): string,
     html(): string,
     get(index: number): React.Node,
-    getNodes(): Array<React.Node>,
     getDOMNode(): HTMLElement | HTMLInputElement,
     at(index: number): this,
     first(): this,
@@ -57,7 +58,7 @@ declare module "enzyme" {
     setContext(context: Object): this,
     instance(): React.Component<*, *>,
     update(): this,
-    debug(): string,
+    debug(options?: Object): string,
     type(): string | Function | null,
     name(): string,
     forEach(fn: (node: this, index: number) => mixed): this,
@@ -91,7 +92,9 @@ declare module "enzyme" {
       options?: ?Object
     ): ShallowWrapper,
     equals(node: React.Node): boolean,
-    shallow(options?: { context?: Object }): ShallowWrapper
+    shallow(options?: { context?: Object }): ShallowWrapper,
+    getElement(): React.Node,
+    getElements(): Array<React.Node>
   }
 
   declare function shallow(

--- a/flow-typed/npm/invariant_v2.x.x.js
+++ b/flow-typed/npm/invariant_v2.x.x.js
@@ -1,6 +1,6 @@
-// flow-typed signature: 41a21b97ad4a7c01c4caf3a8b9382354
-// flow-typed version: b43dff3e0e/invariant_v2.x.x/flow_>=v0.33.x
+// flow-typed signature: 60de437d85342dea19dcd82c5a50f88a
+// flow-typed version: da30fe6876/invariant_v2.x.x/flow_>=v0.33.x
 
 declare module invariant {
-  declare var exports: (condition: boolean, message: string) => void;
+  declare module.exports: (condition: boolean, message: string) => void;
 }

--- a/flow-typed/npm/jest_v22.x.x.js
+++ b/flow-typed/npm/jest_v22.x.x.js
@@ -1,5 +1,5 @@
-// flow-typed signature: 8a6d495ef15f96f0d0c836b6aa70a1cd
-// flow-typed version: cfa05a2b8e/jest_v21.x.x/flow_>=v0.39.x
+// flow-typed signature: ebbcd423b1fcd29d6804fca91bb68879
+// flow-typed version: 7b9f6d2713/jest_v22.x.x/flow_>=v0.39.x
 
 type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
   (...args: TArguments): TReturn,
@@ -114,20 +114,28 @@ type JestPromiseType = {
 };
 
 /**
+ * Jest allows functions and classes to be used as test names in test() and
+ * describe()
+ */
+type JestTestName = string | Function;
+
+/**
  *  Plugin: jest-enzyme
  */
 type EnzymeMatchersType = {
   toBeChecked(): void,
   toBeDisabled(): void,
   toBeEmpty(): void,
+  toBeEmptyRender(): void,
   toBePresent(): void,
   toContainReact(element: React$Element<any>): void,
+  toExist(): void,
   toHaveClassName(className: string): void,
   toHaveHTML(html: string): void,
-  toHaveProp(propKey: string, propValue?: any): void,
+  toHaveProp: ((propKey: string, propValue?: any) => void) & ((props: Object) => void),
   toHaveRef(refName: string): void,
-  toHaveState(stateKey: string, stateValue?: any): void,
-  toHaveStyle(styleKey: string, styleValue?: any): void,
+  toHaveState: ((stateKey: string, stateValue?: any) => void) & ((state: Object) => void),
+  toHaveStyle: ((styleKey: string, styleValue?: any) => void) & ((style: Object) => void),
   toHaveTagName(tagName: string): void,
   toHaveText(text: string): void,
   toIncludeText(text: string): void,
@@ -271,8 +279,8 @@ type JestExpectType = {
    *
    * Alias: .toThrowError
    */
-  toThrow(message?: string | Error | RegExp): void,
-  toThrowError(message?: string | Error | RegExp): void,
+  toThrow(message?: string | Error | Class<Error> | RegExp): void,
+  toThrowError(message?: string | Error | Class<Error> | RegExp): void,
   /**
    * Use .toThrowErrorMatchingSnapshot to test that a function throws a error
    * matching the most recent snapshot when it is called.
@@ -310,6 +318,10 @@ type JestObjectType = {
    * mocked function.
    */
   resetAllMocks(): JestObjectType,
+  /**
+   * Restores all mocks back to their original value.
+   */
+  restoreAllMocks(): JestObjectType,
   /**
    * Removes any pending timers from the timer system.
    */
@@ -458,17 +470,17 @@ declare var describe: {
   /**
    * Creates a block that groups together several related tests in one "test suite"
    */
-  (name: string, fn: () => void): void,
+  (name: JestTestName, fn: () => void): void,
 
   /**
    * Only run this describe block
    */
-  only(name: string, fn: () => void): void,
+  only(name: JestTestName, fn: () => void): void,
 
   /**
    * Skip running this describe block
    */
-  skip(name: string, fn: () => void): void
+  skip(name: JestTestName, fn: () => void): void
 };
 
 /** An individual test unit */
@@ -476,54 +488,54 @@ declare var it: {
   /**
    * An individual test unit
    *
-   * @param {string} Name of Test
+   * @param {JestTestName} Name of Test
    * @param {Function} Test
    * @param {number} Timeout for the test, in milliseconds.
    */
   (
-    name: string,
+    name: JestTestName,
     fn?: (done: () => void) => ?Promise<mixed>,
     timeout?: number
   ): void,
   /**
    * Only run this test
    *
-   * @param {string} Name of Test
+   * @param {JestTestName} Name of Test
    * @param {Function} Test
    * @param {number} Timeout for the test, in milliseconds.
    */
   only(
-    name: string,
+    name: JestTestName,
     fn?: (done: () => void) => ?Promise<mixed>,
     timeout?: number
   ): void,
   /**
    * Skip running this test
    *
-   * @param {string} Name of Test
+   * @param {JestTestName} Name of Test
    * @param {Function} Test
    * @param {number} Timeout for the test, in milliseconds.
    */
   skip(
-    name: string,
+    name: JestTestName,
     fn?: (done: () => void) => ?Promise<mixed>,
     timeout?: number
   ): void,
   /**
    * Run the test concurrently
    *
-   * @param {string} Name of Test
+   * @param {JestTestName} Name of Test
    * @param {Function} Test
    * @param {number} Timeout for the test, in milliseconds.
    */
   concurrent(
-    name: string,
+    name: JestTestName,
     fn?: (done: () => void) => ?Promise<mixed>,
     timeout?: number
   ): void
 };
 declare function fit(
-  name: string,
+  name: JestTestName,
   fn: (done: () => void) => ?Promise<mixed>,
   timeout?: number
 ): void;
@@ -549,12 +561,12 @@ declare var expect: {
   assertions(expectedAssertions: number): void,
   hasAssertions(): void,
   any(value: mixed): JestAsymmetricEqualityType,
-  anything(): void,
-  arrayContaining(value: Array<mixed>): void,
-  objectContaining(value: Object): void,
+  anything(): any,
+  arrayContaining(value: Array<mixed>): Array<mixed>,
+  objectContaining(value: Object): Object,
   /** Matches any received string that contains the exact expected string. */
-  stringContaining(value: string): void,
-  stringMatching(value: string | RegExp): void
+  stringContaining(value: string): string,
+  stringMatching(value: string | RegExp): string
 };
 
 // TODO handle return type
@@ -571,14 +583,14 @@ declare var jest: JestObjectType;
 declare var jasmine: {
   DEFAULT_TIMEOUT_INTERVAL: number,
   any(value: mixed): JestAsymmetricEqualityType,
-  anything(): void,
-  arrayContaining(value: Array<mixed>): void,
+  anything(): any,
+  arrayContaining(value: Array<mixed>): Array<mixed>,
   clock(): JestClockType,
   createSpy(name: string): JestSpyType,
   createSpyObj(
     baseName: string,
     methodNames: Array<string>
   ): { [methodName: string]: JestSpyType },
-  objectContaining(value: Object): void,
-  stringMatching(value: string): void
+  objectContaining(value: Object): Object,
+  stringMatching(value: string): string
 };

--- a/flow-typed/npm/prop-types_v15.x.x.js
+++ b/flow-typed/npm/prop-types_v15.x.x.js
@@ -1,0 +1,35 @@
+// flow-typed signature: d9a983bb1ac458a256c31c139047bdbb
+// flow-typed version: 927687984d/prop-types_v15.x.x/flow_>=v0.41.x
+
+type $npm$propTypes$ReactPropsCheckType = (
+  props: any,
+  propName: string,
+  componentName: string,
+  href?: string) => ?Error;
+
+declare module 'prop-types' {
+  declare var array: React$PropType$Primitive<Array<any>>;
+  declare var bool: React$PropType$Primitive<boolean>;
+  declare var func: React$PropType$Primitive<Function>;
+  declare var number: React$PropType$Primitive<number>;
+  declare var object: React$PropType$Primitive<Object>;
+  declare var string: React$PropType$Primitive<string>;
+  declare var symbol: React$PropType$Primitive<Symbol>;
+  declare var any: React$PropType$Primitive<any>;
+  declare var arrayOf: React$PropType$ArrayOf;
+  declare var element: React$PropType$Primitive<any>; /* TODO */
+  declare var instanceOf: React$PropType$InstanceOf;
+  declare var node: React$PropType$Primitive<any>; /* TODO */
+  declare var objectOf: React$PropType$ObjectOf;
+  declare var oneOf: React$PropType$OneOf;
+  declare var oneOfType: React$PropType$OneOfType;
+  declare var shape: React$PropType$Shape;
+
+  declare function checkPropTypes<V>(
+    propTypes: $Subtype<{[_: $Keys<V>]: $npm$propTypes$ReactPropsCheckType}>,
+    values: V,
+    location: string,
+    componentName: string,
+    getStack: ?(() => ?string)
+  ) : void;
+}

--- a/flow-typed/npm/react-redux_v5.x.x.js
+++ b/flow-typed/npm/react-redux_v5.x.x.js
@@ -1,132 +1,98 @@
-// flow-typed signature: 59b0c4be0e1408f21e2446be96c79804
-// flow-typed version: 9092387fd2/react-redux_v5.x.x/flow_>=v0.54.x
+// flow-typed signature: a2c406bd25fca4586c361574e555202d
+// flow-typed version: dcd1531faf/react-redux_v5.x.x/flow_>=v0.62.0
 
 import type { Dispatch, Store } from "redux";
 
 declare module "react-redux" {
-  /*
+  import type { ComponentType, ElementConfig } from 'react';
 
-    S = State
-    A = Action
-    OP = OwnProps
-    SP = StateProps
-    DP = DispatchProps
-
-  */
-
-  declare type MapStateToProps<S, OP: Object, SP: Object> = (
-    state: S,
-    ownProps: OP
-  ) => ((state: S, ownProps: OP) => SP) | SP;
-
-  declare type MapDispatchToProps<A, OP: Object, DP: Object> =
-    | ((dispatch: Dispatch<A>, ownProps: OP) => DP)
-    | DP;
-
-  declare type MergeProps<SP, DP: Object, OP: Object, P: Object> = (
-    stateProps: SP,
-    dispatchProps: DP,
-    ownProps: OP
-  ) => P;
-
-  declare type Context = { store: Store<*, *> };
-
-  declare type ComponentWithDefaultProps<DP: {}, P: {}, CP: P> = Class<
-    React$Component<CP>
-  > & { defaultProps: DP };
-
-  declare class ConnectedComponentWithDefaultProps<
-    OP,
-    DP,
-    CP
-  > extends React$Component<OP> {
-    static defaultProps: DP, // <= workaround for https://github.com/facebook/flow/issues/4644
-    static WrappedComponent: Class<React$Component<CP>>,
-    getWrappedInstance(): React$Component<CP>,
-    props: OP,
-    state: void
-  }
-
-  declare class ConnectedComponent<OP, P> extends React$Component<OP> {
-    static WrappedComponent: Class<React$Component<P>>,
-    getWrappedInstance(): React$Component<P>,
-    props: OP,
-    state: void
-  }
-
-  declare type ConnectedComponentWithDefaultPropsClass<OP, DP, CP> = Class<
-    ConnectedComponentWithDefaultProps<OP, DP, CP>
-  >;
-
-  declare type ConnectedComponentClass<OP, P> = Class<
-    ConnectedComponent<OP, P>
-  >;
-
-  declare type Connector<OP, P> = (<DP: {}, CP: {}>(
-    component: ComponentWithDefaultProps<DP, P, CP>
-  ) => ConnectedComponentWithDefaultPropsClass<OP, DP, CP>) &
-    ((component: React$ComponentType<P>) => ConnectedComponentClass<OP, P>);
-
-  declare class Provider<S, A> extends React$Component<{
+  declare export class Provider<S, A> extends React$Component<{
     store: Store<S, A>,
     children?: any
   }> {}
 
-  declare function createProvider(
+  declare export function createProvider(
     storeKey?: string,
     subKey?: string
   ): Provider<*, *>;
 
-  declare type ConnectOptions = {
+  /*
+
+  S = State
+  A = Action
+  OP = OwnProps
+  SP = StateProps
+  DP = DispatchProps
+  MP = Merge props
+  MDP = Map dispatch to props object
+  RSP = Returned state props
+  RDP = Returned dispatch props
+  RMP = Returned merge props
+  Com = React Component
+  */
+
+  declare type MapStateToProps<SP: Object, RSP: Object> = (state: Object, props: SP) => RSP;
+
+  declare type MapDispatchToProps<A, OP: Object, RDP: Object> = (dispatch: Dispatch<A>, ownProps: OP) => RDP;
+
+  declare type MergeProps<SP: Object, DP: Object, MP: Object, RMP: Object> = (
+    stateProps: SP,
+    dispatchProps: DP,
+    ownProps: MP
+  ) => RMP;
+
+  declare type ConnectOptions<S: Object, OP: Object, RSP: Object, RMP: Object> = {|
     pure?: boolean,
-    withRef?: boolean
-  };
+    withRef?: boolean,
+    areStatesEqual?: (next: S, prev: S) => boolean,
+    areOwnPropsEqual?: (next: OP, prev: OP) => boolean,
+    areStatePropsEqual?: (next: RSP, prev: RSP) => boolean,
+    areMergedPropsEqual?: (next: RMP, prev: RMP) => boolean,
+    storeKey?: string
+  |};
 
-  declare type Null = null | void;
+  declare type OmitDispatch<Component> = $Diff<Component, {dispatch: Dispatch<*>}>;
 
-  declare function connect<A, OP>(
-    ...rest: Array<void> // <= workaround for https://github.com/facebook/flow/issues/2360
-  ): Connector<OP, $Supertype<{ dispatch: Dispatch<A> } & OP>>;
+  declare export function connect<Com: ComponentType<*>, DP: Object, RSP: Object>(
+    mapStateToProps: MapStateToProps<DP, RSP>,
+    mapDispatchToProps?: null
+  ): (component: Com) => ComponentType<$Diff<OmitDispatch<ElementConfig<Com>>, RSP> & DP>;
 
-  declare function connect<A, OP>(
-    mapStateToProps: Null,
-    mapDispatchToProps: Null,
-    mergeProps: Null,
-    options: ConnectOptions
-  ): Connector<OP, $Supertype<{ dispatch: Dispatch<A> } & OP>>;
+  declare export function connect<Com: ComponentType<*>>(
+    mapStateToProps?: null,
+    mapDispatchToProps?: null
+  ): (component: Com) => ComponentType<OmitDispatch<ElementConfig<Com>>>;
 
-  declare function connect<S, A, OP, SP>(
-    mapStateToProps: MapStateToProps<S, OP, SP>,
-    mapDispatchToProps: Null,
-    mergeProps: Null,
-    options?: ConnectOptions
-  ): Connector<OP, $Supertype<SP & { dispatch: Dispatch<A> } & OP>>;
+  declare export function connect<Com: ComponentType<*>, A, DP: Object, SP: Object, RSP: Object, RDP: Object>(
+    mapStateToProps: MapStateToProps<SP, RSP>,
+    mapDispatchToProps: MapDispatchToProps<A, DP, RDP>
+  ): (component: Com) => ComponentType<$Diff<$Diff<ElementConfig<Com>, RSP>, RDP> & SP & DP>;
 
-  declare function connect<A, OP, DP>(
-    mapStateToProps: Null,
-    mapDispatchToProps: MapDispatchToProps<A, OP, DP>,
-    mergeProps: Null,
-    options?: ConnectOptions
-  ): Connector<OP, $Supertype<DP & OP>>;
+  declare export function connect<Com: ComponentType<*>, A, OP: Object, DP: Object,PR: Object>(
+    mapStateToProps?: null,
+    mapDispatchToProps: MapDispatchToProps<A, OP, DP>
+  ): (Com) => ComponentType<$Diff<ElementConfig<Com>, DP> & OP>;
 
-  declare function connect<S, A, OP, SP, DP>(
-    mapStateToProps: MapStateToProps<S, OP, SP>,
-    mapDispatchToProps: MapDispatchToProps<A, OP, DP>,
-    mergeProps: Null,
-    options?: ConnectOptions
-  ): Connector<OP, $Supertype<SP & DP & OP>>;
+  declare export function connect<Com: ComponentType<*>, MDP: Object>(
+    mapStateToProps?: null,
+    mapDispatchToProps: MDP
+  ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, MDP>>;
 
-  declare function connect<S, A, OP, SP, DP, P>(
-    mapStateToProps: MapStateToProps<S, OP, SP>,
-    mapDispatchToProps: Null,
-    mergeProps: MergeProps<SP, DP, OP, P>,
-    options?: ConnectOptions
-  ): Connector<OP, P>;
+  declare export function connect<Com: ComponentType<*>, SP: Object, RSP: Object, MDP: Object>(
+    mapStateToProps: MapStateToProps<SP, RSP>,
+    mapDispatchToPRops: MDP
+  ): (component: Com) => ComponentType<$Diff<$Diff<ElementConfig<Com>, RSP>, MDP> & SP>;
 
-  declare function connect<S, A, OP, SP, DP, P>(
-    mapStateToProps: MapStateToProps<S, OP, SP>,
-    mapDispatchToProps: MapDispatchToProps<A, OP, DP>,
-    mergeProps: MergeProps<SP, DP, OP, P>,
-    options?: ConnectOptions
-  ): Connector<OP, P>;
+  declare export function connect<Com: ComponentType<*>, A, DP: Object, SP: Object, RSP: Object, RDP: Object, MP: Object, RMP: Object>(
+    mapStateToProps: MapStateToProps<SP, RSP>,
+    mapDispatchToProps: ?MapDispatchToProps<A, DP, RDP>,
+    mergeProps: MergeProps<RSP, RDP, MP, RMP>
+  ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, RMP> & SP & DP & MP>;
+
+  declare export function connect<Com: ComponentType<*>, A, DP: Object, SP: Object, RSP: Object, RDP: Object, MP: Object, RMP: Object>(
+    mapStateToProps: ?MapStateToProps<SP, RSP>,
+    mapDispatchToProps: ?MapDispatchToProps<A, DP, RDP>,
+    mergeProps: ?MergeProps<RSP, RDP, MP, RMP>,
+    options: ConnectOptions<*, SP & DP & MP, RSP, RMP>
+  ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, RMP> & SP & DP & MP>;
 }

--- a/flow-typed/npm/react-test-renderer_v16.x.x.js
+++ b/flow-typed/npm/react-test-renderer_v16.x.x.js
@@ -1,0 +1,62 @@
+// flow-typed signature: 2d946f2ec4aba5210b19d053c411a59d
+// flow-typed version: 95b3e05165/react-test-renderer_v16.x.x/flow_>=v0.47.x
+
+// Type definitions for react-test-renderer 16.x.x
+// Ported from: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-test-renderer
+
+type ReactTestRendererJSON = {
+  type: string,
+  props: { [propName: string]: any },
+  children: null | ReactTestRendererJSON[]
+};
+
+type ReactTestRendererTree = ReactTestRendererJSON & {
+  nodeType: "component" | "host",
+  instance: any,
+  rendered: null | ReactTestRendererTree
+};
+
+type ReactTestInstance = {
+  instance: any,
+  type: string,
+  props: { [propName: string]: any },
+  parent: null | ReactTestInstance,
+  children: Array<ReactTestInstance | string>,
+
+  find(predicate: (node: ReactTestInstance) => boolean): ReactTestInstance,
+  findByType(type: React$ElementType): ReactTestInstance,
+  findByProps(props: { [propName: string]: any }): ReactTestInstance,
+
+  findAll(
+    predicate: (node: ReactTestInstance) => boolean,
+    options?: { deep: boolean }
+  ): ReactTestInstance[],
+  findAllByType(
+    type: React$ElementType,
+    options?: { deep: boolean }
+  ): ReactTestInstance[],
+  findAllByProps(
+    props: { [propName: string]: any },
+    options?: { deep: boolean }
+  ): ReactTestInstance[]
+};
+
+type ReactTestRenderer = {
+  toJSON(): null | ReactTestRendererJSON,
+  toTree(): null | ReactTestRendererTree,
+  unmount(nextElement?: React$Element<any>): void,
+  update(nextElement: React$Element<any>): void,
+  getInstance(): null | ReactTestInstance,
+  root: ReactTestInstance
+};
+
+type TestRendererOptions = {
+  createNodeMock(element: React$Element<any>): any
+};
+
+declare module "react-test-renderer" {
+  declare function create(
+    nextElement: React$Element<any>,
+    options?: TestRendererOptions
+  ): ReactTestRenderer;
+}

--- a/flow-typed/npm/redux_v3.x.x.js
+++ b/flow-typed/npm/redux_v3.x.x.js
@@ -1,5 +1,5 @@
-// flow-typed signature: 33b83b6284653250e74578cf4dbe6124
-// flow-typed version: e282e4128f/redux_v3.x.x/flow_>=v0.33.x
+// flow-typed signature: cca4916b0213065533df8335c3285a4a
+// flow-typed version: cab04034e7/redux_v3.x.x/flow_>=v0.55.x
 
 declare module 'redux' {
 
@@ -27,7 +27,7 @@ declare module 'redux' {
     replaceReducer(nextReducer: Reducer<S, A>): void
   };
 
-  declare export type Reducer<S, A> = (state: S, action: A) => S;
+  declare export type Reducer<S, A> = (state: S | void, action: A) => S;
 
   declare export type CombinedReducer<S, A> = (state: $Shape<S> & {} | void, action: A) => S;
 
@@ -43,7 +43,7 @@ declare module 'redux' {
   declare export type StoreEnhancer<S, A, D = Dispatch<A>> = (next: StoreCreator<S, A, D>) => StoreCreator<S, A, D>;
 
   declare export function createStore<S, A, D>(reducer: Reducer<S, A>, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>;
-  declare export function createStore<S, A, D>(reducer: Reducer<S, A>, preloadedState: S, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>;
+  declare export function createStore<S, A, D>(reducer: Reducer<S, A>, preloadedState?: S, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>;
 
   declare export function applyMiddleware<S, A, D>(...middlewares: Array<Middleware<S, A, D>>): StoreEnhancer<S, A, D>;
 
@@ -55,55 +55,5 @@ declare module 'redux' {
 
   declare export function combineReducers<O: Object, A>(reducers: O): CombinedReducer<$ObjMap<O, <S>(r: Reducer<S, any>) => S>, A>;
 
-  declare export function compose<A, B>(ab: (a: A) => B): (a: A) => B
-  declare export function compose<A, B, C>(
-    bc: (b: B) => C,
-    ab: (a: A) => B
-  ): (a: A) => C
-  declare export function compose<A, B, C, D>(
-    cd: (c: C) => D,
-    bc: (b: B) => C,
-    ab: (a: A) => B
-  ): (a: A) => D
-  declare export function compose<A, B, C, D, E>(
-    de: (d: D) => E,
-    cd: (c: C) => D,
-    bc: (b: B) => C,
-    ab: (a: A) => B
-  ): (a: A) => E
-  declare export function compose<A, B, C, D, E, F>(
-    ef: (e: E) => F,
-    de: (d: D) => E,
-    cd: (c: C) => D,
-    bc: (b: B) => C,
-    ab: (a: A) => B
-  ): (a: A) => F
-  declare export function compose<A, B, C, D, E, F, G>(
-    fg: (f: F) => G,
-    ef: (e: E) => F,
-    de: (d: D) => E,
-    cd: (c: C) => D,
-    bc: (b: B) => C,
-    ab: (a: A) => B
-  ): (a: A) => G
-  declare export function compose<A, B, C, D, E, F, G, H>(
-    gh: (g: G) => H,
-    fg: (f: F) => G,
-    ef: (e: E) => F,
-    de: (d: D) => E,
-    cd: (c: C) => D,
-    bc: (b: B) => C,
-    ab: (a: A) => B
-  ): (a: A) => H
-  declare export function compose<A, B, C, D, E, F, G, H, I>(
-    hi: (h: H) => I,
-    gh: (g: G) => H,
-    fg: (f: F) => G,
-    ef: (e: E) => F,
-    de: (d: D) => E,
-    cd: (c: C) => D,
-    bc: (b: B) => C,
-    ab: (a: A) => B
-  ): (a: A) => I
-
+  declare export var compose: $Compose;
 }

--- a/flow-typed/npm/reselect_v3.x.x.js
+++ b/flow-typed/npm/reselect_v3.x.x.js
@@ -1,13 +1,12 @@
-// flow-typed signature: 6caf4b7ee5de64bc907fc9dcfc714a1a
-// flow-typed version: f0506e4101/reselect_v3.x.x/flow_>=v0.47.x
+// flow-typed signature: 7242133add1d3bd16fc3e9d648152c63
+// flow-typed version: 00301f0d29/reselect_v3.x.x/flow_>=v0.47.x
 
 // flow-typed signature: 0199525b667f385f2e61dbeae3215f21
 // flow-typed version: b43dff3e0e/reselect_v3.x.x/flow_>=v0.28.x
 
 declare module "reselect" {
-  declare type Selector<-TState, TProps, TResult> = {
-    (state: TState, props: TProps, ...rest: any[]): TResult
-  };
+  declare type Selector<-TState, TProps, TResult> =
+    (state: TState, props: TProps, ...rest: any[]) => TResult
 
   declare type SelectorCreator = {
     <TState, TProps, TResult, T1>(
@@ -887,5 +886,5 @@ declare module "reselect" {
     ) => Selector<TState, TProps, any>
   };
 
-  declare var exports: Reselect;
+  declare module.exports: Reselect;
 }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "eslint-plugin-jest": "^21.6.1",
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-react": "^7.5.1",
-    "flow-bin": "0.61.0",
+    "flow-bin": "0.67.1",
     "jest": "^22.0.5",
     "raf-stub": "^2.0.1",
     "react": "^15.6.2",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "eslint-plugin-jest": "^21.6.1",
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-react": "^7.5.1",
-    "flow-bin": "0.67.1",
+    "flow-bin": "0.68.0",
     "jest": "^22.0.5",
     "raf-stub": "^2.0.1",
     "react": "^15.6.2",

--- a/src/state/dimension-marshal/dimension-marshal.js
+++ b/src/state/dimension-marshal/dimension-marshal.js
@@ -33,7 +33,7 @@ type State = {|
   isCollecting: boolean,
   scrollOptions: ?ScrollOptions,
   request: ?LiftRequest,
-  frameId: ?number,
+  frameId: ?AnimationFrameID,
 |}
 
 type ToBePublished = {|
@@ -337,7 +337,7 @@ export default (callbacks: Callbacks) => {
     homeEntry.callbacks.watchScroll(request.scrollOptions);
   };
 
-  const setFrameId = (frameId: ?number) => {
+  const setFrameId = (frameId: ?AnimationFrameID) => {
     setState({
       frameId,
     });
@@ -369,7 +369,7 @@ export default (callbacks: Callbacks) => {
     const toBeCollected: UnknownDescriptorType[] = getToBeCollected();
 
     // Phase 1: collect dimensions in a single frame
-    const collectFrameId: number = requestAnimationFrame(() => {
+    const collectFrameId: AnimationFrameID = requestAnimationFrame(() => {
       const toBePublishedBuffer: UnknownDimensionType[] = toBeCollected.map(
         (descriptor: UnknownDescriptorType): UnknownDimensionType => {
           // is a droppable
@@ -382,7 +382,7 @@ export default (callbacks: Callbacks) => {
       );
 
       // Phase 2: publish all dimensions to the store
-      const publishFrameId: number = requestAnimationFrame(() => {
+      const publishFrameId: AnimationFrameID = requestAnimationFrame(() => {
         const toBePublished: ToBePublished = toBePublishedBuffer.reduce(
           (previous: ToBePublished, dimension: UnknownDimensionType): ToBePublished => {
             // is a draggable

--- a/src/state/dimension.js
+++ b/src/state/dimension.js
@@ -128,11 +128,10 @@ export const scrollDroppable = (
     clipped,
   };
 
-  // $ExpectError - using spread
-  return {
+  return ({
     ...droppable,
     viewport,
-  };
+  }: any);
 };
 
 type GetDroppableArgs = {|

--- a/src/state/get-new-home-client-center.js
+++ b/src/state/get-new-home-client-center.js
@@ -71,7 +71,6 @@ export default ({
     }
 
     // Otherwise, return the dimension of the empty foreign droppable
-    // $ExpectError - flow does not correctly type this as non optional
     return destination.client.contentBox;
   })();
 

--- a/src/state/reducer.js
+++ b/src/state/reducer.js
@@ -266,14 +266,13 @@ export default (state: State = clean('IDLE'), action: Action): State => {
         return existing;
       }
 
-      // $ExpectError - using spread
-      const newDrag: DragState = {
+      const newDrag: DragState = ({
         ...existing,
         current: {
           ...existing.current,
           hasCompletedFirstBulkPublish: true,
         },
-      };
+      }: any);
 
       return newDrag;
     })();

--- a/src/view/drag-handle/sensor/create-mouse-sensor.js
+++ b/src/view/drag-handle/sensor/create-mouse-sensor.js
@@ -204,12 +204,12 @@ export default ({
     {
       eventName: 'webkitmouseforcechanged',
       fn: (event: MouseForceChangedEvent) => {
-        if (event.webkitForce == null || MouseEvent.WEBKIT_FORCE_AT_FORCE_MOUSE_DOWN == null) {
+        if (event.webkitForce == null || (MouseEvent: any).WEBKIT_FORCE_AT_FORCE_MOUSE_DOWN == null) {
           console.error('handling a mouse force changed event when it is not supported');
           return;
         }
 
-        const forcePressThreshold: number = (MouseEvent.WEBKIT_FORCE_AT_FORCE_MOUSE_DOWN : any);
+        const forcePressThreshold: number = (MouseEvent: any).WEBKIT_FORCE_AT_FORCE_MOUSE_DOWN;
         const isForcePressing: boolean = event.webkitForce >= forcePressThreshold;
 
         if (isForcePressing) {

--- a/src/view/drag-handle/sensor/create-mouse-sensor.js
+++ b/src/view/drag-handle/sensor/create-mouse-sensor.js
@@ -204,7 +204,10 @@ export default ({
     {
       eventName: 'webkitmouseforcechanged',
       fn: (event: MouseForceChangedEvent) => {
-        if (event.webkitForce == null || (MouseEvent: any).WEBKIT_FORCE_AT_FORCE_MOUSE_DOWN == null) {
+        if (
+          event.webkitForce == null ||
+          (MouseEvent: any).WEBKIT_FORCE_AT_FORCE_MOUSE_DOWN == null
+        ) {
           console.error('handling a mouse force changed event when it is not supported');
           return;
         }

--- a/src/view/drag-handle/sensor/create-touch-sensor.js
+++ b/src/view/drag-handle/sensor/create-touch-sensor.js
@@ -15,7 +15,7 @@ import type { TouchSensor, CreateSensorArgs } from './sensor-types';
 type State = {
   isDragging: boolean,
   hasMoved: boolean,
-  longPressTimerId: ?number,
+  longPressTimerId: ?TimeoutID,
   pending: ?Position,
 }
 
@@ -96,7 +96,7 @@ export default ({
       y: clientY,
     };
 
-    const longPressTimerId: number = setTimeout(startDragging, timeForLongPress);
+    const longPressTimerId: TimeoutID = setTimeout(startDragging, timeForLongPress);
 
     setState({
       longPressTimerId,
@@ -108,7 +108,9 @@ export default ({
   };
 
   const stopPendingDrag = () => {
-    clearTimeout(state.longPressTimerId);
+    if (state.longPressTimerId) {
+      clearTimeout(state.longPressTimerId);
+    }
     schedule.cancel();
     touchStartMarshal.reset();
     unbindWindowEvents();

--- a/src/view/draggable/connected-draggable.js
+++ b/src/view/draggable/connected-draggable.js
@@ -1,4 +1,5 @@
 // @flow
+import type { Node } from 'react';
 import memoizeOne from 'memoize-one';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
@@ -32,6 +33,7 @@ import type {
 import type {
   MapProps,
   OwnProps,
+  DefaultProps,
   DispatchProps,
   Selector,
 } from './draggable-types';
@@ -262,12 +264,19 @@ const mapDispatchToProps: DispatchProps = {
 // Leaning heavily on the default shallow equality checking
 // that `connect` provides.
 // It avoids needing to do it own within `Draggable`
-export default connect(
+const ConnectedDraggable: OwnProps => Node = (connect(
   // returning a function to ensure each
   // Draggable gets its own selector
   (makeMapStateToProps: any),
-  mapDispatchToProps,
+  (mapDispatchToProps: any),
   null,
   { storeKey },
-)(Draggable);
+): any)(Draggable);
 
+ConnectedDraggable.defaultProps = ({
+  isDragDisabled: false,
+  // cannot drag interactive elements by default
+  disableInteractiveElementBlocking: false,
+}: DefaultProps);
+
+export default ConnectedDraggable;

--- a/src/view/draggable/connected-draggable.js
+++ b/src/view/draggable/connected-draggable.js
@@ -243,7 +243,6 @@ export const makeSelector = (): Selector => {
 
 const makeMapStateToProps = () => {
   const selector: Selector = makeSelector();
-  // $FlowFixMe - no idea how to type this correctly
   return (state: State, props: OwnProps) => selector(state, props);
 };
 
@@ -266,7 +265,7 @@ const mapDispatchToProps: DispatchProps = {
 export default connect(
   // returning a function to ensure each
   // Draggable gets its own selector
-  makeMapStateToProps,
+  (makeMapStateToProps: any),
   mapDispatchToProps,
   null,
   { storeKey },

--- a/src/view/draggable/draggable.jsx
+++ b/src/view/draggable/draggable.jsx
@@ -53,12 +53,6 @@ export default class Draggable extends Component<Props, State> {
     ref: null,
   }
 
-  static defaultProps: DefaultProps = {
-    isDragDisabled: false,
-    // cannot drag interactive elements by default
-    disableInteractiveElementBlocking: false,
-  }
-
   // Need to declare contextTypes without flow
   // https://github.com/brigand/babel-plugin-flow-react-proptypes/issues/22
   static contextTypes = {

--- a/src/view/droppable/connected-droppable.js
+++ b/src/view/droppable/connected-droppable.js
@@ -1,4 +1,5 @@
 // @flow
+import type { Node } from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import memoizeOne from 'memoize-one';
@@ -23,6 +24,7 @@ import type {
 } from '../../types';
 import type {
   OwnProps,
+  DefaultProps,
   MapProps,
   Selector,
 } from './droppable-types';
@@ -151,13 +153,20 @@ const makeMapStateToProps = () => {
 // Leaning heavily on the default shallow equality checking
 // that `connect` provides.
 // It avoids needing to do it own within `Droppable`
-const connectedDroppable: React.ComponentType<OwnProps> = connect(
+const connectedDroppable: OwnProps => Node = (connect(
   // returning a function to ensure each
   // Droppable gets its own selector
   (makeMapStateToProps: any),
   null,
   null,
   { storeKey },
-)(Droppable);
+): any)(Droppable);
+
+connectedDroppable.defaultProps = ({
+  type: 'DEFAULT',
+  isDropDisabled: false,
+  direction: 'vertical',
+  ignoreContainerClipping: false,
+}: DefaultProps);
 
 export default connectedDroppable;

--- a/src/view/droppable/connected-droppable.js
+++ b/src/view/droppable/connected-droppable.js
@@ -151,13 +151,13 @@ const makeMapStateToProps = () => {
 // Leaning heavily on the default shallow equality checking
 // that `connect` provides.
 // It avoids needing to do it own within `Droppable`
-// $ExpectError - no idea how to type this correctly
-export default connect(
+const connectedDroppable: React.ComponentType<OwnProps> = connect(
   // returning a function to ensure each
   // Droppable gets its own selector
-  makeMapStateToProps,
+  (makeMapStateToProps: any),
   null,
   null,
   { storeKey },
 )(Droppable);
 
+export default connectedDroppable;

--- a/src/view/droppable/droppable.jsx
+++ b/src/view/droppable/droppable.jsx
@@ -26,13 +26,6 @@ export default class Droppable extends Component<Props, State> {
     ref: null,
   }
 
-  static defaultProps: DefaultProps = {
-    type: 'DEFAULT',
-    isDropDisabled: false,
-    direction: 'vertical',
-    ignoreContainerClipping: false,
-  }
-
   // Need to declare childContextTypes without flow
   static contextTypes = {
     [styleContextKey]: PropTypes.string.isRequired,

--- a/src/view/moveable/moveable-types.js
+++ b/src/view/moveable/moveable-types.js
@@ -1,5 +1,5 @@
 // @flow
-import type { Node } from 'react';
+import type { Element } from 'react';
 import type { Position } from '../../types';
 
 export type Speed = 'INSTANT' | 'STANDARD' | 'FAST';
@@ -12,7 +12,7 @@ export type Props = {|
   speed: Speed,
   destination: Position,
   onMoveEnd: () => void,
-  children: (Style) => React.Element<*>,
+  children: (Style) => Element<*>,
 |}
 
 export type DefaultProps = {|

--- a/src/view/moveable/moveable-types.js
+++ b/src/view/moveable/moveable-types.js
@@ -1,5 +1,5 @@
 // @flow
-import type { Element } from 'react';
+import type { Node } from 'react';
 import type { Position } from '../../types';
 
 export type Speed = 'INSTANT' | 'STANDARD' | 'FAST';
@@ -12,7 +12,7 @@ export type Props = {|
   speed: Speed,
   destination: Position,
   onMoveEnd: () => void,
-  children: (Style) => Element<*>,
+  children: (Style) => Node,
 |}
 
 export type DefaultProps = {|

--- a/src/view/moveable/moveable-types.js
+++ b/src/view/moveable/moveable-types.js
@@ -12,7 +12,7 @@ export type Props = {|
   speed: Speed,
   destination: Position,
   onMoveEnd: () => void,
-  children: (Style) => Node,
+  children: (Style) => React.Element<*>,
 |}
 
 export type DefaultProps = {|

--- a/src/view/moveable/moveable.jsx
+++ b/src/view/moveable/moveable.jsx
@@ -89,9 +89,8 @@ export default class Movable extends Component<Props> {
       // Expecting a flow error
       // React Motion type: children: (interpolatedStyle: PlainStyle) => ReactElement
       // Our type: children: (Position) => (Style) => React.Node
-      // $ExpectError
       <Motion defaultStyle={origin} style={final} onRest={this.onRest}>
-        {(current: Position) =>
+        {(current: { [string]: number }) =>
           this.props.children(
             getStyle(isNotMoving, current.x, current.y)
           )}

--- a/src/view/moveable/moveable.jsx
+++ b/src/view/moveable/moveable.jsx
@@ -90,7 +90,7 @@ export default class Movable extends Component<Props> {
       // React Motion type: children: (interpolatedStyle: PlainStyle) => ReactElement
       // Our type: children: (Position) => (Style) => React.Node
       <Motion defaultStyle={origin} style={final} onRest={this.onRest}>
-        {(current: { [string]: number }) =>
+        {(current: { [string]: number }): any =>
           this.props.children(
             getStyle(isNotMoving, current.x, current.y)
           )}

--- a/test/unit/view/drag-drop-context.spec.js
+++ b/test/unit/view/drag-drop-context.spec.js
@@ -42,6 +42,8 @@ describe('DragDropContext', () => {
 
     const app = TestUtils.findRenderedComponentWithType(tree, App);
 
+    if (!app) return;
+
     expect(app.context[storeKey]).toHaveProperty('dispatch');
     expect(app.context[storeKey].dispatch).toBeInstanceOf(Function);
     expect(app.context[storeKey]).toHaveProperty('getState');
@@ -75,6 +77,8 @@ describe('DragDropContext', () => {
       );
 
       const app = TestUtils.findRenderedComponentWithType(tree, App);
+
+      if (!app) return;
 
       expect(app.context[canLiftContextKey]).toBeInstanceOf(Function);
     });

--- a/test/unit/view/drag-drop-context.spec.js
+++ b/test/unit/view/drag-drop-context.spec.js
@@ -43,7 +43,7 @@ describe('DragDropContext', () => {
     const app = TestUtils.findRenderedComponentWithType(tree, App);
 
     if (!app) {
-      return;
+      throw new Error('Invalid test setup');
     }
 
     expect(app.context[storeKey]).toHaveProperty('dispatch');
@@ -81,7 +81,7 @@ describe('DragDropContext', () => {
       const app = TestUtils.findRenderedComponentWithType(tree, App);
 
       if (!app) {
-        return;
+        throw new Error('Invalid test setup');
       }
 
       expect(app.context[canLiftContextKey]).toBeInstanceOf(Function);

--- a/test/unit/view/drag-drop-context.spec.js
+++ b/test/unit/view/drag-drop-context.spec.js
@@ -42,7 +42,9 @@ describe('DragDropContext', () => {
 
     const app = TestUtils.findRenderedComponentWithType(tree, App);
 
-    if (!app) return;
+    if (!app) {
+      return;
+    }
 
     expect(app.context[storeKey]).toHaveProperty('dispatch');
     expect(app.context[storeKey].dispatch).toBeInstanceOf(Function);
@@ -78,7 +80,9 @@ describe('DragDropContext', () => {
 
       const app = TestUtils.findRenderedComponentWithType(tree, App);
 
-      if (!app) return;
+      if (!app) {
+        return;
+      }
 
       expect(app.context[canLiftContextKey]).toBeInstanceOf(Function);
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3175,9 +3175,9 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-bin@0.67.1:
-  version "0.67.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.67.1.tgz#eabb7197cce870ac9442cfd04251c7ddc30377db"
+flow-bin@0.68.0:
+  version "0.68.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.68.0.tgz#86c2d14857d306eb2e85e274f2eebf543564f623"
 
 for-in@^1.0.1:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3175,9 +3175,9 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-bin@0.61.0:
-  version "0.61.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.61.0.tgz#d0473a8c35dbbf4de573823f4932124397d32d35"
+flow-bin@0.67.1:
+  version "0.67.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.67.1.tgz#eabb7197cce870ac9442cfd04251c7ddc30377db"
 
 for-in@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
- upgraded flow
- upgraded definitions with `flow-typed install --skip`
- fixed opaque types of `requestAnimationFrame` and `setTimeout`
- removed $ExpectError suppressions which may not exists in user config
- removed $FlowFixMe suppressions because sometimes they force flow recheck infinitely (personal experience)
- fixed a few suppressed errors
- prevented react-redux errors with more safe `any`, I think it's ok since you annotate so much

P.S. New react-redux definitions are still broken, probably because they do not cover all cases