### PR TITLE
support transformed draggables without portals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1035,7 +1035,26 @@ It is a contract of this library that it owns the positioning logic of the dragg
 
 `react-beautiful-dnd` uses `position: fixed` to position the dragging element. This is quite robust and allows for you to have `position: relative | absolute | fixed` parents. However, unfortunately `position:fixed` is [impacted by `transform`](http://meyerweb.com/eric/thoughts/2011/09/12/un-fixing-fixed-elements-with-css-transforms/) (such as `transform: rotate(10deg);`). This means that if you have a `transform: *` on one of the parents of a `Draggable` then the positioning logic will be incorrect while dragging. Lame! For most consumers this will not be an issue.
 
-This will be changing soon as we move to a [portal solution](https://github.com/atlassian/react-beautiful-dnd/issues/192) where we will be appending the `Draggable` to the end of the body to avoid any parent transforms. If you really need this feature right now we have [created an example](https://www.webpackbin.com/bins/-L-3aZ_bTMiGPl8bqlRB) where we implement a portal on top of the current api. Please note however, this technique is not officially supported and might break in minor / patch releases.
+If your draggable has an ancestor that uses `transform`, `perspective`, or `filter`, simply add `transformRef` to the parent of the div that has `innerRef`:
+
+```js
+import { Draggable } from 'react-beautiful-dnd';
+
+<Draggable draggableId="draggable-1" index={0}>
+  {(provided, snapshot) => (
+    <div ref={provided.transformRef}>
+      <div
+        ref={provided.innerRef}
+        {...provided.draggableProps}
+        {...provided.dragHandleProps}
+      >
+        <h4>My draggable</h4>
+      </div>
+      {provided.placeholder}
+    </div>
+  )}
+</Draggable>;
+```
 
 ##### Extending `DraggableProps.style`
 

--- a/src/view/draggable/draggable-types.js
+++ b/src/view/draggable/draggable-types.js
@@ -103,6 +103,7 @@ export type Provided = {|
   // The following props will be removed once we move to react 16
   innerRef: (?HTMLElement) => void,
   placeholder: ?Node,
+  transformRef: (?HTMLElement) => void,
 |}
 
 export type StateSnapshot = {|


### PR DESCRIPTION
Per #192 it looks like portals are not the way to go.
I agree. I usually love portals, but when performance is critical, they aren't great.
I have a hard requirement on using a transform.
We _could_ do this without extending the API, but that would be more expensive because we'd have to climb the DOM tree looking for a `transform`. In the spirit of performance-first, I opted to add a single extra `provided` function. For those that don't use transforms, no change is required. For those that do, they add a single argument to a div.

How it works:
react-beautiful-dnd uses `position: fixed`, which is great, except for 1 caveat. Per MDN docs:

> When an ancestor has the transform, perspective, or filter property set to something other than none, that ancestor is used as the container instead of the viewport

If the developer provides a `transformRef`, then that tells the `Draggable` that an ancestor is being transformed, and therefore the `left, top` should be relative to the transformed node, _not_ the viewport. It adjusts the `left, top` accordingly.
 