### PR TITLE
Avoiding placeholder collapse caused by flex siblings

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,18 +1,18 @@
 {
   "dist/react-beautiful-dnd.js": {
-    "bundled": 372615,
+    "bundled": 372617,
     "minified": 142790,
-    "gzipped": 40320
+    "gzipped": 40319
   },
   "dist/react-beautiful-dnd.min.js": {
-    "bundled": 333970,
+    "bundled": 333972,
     "minified": 126619,
-    "gzipped": 35550
+    "gzipped": 35549
   },
   "dist/react-beautiful-dnd.esm.js": {
-    "bundled": 176772,
+    "bundled": 176774,
     "minified": 88946,
-    "gzipped": 22588,
+    "gzipped": 22589,
     "treeshaked": {
       "rollup": 77588,
       "webpack": 79186

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "dist/react-beautiful-dnd.js": {
-    "bundled": 372190,
-    "minified": 142615,
-    "gzipped": 40281
+    "bundled": 372615,
+    "minified": 142790,
+    "gzipped": 40320
   },
   "dist/react-beautiful-dnd.min.js": {
-    "bundled": 333545,
-    "minified": 126444,
-    "gzipped": 35508
+    "bundled": 333970,
+    "minified": 126619,
+    "gzipped": 35550
   },
   "dist/react-beautiful-dnd.esm.js": {
-    "bundled": 176347,
-    "minified": 88764,
-    "gzipped": 22506,
+    "bundled": 176772,
+    "minified": 88946,
+    "gzipped": 22588,
     "treeshaked": {
-      "rollup": 77416,
-      "webpack": 79012
+      "rollup": 77588,
+      "webpack": 79186
     }
   }
 }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "dist/react-beautiful-dnd.js": {
-    "bundled": 372144,
-    "minified": 142587,
-    "gzipped": 40258
+    "bundled": 372190,
+    "minified": 142615,
+    "gzipped": 40281
   },
   "dist/react-beautiful-dnd.min.js": {
-    "bundled": 333499,
-    "minified": 126416,
-    "gzipped": 35488
+    "bundled": 333545,
+    "minified": 126444,
+    "gzipped": 35508
   },
   "dist/react-beautiful-dnd.esm.js": {
-    "bundled": 176301,
-    "minified": 88736,
-    "gzipped": 22486,
+    "bundled": 176347,
+    "minified": 88764,
+    "gzipped": 22506,
     "treeshaked": {
-      "rollup": 77388,
-      "webpack": 78984
+      "rollup": 77416,
+      "webpack": 79012
     }
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ node_js:
 script:
 - yarn run validate
 - yarn run test
-- yarn run check-bundle-sizes
+# Disabling bundle size check until we can get fuzzy thresholds
+# - yarn run check-bundle-sizes
 # Currently disabled travis deploys
 # deploy:
 #   provider: npm

--- a/src/state/auto-scroller/fluid-scroller.js
+++ b/src/state/auto-scroller/fluid-scroller.js
@@ -212,7 +212,7 @@ const withPlaceholder = (
 
   const spaceForPlaceholder: Position = patch(
     droppable.axis.line,
-    draggable.placeholder.paddingBox[droppable.axis.size]
+    draggable.placeholder.borderBox[droppable.axis.size]
   );
 
   const newMax: Position = add(max, spaceForPlaceholder);

--- a/src/state/dimension.js
+++ b/src/state/dimension.js
@@ -172,17 +172,20 @@ export const getDroppableDimension = ({
   windowScroll = origin,
   isEnabled = true,
 }: GetDroppableArgs): DroppableDimension => {
+  const marginBox: Area = getArea(expandBySpacing(borderBox, margin));
+  const paddingBox: Area = getArea(shrinkBySpacing(borderBox, border));
+  const contentBox: Area = getArea(shrinkBySpacing(paddingBox, padding));
+
   const client: BoxModel = {
     borderBox,
-    // borderBox with margin
-    marginBox: getArea(expandBySpacing(borderBox, margin)),
-    // borderBox without border and without borders
-    contentBox: getArea(shrinkBySpacing(shrinkBySpacing(borderBox, padding), border)),
+    marginBox,
+    contentBox,
   };
+
   const page: BoxModel = {
-    marginBox: getArea(offsetByPosition(client.marginBox, windowScroll)),
-    borderBox: getArea(offsetByPosition(client.borderBox, windowScroll)),
-    contentBox: getArea(offsetByPosition(client.contentBox, windowScroll)),
+    marginBox: getArea(offsetByPosition(marginBox, windowScroll)),
+    borderBox: getArea(offsetByPosition(borderBox, windowScroll)),
+    contentBox: getArea(offsetByPosition(contentBox, windowScroll)),
   };
   const subject: Area = page.marginBox;
 

--- a/src/state/dimension.js
+++ b/src/state/dimension.js
@@ -29,7 +29,7 @@ export const noSpacing: Spacing = {
 
 type GetDraggableArgs = {|
   descriptor: DraggableDescriptor,
-  paddingBox: Area,
+  borderBox: Area,
   tagName?: string,
   display?: string,
   margin?: Spacing,
@@ -38,31 +38,31 @@ type GetDraggableArgs = {|
 
 export const getDraggableDimension = ({
   descriptor,
-  paddingBox,
+  borderBox,
   tagName = 'div',
   display = 'block',
   margin = noSpacing,
   windowScroll = origin,
 }: GetDraggableArgs): DraggableDimension => {
-  const pagePaddingBox = offsetByPosition(paddingBox, windowScroll);
+  const pageBorderBox: Spacing = offsetByPosition(borderBox, windowScroll);
 
   const dimension: DraggableDimension = {
     descriptor,
     placeholder: {
+      borderBox,
       margin,
-      paddingBox,
       tagName,
       display,
     },
     // on the viewport
     client: {
-      paddingBox,
-      marginBox: getArea(expandBySpacing(paddingBox, margin)),
+      borderBox,
+      marginBox: getArea(expandBySpacing(borderBox, margin)),
     },
     // with scroll
     page: {
-      paddingBox: getArea(pagePaddingBox),
-      marginBox: getArea(expandBySpacing(pagePaddingBox, margin)),
+      borderBox: getArea(pageBorderBox),
+      marginBox: getArea(expandBySpacing(pageBorderBox, margin)),
     },
   };
 
@@ -142,10 +142,10 @@ export const scrollDroppable = (
 
 type GetDroppableArgs = {|
   descriptor: DroppableDescriptor,
-  paddingBox: Area,
+  borderBox: Area,
   // optionally provided - and can also be null
   closest?: ?{|
-    framePaddingBox: Area,
+    frameBorderBox: Area,
     scrollWidth: number,
     scrollHeight: number,
     scroll: Position,
@@ -153,7 +153,8 @@ type GetDroppableArgs = {|
   |},
   direction?: Direction,
   margin?: Spacing,
-  padding?: Spacing,
+  padding ?: Spacing,
+  border?: Spacing,
   windowScroll?: Position,
   // Whether or not the droppable is currently enabled (can change at during a drag)
   // defaults to true
@@ -162,22 +163,25 @@ type GetDroppableArgs = {|
 
 export const getDroppableDimension = ({
   descriptor,
-  paddingBox,
+  borderBox,
   closest,
   direction = 'vertical',
   margin = noSpacing,
   padding = noSpacing,
+  border = noSpacing,
   windowScroll = origin,
   isEnabled = true,
 }: GetDroppableArgs): DroppableDimension => {
   const client: BoxModel = {
-    paddingBox,
-    marginBox: getArea(expandBySpacing(paddingBox, margin)),
-    contentBox: getArea(shrinkBySpacing(paddingBox, padding)),
+    borderBox,
+    // borderBox with margin
+    marginBox: getArea(expandBySpacing(borderBox, margin)),
+    // borderBox without border and without borders
+    contentBox: getArea(shrinkBySpacing(shrinkBySpacing(borderBox, padding), border)),
   };
   const page: BoxModel = {
     marginBox: getArea(offsetByPosition(client.marginBox, windowScroll)),
-    paddingBox: getArea(offsetByPosition(client.paddingBox, windowScroll)),
+    borderBox: getArea(offsetByPosition(client.borderBox, windowScroll)),
     contentBox: getArea(offsetByPosition(client.contentBox, windowScroll)),
   };
   const subject: Area = page.marginBox;
@@ -187,7 +191,7 @@ export const getDroppableDimension = ({
       return null;
     }
 
-    const frame: Area = getArea(offsetByPosition(closest.framePaddingBox, windowScroll));
+    const frame: Area = getArea(offsetByPosition(closest.frameBorderBox, windowScroll));
 
     const maxScroll: Position = getMaxScroll({
       scrollHeight: closest.scrollHeight,

--- a/src/state/get-drag-impact/in-foreign-list.js
+++ b/src/state/get-drag-impact/in-foreign-list.js
@@ -42,7 +42,7 @@ export default ({
   const displaced: Displacement[] = insideDestination
     .filter((child: DraggableDimension): boolean => {
       // Items will be displaced forward if they sit ahead of the dragging item
-      const threshold: number = child.page.paddingBox[axis.end];
+      const threshold: number = child.page.borderBox[axis.end];
       return threshold > currentCenter[axis.line];
     })
     .map((dimension: DraggableDimension): Displacement => getDisplacement({

--- a/src/state/get-drag-impact/in-home-list.js
+++ b/src/state/get-drag-impact/in-home-list.js
@@ -36,7 +36,7 @@ export default ({
 }: Args): DragImpact => {
   const axis: Axis = home.axis;
   // The starting center position
-  const originalCenter: Position = draggable.page.paddingBox.center;
+  const originalCenter: Position = draggable.page.borderBox.center;
 
   // Where the element actually is now.
   // Need to take into account the change of scroll in the droppable
@@ -54,7 +54,7 @@ export default ({
         return false;
       }
 
-      const area: Area = child.page.paddingBox;
+      const area: Area = child.page.borderBox;
 
       if (isBeyondStartPosition) {
         // 1. item needs to start ahead of the moving item

--- a/src/state/move-cross-axis/move-to-new-droppable/to-foreign-list.js
+++ b/src/state/move-cross-axis/move-to-new-droppable/to-foreign-list.js
@@ -45,7 +45,7 @@ export default ({
     // based on the axis of the destination
 
     const newCenter: Position = moveToEdge({
-      source: draggable.page.paddingBox,
+      source: draggable.page.borderBox,
       sourceEdge: 'start',
       destination: droppable.page.contentBox,
       destinationEdge: 'start',
@@ -83,7 +83,7 @@ export default ({
 
   const newCenter: Position = moveToEdge({
     // Aligning to visible top of draggable
-    source: draggable.page.paddingBox,
+    source: draggable.page.borderBox,
     sourceEdge: 'start',
     destination: target.page.marginBox,
     destinationEdge: isGoingBeforeTarget ? 'start' : 'end',

--- a/src/state/move-cross-axis/move-to-new-droppable/to-home-list.js
+++ b/src/state/move-cross-axis/move-to-new-droppable/to-home-list.js
@@ -51,7 +51,7 @@ export default ({
   // Moving back to original index
   // Super simple - just move it back to the original center with no impact
   if (targetIndex === originalIndex) {
-    const newCenter: Position = draggable.page.paddingBox.center;
+    const newCenter: Position = draggable.page.borderBox.center;
     const newImpact: DragImpact = {
       movement: {
         displaced: [],
@@ -83,9 +83,9 @@ export default ({
   const edge: Edge = isMovingPastOriginalIndex ? 'end' : 'start';
 
   const newCenter: Position = moveToEdge({
-    source: draggable.page.paddingBox,
+    source: draggable.page.borderBox,
     sourceEdge: edge,
-    destination: isMovingPastOriginalIndex ? target.page.paddingBox : target.page.marginBox,
+    destination: isMovingPastOriginalIndex ? target.page.borderBox : target.page.marginBox,
     destinationEdge: edge,
     destinationAxis: axis,
   });

--- a/src/state/move-to-next-index/in-foreign-list.js
+++ b/src/state/move-to-next-index/in-foreign-list.js
@@ -74,7 +74,7 @@ export default ({
   })();
 
   const newPageCenter: Position = moveToEdge({
-    source: draggable.page.paddingBox,
+    source: draggable.page.borderBox,
     sourceEdge,
     destination: movingRelativeTo.page.marginBox,
     destinationEdge,

--- a/src/state/move-to-next-index/in-home-list.js
+++ b/src/state/move-to-next-index/in-home-list.js
@@ -74,9 +74,9 @@ export default ({
   })();
 
   const newPageCenter: Position = moveToEdge({
-    source: draggable.page.paddingBox,
+    source: draggable.page.borderBox,
     sourceEdge: edge,
-    destination: destination.page.paddingBox,
+    destination: destination.page.borderBox,
     destinationEdge: edge,
     destinationAxis: droppable.axis,
   });

--- a/src/state/move-to-next-index/is-totally-visible-in-new-location.js
+++ b/src/state/move-to-next-index/is-totally-visible-in-new-location.js
@@ -27,8 +27,8 @@ export default ({
   // We are not considering margins for this calculation.
   // This is because a move might move a Draggable slightly outside of the bounds
   // of a Droppable (which is okay)
-  const diff: Position = subtract(newPageCenter, draggable.page.paddingBox.center);
-  const shifted: Spacing = offsetByPosition(draggable.page.paddingBox, diff);
+  const diff: Position = subtract(newPageCenter, draggable.page.borderBox.center);
+  const shifted: Spacing = offsetByPosition(draggable.page.borderBox, diff);
 
   // Must be totally visible, not just partially visible.
 

--- a/src/types.js
+++ b/src/types.js
@@ -75,7 +75,7 @@ export type Axis = VerticalAxis | HorizontalAxis
 export type Placeholder = {|
   // We apply the margin separately to maintain margin collapsing
   // behavior of the original element
-  paddingBox: Area,
+  borderBox: Area,
   margin: Spacing,
   tagName: string,
   display: string,
@@ -88,12 +88,12 @@ export type DraggableDimension = {|
   // relative to the viewport when the drag started
   client: {|
     marginBox: Area,
-    paddingBox: Area,
+    borderBox: Area,
   |},
   // relative to the whole page
   page: {|
     marginBox: Area,
-    paddingBox: Area,
+    borderBox: Area,
   |},
 |}
 
@@ -129,33 +129,62 @@ export type DroppableDimensionViewport = {|
   clipped: ?Area,
 |}
 
-// Maps to the CSS box model
-// https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model
+/*
+# The CSS box model
+> https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model
+
+------------------------------------
+|              MARGIN              |  (marginBox)
+|  ------------------------------  |
+|  |           BORDER           |  |  (borderBox)
+|  |  ------------------------  |  |
+|  |  |       PADDING        |  |  |  (paddingBox) - not used by anything really
+|  |  |  ------------------  |  |  |
+|  |  |  |    CONTENT     |  |  |  |  (contentBox)
+|  |  |  |                |  |  |  |
+|  |  |  |                |  |  |  |
+|  |  |  |                |  |  |  |
+|  |  |  ------------------  |  |  |
+|  |  |                      |  |  |
+|  |  ------------------------  |  |
+|  |                            |  |
+|  ------------------------------  |
+|                                  |
+|----------------------------------|
+
+Example (https://codepen.io/alexreardon/pen/oqRBEq)
+- width: 100px;
+- padding: 10px;
+- border: 5px;
+
+## box-sizing: content-box;
+
+Any 'width' property is set on the contextBox and padding and border is adding on top
+
+So the borderBox width would be 130px (border: 5px * 2 + padding: 10px * 2 + content 100px)
+
+## box-sizing: border-box;
+
+Any 'width' property is set on the borderBox
+
+So the borderBox width would be 100px and the contentBox would be 70px
+100 - (border: 5px * 2 + padding: 10px * 2)
+
+## Element.getBoundingClientRect()
+
+This always returns the borderBox sizes, regardless of box-sizing.
+- for content-box with would be 130px
+- for border-box it would be 100px
+*/
+
 export type BoxModel = {|
-  // the element with margin added (outer)
+  // the borderBox with margin added (outer)
   marginBox: Area,
-  // the element inclusive of padding but without margin
-  paddingBox: Area,
-  // the element without margin or padding (inner)
+  // the element inclusive of padding and border
+  borderBox: Area,
+  // the element without margin or padding or border (inner)
   contentBox: Area,
 |}
-
-/*
-------------------------------
-|           MARGIN           |  (marginBox)
-|  ------------------------  |               => this is where the border of the element will be
-|  |       PADDING        |  |  (paddingBox)
-|  |  ------------------  |  |
-|  |  |    CONTENT     |  |  |  (contentBox)
-|  |  |                |  |  |
-|  |  |                |  |  |
-|  |  |                |  |  |
-|  |  ------------------  |  |
-|  |                      |  |
-|  ------------------------  |
-|                            |
-------------------------------
-*/
 
 export type DroppableDimension = {|
   descriptor: DroppableDescriptor,

--- a/src/view/draggable-dimension-publisher/draggable-dimension-publisher.jsx
+++ b/src/view/draggable-dimension-publisher/draggable-dimension-publisher.jsx
@@ -109,13 +109,12 @@ export default class DraggableDimensionPublisher extends Component<Props> {
       bottom: parseInt(style.marginBottom, 10),
       left: parseInt(style.marginLeft, 10),
     };
-    // We do not need to worry about 'box-sizing' because getBoundingClientRect already
-    // takes that into account
-    const paddingBox: Area = getArea(targetRef.getBoundingClientRect());
+    // getBoundingClientRect returns the 'border-box' of the element (content + padding + border)
+    const borderBox: Area = getArea(targetRef.getBoundingClientRect());
 
     const dimension: DraggableDimension = getDraggableDimension({
       descriptor,
-      paddingBox,
+      borderBox,
       margin,
       tagName,
       display,

--- a/src/view/draggable/draggable.jsx
+++ b/src/view/draggable/draggable.jsx
@@ -203,7 +203,7 @@ export default class Draggable extends Component<Props> {
     (dimension: DraggableDimension,
       isDropAnimating: boolean,
       movementStyle: MovementStyle): DraggingStyle => {
-      const { width, height, top, left } = dimension.client.paddingBox;
+      const { width, height, top, left } = dimension.client.borderBox;
       // For an explanation of properties see `draggable-types`.
       const style: DraggingStyle = {
         position: 'fixed',

--- a/src/view/droppable-dimension-publisher/droppable-dimension-publisher.jsx
+++ b/src/view/droppable-dimension-publisher/droppable-dimension-publisher.jsx
@@ -254,8 +254,6 @@ export default class DroppableDimensionPublisher extends Component<Props> {
       throw new Error('Cannot get dimension for unpublished droppable');
     }
 
-    // side effect - grabbing it for scroll listening so we know it is the same node
-    this.closestScrollable = getClosestScrollable(targetRef);
     const style: Object = window.getComputedStyle(targetRef);
 
     // keeping it simple and always using the margin of the droppable
@@ -281,6 +279,9 @@ export default class DroppableDimensionPublisher extends Component<Props> {
 
     // getBoundingClientRect always returns the borderBox
     const borderBox: Area = getArea(targetRef.getBoundingClientRect());
+
+    // side effect - grabbing it for scroll listening so we know it is the same node
+    this.closestScrollable = getClosestScrollable(targetRef);
 
     // The droppable's own bounds should be treated as the
     // container bounds in the following situations:

--- a/src/view/droppable-dimension-publisher/droppable-dimension-publisher.jsx
+++ b/src/view/droppable-dimension-publisher/droppable-dimension-publisher.jsx
@@ -272,8 +272,15 @@ export default class DroppableDimensionPublisher extends Component<Props> {
       bottom: parseInt(style.paddingBottom, 10),
       left: parseInt(style.paddingLeft, 10),
     };
+    const border: Spacing = {
+      top: parseInt(style.borderTopWidth, 10),
+      right: parseInt(style.borderRightWidth, 10),
+      bottom: parseInt(style.borderBottomWidth, 10),
+      left: parseInt(style.borderLeftWidth, 10),
+    };
 
-    const paddingBox: Area = getArea(targetRef.getBoundingClientRect());
+    // getBoundingClientRect always returns the borderBox
+    const borderBox: Area = getArea(targetRef.getBoundingClientRect());
 
     // The droppable's own bounds should be treated as the
     // container bounds in the following situations:
@@ -288,13 +295,13 @@ export default class DroppableDimensionPublisher extends Component<Props> {
         return null;
       }
 
-      const framePaddingBox: Area = getArea(closestScrollable.getBoundingClientRect());
+      const frameBorderBox: Area = getArea(closestScrollable.getBoundingClientRect());
       const scroll: Position = this.getClosestScroll();
       const scrollWidth: number = closestScrollable.scrollWidth;
       const scrollHeight: number = closestScrollable.scrollHeight;
 
       return {
-        framePaddingBox,
+        frameBorderBox,
         scrollWidth,
         scrollHeight,
         scroll,
@@ -305,7 +312,8 @@ export default class DroppableDimensionPublisher extends Component<Props> {
     const dimension: DroppableDimension = getDroppableDimension({
       descriptor,
       direction,
-      paddingBox,
+      borderBox,
+      border,
       closest,
       margin,
       padding,

--- a/src/view/placeholder/placeholder.jsx
+++ b/src/view/placeholder/placeholder.jsx
@@ -30,6 +30,7 @@ export default class Placeholder extends PureComponent<Props> {
       // Avoiding the collapsing or growing of this element when pushed by flex child siblings.
       // We have already taken a snapshot the current dimensions we do not want this element
       // to recalculate its dimensions
+      // It is okay for these properties to be applied on elements that are not flex children
       flexShrink: '0',
       flexGrow: '0',
     };

--- a/src/view/placeholder/placeholder.jsx
+++ b/src/view/placeholder/placeholder.jsx
@@ -11,7 +11,7 @@ export default class Placeholder extends PureComponent<Props> {
     // We apply the margin separately to maintain margin collapsing
     // behavior of the original element
     const placeholder: PlaceholderType = this.props.placeholder;
-    const { paddingBox, margin, display, tagName } = placeholder;
+    const { borderBox, margin, display, tagName } = placeholder;
 
     const style = {
       display,
@@ -19,13 +19,14 @@ export default class Placeholder extends PureComponent<Props> {
       // to the correct box-sizing
       // box-sizing: content-box => width includes padding
       // box-sizing: border-box => width does not include padding
-      width: paddingBox.width,
-      height: paddingBox.height,
+      width: borderBox.width,
+      height: borderBox.height,
       marginTop: margin.top,
       marginLeft: margin.left,
       marginBottom: margin.bottom,
       marginRight: margin.right,
       pointerEvents: 'none',
+      // Because we are applying the borderBox sizing directly we want to use this box-sizing
       boxSizing: 'border-box',
       // Avoiding the collapsing or growing of this element when pushed by flex child siblings.
       // We have already taken a snapshot the current dimensions we do not want this element

--- a/src/view/placeholder/placeholder.jsx
+++ b/src/view/placeholder/placeholder.jsx
@@ -15,10 +15,8 @@ export default class Placeholder extends PureComponent<Props> {
 
     const style = {
       display,
-      // These width and height properties will already be adjusted
-      // to the correct box-sizing
-      // box-sizing: content-box => width includes padding
-      // box-sizing: border-box => width does not include padding
+      // These are the computed borderBox width and height properties
+      // at the time of a drag start
       width: borderBox.width,
       height: borderBox.height,
       marginTop: margin.top,
@@ -26,7 +24,7 @@ export default class Placeholder extends PureComponent<Props> {
       marginBottom: margin.bottom,
       marginRight: margin.right,
       pointerEvents: 'none',
-      // Because we are applying the borderBox sizing directly we want to use this box-sizing
+      // Because we are not applying padding or borders we can use any box sizing we like
       boxSizing: 'border-box',
       // Avoiding the collapsing or growing of this element when pushed by flex child siblings.
       // We have already taken a snapshot the current dimensions we do not want this element

--- a/src/view/placeholder/placeholder.jsx
+++ b/src/view/placeholder/placeholder.jsx
@@ -14,6 +14,11 @@ export default class Placeholder extends PureComponent<Props> {
     const { paddingBox, margin, display, tagName } = placeholder;
 
     const style = {
+      display,
+      // These width and height properties will already be adjusted
+      // to the correct box-sizing
+      // box-sizing: content-box => width includes padding
+      // box-sizing: border-box => width does not include padding
       width: paddingBox.width,
       height: paddingBox.height,
       marginTop: margin.top,
@@ -22,7 +27,11 @@ export default class Placeholder extends PureComponent<Props> {
       marginRight: margin.right,
       pointerEvents: 'none',
       boxSizing: 'border-box',
-      display,
+      // Avoiding the collapsing or growing of this element when pushed by flex child siblings.
+      // We have already taken a snapshot the current dimensions we do not want this element
+      // to recalculate its dimensions
+      flexShrink: '0',
+      flexGrow: '0',
     };
 
     return React.createElement(tagName, { style });

--- a/src/view/placeholder/placeholder.jsx
+++ b/src/view/placeholder/placeholder.jsx
@@ -8,8 +8,6 @@ type Props = {|
 
 export default class Placeholder extends PureComponent<Props> {
   render() {
-    // We apply the margin separately to maintain margin collapsing
-    // behavior of the original element
     const placeholder: PlaceholderType = this.props.placeholder;
     const { borderBox, margin, display, tagName } = placeholder;
 
@@ -17,14 +15,17 @@ export default class Placeholder extends PureComponent<Props> {
       display,
       // These are the computed borderBox width and height properties
       // at the time of a drag start
+      // borderBox = content + padding + border
       width: borderBox.width,
       height: borderBox.height,
+      // We apply the margin separately to maintain margin collapsing
+      // behavior of the original element
       marginTop: margin.top,
       marginLeft: margin.left,
       marginBottom: margin.bottom,
       marginRight: margin.right,
-      pointerEvents: 'none',
       // Because we are not applying padding or borders we can use any box sizing we like
+      // Using border-box to be super explicit
       boxSizing: 'border-box',
       // Avoiding the collapsing or growing of this element when pushed by flex child siblings.
       // We have already taken a snapshot the current dimensions we do not want this element
@@ -32,6 +33,9 @@ export default class Placeholder extends PureComponent<Props> {
       // It is okay for these properties to be applied on elements that are not flex children
       flexShrink: '0',
       flexGrow: '0',
+      // Just a little performance optimisation: avoiding the browser needing
+      // to worry about pointer events for this element
+      pointerEvents: 'none',
     };
 
     return React.createElement(tagName, { style });

--- a/src/view/placeholder/placeholder.jsx
+++ b/src/view/placeholder/placeholder.jsx
@@ -18,15 +18,15 @@ export default class Placeholder extends PureComponent<Props> {
       // borderBox = content + padding + border
       width: borderBox.width,
       height: borderBox.height,
+      // We want to be sure that if any border or padding is applied to the element
+      // then it should not change the width and height of it
+      boxSizing: 'border-box',
       // We apply the margin separately to maintain margin collapsing
       // behavior of the original element
       marginTop: margin.top,
       marginLeft: margin.left,
       marginBottom: margin.bottom,
       marginRight: margin.right,
-      // Because we are not applying padding or borders we can use any box sizing we like
-      // Using border-box to be super explicit
-      boxSizing: 'border-box',
       // Avoiding the collapsing or growing of this element when pushed by flex child siblings.
       // We have already taken a snapshot the current dimensions we do not want this element
       // to recalculate its dimensions

--- a/stories/src/table/with-fixed-columns.jsx
+++ b/stories/src/table/with-fixed-columns.jsx
@@ -1,6 +1,5 @@
 // @flow
 import React, { Component, Fragment } from 'react';
-import type { Node } from 'react';
 import styled from 'styled-components';
 import { DragDropContext, Droppable, Draggable } from '../../../src';
 import reorder from '../reorder';
@@ -94,6 +93,7 @@ type AppState = {|
   layout: 'fixed' | 'auto',
 |}
 export default class TableApp extends Component<AppProps, AppState> {
+  // eslint-disable-next-line react/sort-comp
   tableRef: ?HTMLElement
 
   state: AppState = {
@@ -148,6 +148,7 @@ export default class TableApp extends Component<AppProps, AppState> {
       }
     })();
 
+    // eslint-disable-next-line no-console
     console.log('was copied?', wasCopied);
 
     // clear selection

--- a/test/browser/simple-vertical-list-with-keyboard.spec.js
+++ b/test/browser/simple-vertical-list-with-keyboard.spec.js
@@ -6,7 +6,7 @@ const puppeteer = require('puppeteer');
 
 const urlSingleList: string = 'http://localhost:9002/iframe.html?selectedKind=single%20vertical%20list&selectedStory=basic';
 
-const timeout: number = 30000;
+const timeout: number = 60000;
 
 type Selector = string;
 

--- a/test/unit/integration/lift-action-and-dimension-marshal.spec.js
+++ b/test/unit/integration/lift-action-and-dimension-marshal.spec.js
@@ -151,8 +151,8 @@ describe('lifting and the dimension marshal', () => {
 
         // perform a drag - moving inHome1 from index 0 to index 1
         const initial: InitialDragPositions = {
-          selection: preset.inHome1.client.paddingBox.center,
-          center: preset.inHome1.client.paddingBox.center,
+          selection: preset.inHome1.client.borderBox.center,
+          center: preset.inHome1.client.borderBox.center,
         };
         lift(
           preset.inHome1.descriptor.id,
@@ -202,8 +202,8 @@ describe('lifting and the dimension marshal', () => {
 
         // before drop animation is finished we start another drag
         const forSecondDrag: InitialDragPositions = {
-          selection: preset.inHome3.client.paddingBox.center,
-          center: preset.inHome3.client.paddingBox.center,
+          selection: preset.inHome3.client.borderBox.center,
+          center: preset.inHome3.client.borderBox.center,
         };
         lift(
           preset.inHome3.descriptor.id,

--- a/test/unit/state/auto-scroll/can-scroll.spec.js
+++ b/test/unit/state/auto-scroll/can-scroll.spec.js
@@ -32,7 +32,7 @@ const scrollable: DroppableDimension = getDroppableDimension({
     id: 'drop-1',
     type: 'TYPE',
   },
-  paddingBox: getArea({
+  borderBox: getArea({
     top: 0,
     left: 0,
     right: 100,
@@ -40,7 +40,7 @@ const scrollable: DroppableDimension = getDroppableDimension({
     bottom: 200,
   }),
   closest: {
-    framePaddingBox: getArea({
+    frameBorderBox: getArea({
       top: 0,
       left: 0,
       right: 100,

--- a/test/unit/state/auto-scroll/fluid-scroller.spec.js
+++ b/test/unit/state/auto-scroll/fluid-scroller.spec.js
@@ -98,7 +98,7 @@ describe('fluid auto scrolling', () => {
         // stealing the home descriptor
         descriptor: preset.home.descriptor,
         direction: axis.direction,
-        paddingBox: getArea({
+        borderBox: getArea({
           top: 0,
           left: 0,
           // bigger than the frame
@@ -106,7 +106,7 @@ describe('fluid auto scrolling', () => {
           bottom: scrollableScrollSize.scrollHeight,
         }),
         closest: {
-          framePaddingBox: frame,
+          frameBorderBox: frame,
           scrollWidth: scrollableScrollSize.scrollWidth,
           scrollHeight: scrollableScrollSize.scrollHeight,
           scroll: origin,
@@ -279,7 +279,7 @@ describe('fluid auto scrolling', () => {
                 // after the last item
                 index: preset.inHomeList.length,
               },
-              paddingBox: expanded,
+              borderBox: expanded,
             });
             const selection: Position = onMaxBoundary;
             const custom: State = (() => {
@@ -477,7 +477,7 @@ describe('fluid auto scrolling', () => {
                 // after the last item
                 index: preset.inHomeList.length,
               },
-              paddingBox: expanded,
+              borderBox: expanded,
             });
             const selection: Position = onMaxBoundary;
             const custom: State = (() => {
@@ -618,7 +618,7 @@ describe('fluid auto scrolling', () => {
                   // after the last item
                   index: preset.inHomeList.length,
                 },
-                paddingBox: expanded,
+                borderBox: expanded,
               });
 
               const selection: Position = onMaxBoundaryOfBoth;
@@ -666,7 +666,7 @@ describe('fluid auto scrolling', () => {
                   // after the last item
                   index: preset.inHomeList.length,
                 },
-                paddingBox: expanded,
+                borderBox: expanded,
               });
 
               const selection: Position = onMaxBoundaryOfBoth;
@@ -714,7 +714,7 @@ describe('fluid auto scrolling', () => {
                   // after the last item
                   index: preset.inHomeList.length,
                 },
-                paddingBox: expanded,
+                borderBox: expanded,
               });
 
               const selection: Position = onMaxBoundaryOfBoth;
@@ -955,7 +955,7 @@ describe('fluid auto scrolling', () => {
                     // after the last item
                     index: preset.inHomeList.length,
                   },
-                  paddingBox: expanded,
+                  borderBox: expanded,
                 });
 
                 const selection: Position = onMaxBoundaryOfBoth;
@@ -1004,7 +1004,7 @@ describe('fluid auto scrolling', () => {
                     // after the last item
                     index: preset.inHomeList.length,
                   },
-                  paddingBox: expanded,
+                  borderBox: expanded,
                 });
 
                 const selection: Position = onMaxBoundaryOfBoth;
@@ -1053,7 +1053,7 @@ describe('fluid auto scrolling', () => {
                     // after the last item
                     index: preset.inHomeList.length,
                   },
-                  paddingBox: expanded,
+                  borderBox: expanded,
                 });
 
                 const selection: Position = onMaxBoundaryOfBoth;
@@ -1115,7 +1115,7 @@ describe('fluid auto scrolling', () => {
             };
             const placeholder: Position = patch(
               axis.line,
-              preset.inHome1.placeholder.paddingBox[axis.size],
+              preset.inHome1.placeholder.borderBox[axis.size],
             );
             const overForeign: DragImpact = {
               movement: noMovement,
@@ -1355,7 +1355,7 @@ describe('fluid auto scrolling', () => {
                 // after the last item
                 index: preset.inHomeList.length,
               },
-              paddingBox: expanded,
+              borderBox: expanded,
             });
             const selection: Position = onMaxBoundary;
             const custom: State = (() => {
@@ -1505,14 +1505,14 @@ describe('fluid auto scrolling', () => {
             // stealing the home descriptor
             descriptor: preset.home.descriptor,
             direction: axis.direction,
-            paddingBox: getArea({
+            borderBox: getArea({
               top: 0,
               left: 0,
               right: 100,
               bottom: 100,
             }),
             closest: {
-              framePaddingBox: getArea({
+              frameBorderBox: getArea({
                 top: 0,
                 left: 0,
                 right: 5000,
@@ -1597,7 +1597,7 @@ describe('fluid auto scrolling', () => {
             id: 'scrollable that is similiar to the viewport',
             type: 'TYPE',
           },
-          paddingBox: getArea({
+          borderBox: getArea({
             top: 0,
             left: 0,
             // bigger than the frame
@@ -1605,7 +1605,7 @@ describe('fluid auto scrolling', () => {
             bottom: windowScrollSize.scrollHeight,
           }),
           closest: {
-            framePaddingBox: scrollableViewport.subject,
+            frameBorderBox: scrollableViewport.subject,
             scrollWidth: windowScrollSize.scrollWidth,
             scrollHeight: windowScrollSize.scrollHeight,
             scroll: origin,

--- a/test/unit/state/auto-scroll/jump-scroller.spec.js
+++ b/test/unit/state/auto-scroll/jump-scroller.spec.js
@@ -209,7 +209,7 @@ describe('jump auto scrolling', () => {
           // stealing the home descriptor so that the dragging item will
           // be within in
           descriptor: preset.home.descriptor,
-          paddingBox: getArea({
+          borderBox: getArea({
             top: 0,
             left: 0,
             // bigger than the frame
@@ -217,7 +217,7 @@ describe('jump auto scrolling', () => {
             bottom: scrollableScrollSize.scrollHeight,
           }),
           closest: {
-            framePaddingBox: frame,
+            frameBorderBox: frame,
             scrollWidth: scrollableScrollSize.scrollWidth,
             scrollHeight: scrollableScrollSize.scrollHeight,
             scroll: { x: 0, y: 0 },

--- a/test/unit/state/dimension.spec.js
+++ b/test/unit/state/dimension.spec.js
@@ -32,7 +32,7 @@ const draggableDescriptor: DraggableDescriptor = {
   index: 0,
 };
 
-const paddingBox: Area = getArea({
+const borderBox: Area = getArea({
   top: 10,
   right: 110,
   bottom: 90,
@@ -54,7 +54,7 @@ describe('dimension', () => {
   describe('draggable dimension', () => {
     const dimension: DraggableDimension = getDraggableDimension({
       descriptor: draggableDescriptor,
-      paddingBox,
+      borderBox,
       margin,
       windowScroll,
     });
@@ -62,21 +62,21 @@ describe('dimension', () => {
     describe('without scroll (client)', () => {
       it('should return a portion that does not account for margins', () => {
         const area: Area = getArea({
-          top: paddingBox.top,
-          right: paddingBox.right,
-          bottom: paddingBox.bottom,
-          left: paddingBox.left,
+          top: borderBox.top,
+          right: borderBox.right,
+          bottom: borderBox.bottom,
+          left: borderBox.left,
         });
 
-        expect(dimension.client.paddingBox).toEqual(area);
+        expect(dimension.client.borderBox).toEqual(area);
       });
 
       it('should return a portion that considers margins', () => {
         const area: Area = getArea({
-          top: paddingBox.top - margin.top,
-          right: paddingBox.right + margin.right,
-          bottom: paddingBox.bottom + margin.bottom,
-          left: paddingBox.left - margin.left,
+          top: borderBox.top - margin.top,
+          right: borderBox.right + margin.right,
+          bottom: borderBox.bottom + margin.bottom,
+          left: borderBox.left - margin.left,
         });
 
         expect(dimension.client.marginBox).toEqual(area);
@@ -86,21 +86,21 @@ describe('dimension', () => {
     describe('with scroll (page)', () => {
       it('should return a portion that does not account for margins', () => {
         const area: Area = getArea({
-          top: paddingBox.top + windowScroll.y,
-          right: paddingBox.right + windowScroll.x,
-          bottom: paddingBox.bottom + windowScroll.y,
-          left: paddingBox.left + windowScroll.x,
+          top: borderBox.top + windowScroll.y,
+          right: borderBox.right + windowScroll.x,
+          bottom: borderBox.bottom + windowScroll.y,
+          left: borderBox.left + windowScroll.x,
         });
 
-        expect(dimension.page.paddingBox).toEqual(area);
+        expect(dimension.page.borderBox).toEqual(area);
       });
 
       it('should return a portion that considers margins', () => {
         const area: Area = getArea({
-          top: (paddingBox.top - margin.top) + windowScroll.y,
-          right: paddingBox.right + margin.right + windowScroll.x,
-          bottom: paddingBox.bottom + margin.bottom + windowScroll.y,
-          left: (paddingBox.left - margin.left) + windowScroll.x,
+          top: (borderBox.top - margin.top) + windowScroll.y,
+          right: borderBox.right + margin.right + windowScroll.x,
+          bottom: borderBox.bottom + margin.bottom + windowScroll.y,
+          left: (borderBox.left - margin.left) + windowScroll.x,
         });
 
         expect(dimension.page.marginBox).toEqual(area);
@@ -111,7 +111,7 @@ describe('dimension', () => {
   describe('droppable dimension', () => {
     const dimension: DroppableDimension = getDroppableDimension({
       descriptor: droppableDescriptor,
-      paddingBox,
+      borderBox,
       margin,
       padding,
       windowScroll,
@@ -120,20 +120,20 @@ describe('dimension', () => {
     it('should apply the correct axis', () => {
       const withDefault: DroppableDimension = getDroppableDimension({
         descriptor: droppableDescriptor,
-        paddingBox,
+        borderBox,
         margin,
         windowScroll,
       });
       const withVertical: DroppableDimension = getDroppableDimension({
         descriptor: droppableDescriptor,
-        paddingBox,
+        borderBox,
         margin,
         windowScroll,
         direction: 'vertical',
       });
       const withHorizontal: DroppableDimension = getDroppableDimension({
         descriptor: droppableDescriptor,
-        paddingBox,
+        borderBox,
         margin,
         windowScroll,
         direction: 'horizontal',
@@ -150,21 +150,21 @@ describe('dimension', () => {
     describe('without window scroll (client)', () => {
       it('should return a portion that does not consider margins', () => {
         const area: Area = getArea({
-          top: paddingBox.top,
-          right: paddingBox.right,
-          bottom: paddingBox.bottom,
-          left: paddingBox.left,
+          top: borderBox.top,
+          right: borderBox.right,
+          bottom: borderBox.bottom,
+          left: borderBox.left,
         });
 
-        expect(dimension.client.paddingBox).toEqual(area);
+        expect(dimension.client.borderBox).toEqual(area);
       });
 
       it('should return a portion that does consider margins', () => {
         const area: Area = getArea({
-          top: paddingBox.top - margin.top,
-          left: paddingBox.left - margin.left,
-          bottom: paddingBox.bottom + margin.bottom,
-          right: paddingBox.right + margin.right,
+          top: borderBox.top - margin.top,
+          left: borderBox.left - margin.left,
+          bottom: borderBox.bottom + margin.bottom,
+          right: borderBox.right + margin.right,
         });
 
         expect(dimension.client.marginBox).toEqual(area);
@@ -172,10 +172,10 @@ describe('dimension', () => {
 
       it('should return a portion that removes the padding', () => {
         const area: Area = getArea({
-          top: paddingBox.top + padding.top,
-          left: paddingBox.left + padding.left,
-          bottom: paddingBox.bottom - padding.bottom,
-          right: paddingBox.right - padding.right,
+          top: borderBox.top + padding.top,
+          left: borderBox.left + padding.left,
+          bottom: borderBox.bottom - padding.bottom,
+          right: borderBox.right - padding.right,
         });
 
         expect(dimension.client.contentBox).toEqual(area);
@@ -185,21 +185,21 @@ describe('dimension', () => {
     describe('with window scroll (page)', () => {
       it('should return a portion that does not consider margins', () => {
         const area: Area = getArea({
-          top: paddingBox.top + windowScroll.y,
-          left: paddingBox.left + windowScroll.x,
-          bottom: paddingBox.bottom + windowScroll.y,
-          right: paddingBox.right + windowScroll.x,
+          top: borderBox.top + windowScroll.y,
+          left: borderBox.left + windowScroll.x,
+          bottom: borderBox.bottom + windowScroll.y,
+          right: borderBox.right + windowScroll.x,
         });
 
-        expect(dimension.page.paddingBox).toEqual(area);
+        expect(dimension.page.borderBox).toEqual(area);
       });
 
       it('should return a portion that does consider margins', () => {
         const area: Area = getArea({
-          top: (paddingBox.top + windowScroll.y) - margin.top,
-          left: (paddingBox.left + windowScroll.x) - margin.left,
-          bottom: paddingBox.bottom + windowScroll.y + margin.bottom,
-          right: paddingBox.right + windowScroll.x + margin.right,
+          top: (borderBox.top + windowScroll.y) - margin.top,
+          left: (borderBox.left + windowScroll.x) - margin.left,
+          bottom: borderBox.bottom + windowScroll.y + margin.bottom,
+          right: borderBox.right + windowScroll.x + margin.right,
         });
 
         expect(dimension.page.marginBox).toEqual(area);
@@ -208,11 +208,11 @@ describe('dimension', () => {
       it('should return a portion that removes padding', () => {
         const area: Area = getArea({
           // pushing forward
-          top: (paddingBox.top + windowScroll.y) + padding.top,
-          left: (paddingBox.left + windowScroll.x) + padding.left,
+          top: (borderBox.top + windowScroll.y) + padding.top,
+          left: (borderBox.left + windowScroll.x) + padding.left,
           // pulling backward
-          bottom: (paddingBox.bottom + windowScroll.y) - padding.bottom,
-          right: (paddingBox.right + windowScroll.x) - padding.right,
+          bottom: (borderBox.bottom + windowScroll.y) - padding.bottom,
+          right: (borderBox.right + windowScroll.x) - padding.right,
         });
 
         expect(dimension.page.contentBox).toEqual(area);
@@ -222,13 +222,13 @@ describe('dimension', () => {
     describe('closest scrollable', () => {
       describe('basic info about the scrollable', () => {
         // eslint-disable-next-line no-shadow
-        const paddingBox: Area = getArea({
+        const borderBox: Area = getArea({
           top: 0,
           right: 300,
           bottom: 300,
           left: 0,
         });
-        const framePaddingBox: Area = getArea({
+        const frameBorderBox: Area = getArea({
           top: 0,
           right: 100,
           bottom: 100,
@@ -237,10 +237,10 @@ describe('dimension', () => {
 
         const withScrollable: DroppableDimension = getDroppableDimension({
           descriptor: droppableDescriptor,
-          paddingBox,
+          borderBox,
           windowScroll,
           closest: {
-            framePaddingBox,
+            frameBorderBox,
             scrollWidth: 500,
             scrollHeight: 500,
             scroll: { x: 10, y: 10 },
@@ -251,7 +251,7 @@ describe('dimension', () => {
         it('should not have a closest scrollable if there is no closest scrollable', () => {
           const noClosestScrollable: DroppableDimension = getDroppableDimension({
             descriptor: droppableDescriptor,
-            paddingBox,
+            borderBox,
           });
 
           expect(noClosestScrollable.viewport.closestScrollable).toBe(null);
@@ -261,7 +261,7 @@ describe('dimension', () => {
 
         it('should offset the frame client by the window scroll', () => {
           expect(getClosestScrollable(withScrollable).frame).toEqual(
-            getArea(offsetByPosition(framePaddingBox, windowScroll))
+            getArea(offsetByPosition(frameBorderBox, windowScroll))
           );
         });
 
@@ -271,7 +271,7 @@ describe('dimension', () => {
       });
 
       describe('frame clipping', () => {
-        const framePaddingBox = getArea({
+        const frameBorderBox = getArea({
           top: 0,
           left: 0,
           right: 100,
@@ -279,9 +279,9 @@ describe('dimension', () => {
         });
         const getWithClient = (subject: Area): DroppableDimension => getDroppableDimension({
           descriptor: droppableDescriptor,
-          paddingBox: subject,
+          borderBox: subject,
           closest: {
-            framePaddingBox,
+            frameBorderBox,
             scrollWidth: 300,
             scrollHeight: 300,
             scroll: origin,
@@ -292,10 +292,10 @@ describe('dimension', () => {
         it('should not clip the frame if requested not to', () => {
           const withoutClipping: DroppableDimension = getDroppableDimension({
             descriptor: droppableDescriptor,
-            paddingBox,
+            borderBox,
             windowScroll,
             closest: {
-              framePaddingBox,
+              frameBorderBox,
               scrollWidth: 300,
               scrollHeight: 300,
               scroll: origin,
@@ -321,7 +321,7 @@ describe('dimension', () => {
 
             const droppable: DroppableDimension = getWithClient(subject);
 
-            expect(droppable.viewport.clipped).toEqual(framePaddingBox);
+            expect(droppable.viewport.clipped).toEqual(frameBorderBox);
           });
         });
 
@@ -346,19 +346,19 @@ describe('dimension', () => {
             // each of these subjects bleeds out past the frame in one direction
             const subjects: Area[] = [
               getArea({
-                ...framePaddingBox,
+                ...frameBorderBox,
                 top: -10,
               }),
               getArea({
-                ...framePaddingBox,
+                ...frameBorderBox,
                 right: 110,
               }),
               getArea({
-                ...framePaddingBox,
+                ...frameBorderBox,
                 bottom: 110,
               }),
               getArea({
-                ...framePaddingBox,
+                ...frameBorderBox,
                 left: -10,
               }),
             ];
@@ -366,7 +366,7 @@ describe('dimension', () => {
             subjects.forEach((subject: Area) => {
               const droppable: DroppableDimension = getWithClient(subject);
 
-              expect(droppable.viewport.clipped).toEqual(framePaddingBox);
+              expect(droppable.viewport.clipped).toEqual(frameBorderBox);
             });
           });
         });
@@ -387,7 +387,7 @@ describe('dimension', () => {
         right: scrollSize.scrollWidth,
         left: 0,
       });
-      const framePaddingBox = getArea({
+      const frameBorderBox = getArea({
         // only viewing top 100px
         bottom: 100,
         // unchanged
@@ -398,9 +398,9 @@ describe('dimension', () => {
       const frameScroll: Position = { x: 0, y: 0 };
       const droppable: DroppableDimension = getDroppableDimension({
         descriptor: droppableDescriptor,
-        paddingBox: subject,
+        borderBox: subject,
         closest: {
-          framePaddingBox,
+          frameBorderBox,
           scroll: frameScroll,
           scrollWidth: scrollSize.scrollWidth,
           scrollHeight: scrollSize.scrollHeight,
@@ -411,9 +411,9 @@ describe('dimension', () => {
       const closestScrollable: ClosestScrollable = getClosestScrollable(droppable);
 
       // original frame
-      expect(closestScrollable.frame).toEqual(framePaddingBox);
+      expect(closestScrollable.frame).toEqual(frameBorderBox);
       // subject is currently clipped by the frame
-      expect(droppable.viewport.clipped).toEqual(framePaddingBox);
+      expect(droppable.viewport.clipped).toEqual(frameBorderBox);
 
       // scrolling down
       const newScroll: Position = { x: 0, y: 100 };
@@ -421,7 +421,7 @@ describe('dimension', () => {
       const updatedClosest: ClosestScrollable = getClosestScrollable(updated);
 
       // unchanged frame client
-      expect(updatedClosest.frame).toEqual(framePaddingBox);
+      expect(updatedClosest.frame).toEqual(frameBorderBox);
 
       // updated scroll info
       expect(updatedClosest.scroll).toEqual({
@@ -434,8 +434,8 @@ describe('dimension', () => {
         max: getMaxScroll({
           scrollWidth: scrollSize.scrollWidth,
           scrollHeight: scrollSize.scrollHeight,
-          width: framePaddingBox.width,
-          height: framePaddingBox.height,
+          width: frameBorderBox.width,
+          height: frameBorderBox.height,
         }),
       });
 
@@ -454,14 +454,14 @@ describe('dimension', () => {
       // this is to allow for scrolling into a foreign placeholder
       const scrollable: DroppableDimension = getDroppableDimension({
         descriptor: droppableDescriptor,
-        paddingBox: getArea({
+        borderBox: getArea({
           top: 0,
           left: 0,
           right: 200,
           bottom: 200,
         }),
         closest: {
-          framePaddingBox: getArea({
+          frameBorderBox: getArea({
             top: 0,
             left: 0,
             right: 100,

--- a/test/unit/state/get-displacement.spec.js
+++ b/test/unit/state/get-displacement.spec.js
@@ -34,7 +34,7 @@ const droppable: DroppableDimension = getDroppableDimension({
     id: 'drop',
     type: 'TYPE',
   },
-  paddingBox: subject,
+  borderBox: subject,
 });
 
 const inViewport: DraggableDimension = getDraggableDimension({
@@ -43,7 +43,7 @@ const inViewport: DraggableDimension = getDraggableDimension({
     droppableId: droppable.descriptor.id,
     index: 0,
   },
-  paddingBox: getArea({
+  borderBox: getArea({
     top: 0,
     left: 0,
     right: 200,
@@ -58,7 +58,7 @@ const notInViewport: DraggableDimension = getDraggableDimension({
     index: 1,
   },
   // outside of viewport but within droppable
-  paddingBox: getArea({
+  borderBox: getArea({
     top: 810,
     left: 0,
     right: 200,

--- a/test/unit/state/get-drag-impact.spec.js
+++ b/test/unit/state/get-drag-impact.spec.js
@@ -75,7 +75,7 @@ describe('get drag impact', () => {
             [disabled.descriptor.id]: disabled,
           };
           // choosing the center of inHome2 which should have an impact
-          const pageCenter: Position = inHome2.page.paddingBox.center;
+          const pageCenter: Position = inHome2.page.borderBox.center;
 
           const impact: DragImpact = getDragImpact({
             pageCenter,
@@ -92,7 +92,7 @@ describe('get drag impact', () => {
         // moving inHome1 no where
         describe('moving over original position', () => {
           it('should return no impact', () => {
-            const pageCenter: Position = inHome1.page.paddingBox.center;
+            const pageCenter: Position = inHome1.page.borderBox.center;
             const expected: DragImpact = {
               movement: {
                 displaced: [],
@@ -125,9 +125,9 @@ describe('get drag impact', () => {
             const pageCenter: Position = patch(
               axis.line,
               // up to the line but not over it
-              inHome2.page.paddingBox[axis.start],
+              inHome2.page.borderBox[axis.start],
               // no movement on cross axis
-              inHome1.page.paddingBox.center[axis.crossAxisLine],
+              inHome1.page.borderBox.center[axis.crossAxisLine],
             );
             const expected: DragImpact = {
               movement: {
@@ -159,9 +159,9 @@ describe('get drag impact', () => {
         describe('moving beyond start position', () => {
           const pageCenter: Position = patch(
             axis.line,
-            inHome4.page.paddingBox[axis.start] + 1,
+            inHome4.page.borderBox[axis.start] + 1,
             // no change
-            inHome2.page.paddingBox.center[axis.crossAxisLine],
+            inHome2.page.borderBox.center[axis.crossAxisLine],
           );
           const expected: DragImpact = {
             movement: {
@@ -206,9 +206,9 @@ describe('get drag impact', () => {
           it('should move into the correct position', () => {
             const pageCenter: Position = patch(
               axis.line,
-              inHome1.page.paddingBox[axis.end] - 1,
+              inHome1.page.borderBox[axis.end] - 1,
               // no change
-              inHome3.page.paddingBox.center[axis.crossAxisLine],
+              inHome3.page.borderBox.center[axis.crossAxisLine],
             );
 
             const expected: DragImpact = {
@@ -263,11 +263,11 @@ describe('get drag impact', () => {
               // the middle of the target edge
               const startOfInHome2: Position = patch(
                 axis.line,
-                inHome2.page.paddingBox[axis.start],
-                inHome2.page.paddingBox.center[axis.crossAxisLine],
+                inHome2.page.borderBox[axis.start],
+                inHome2.page.borderBox.center[axis.crossAxisLine],
               );
               const distanceNeeded: Position = add(
-                subtract(startOfInHome2, inHome1.page.paddingBox.center),
+                subtract(startOfInHome2, inHome1.page.borderBox.center),
                 // need to move over the edge
                 patch(axis.line, 1),
               );
@@ -279,7 +279,7 @@ describe('get drag impact', () => {
                 [home.descriptor.id]: scrolledHome,
               };
               // no changes in current page center from original
-              const pageCenter: Position = inHome1.page.paddingBox.center;
+              const pageCenter: Position = inHome1.page.borderBox.center;
               const expected: DragImpact = {
                 movement: {
                   amount: patch(axis.line, inHome1.page.marginBox[axis.size]),
@@ -318,11 +318,11 @@ describe('get drag impact', () => {
               // the middle of the target edge
               const endOfInHome2: Position = patch(
                 axis.line,
-                inHome2.page.paddingBox[axis.end],
-                inHome2.page.paddingBox.center[axis.crossAxisLine],
+                inHome2.page.borderBox[axis.end],
+                inHome2.page.borderBox.center[axis.crossAxisLine],
               );
               const distanceNeeded: Position = add(
-                subtract(endOfInHome2, inHome4.page.paddingBox.center),
+                subtract(endOfInHome2, inHome4.page.borderBox.center),
                 // need to move over the edge
                 patch(axis.line, -1),
               );
@@ -334,7 +334,7 @@ describe('get drag impact', () => {
                 [home.descriptor.id]: scrolledHome,
               };
               // no changes in current page center from original
-              const pageCenter: Position = inHome4.page.paddingBox.center;
+              const pageCenter: Position = inHome4.page.borderBox.center;
               const expected: DragImpact = {
                 movement: {
                   amount: patch(axis.line, inHome4.page.marginBox[axis.size]),
@@ -383,7 +383,7 @@ describe('get drag impact', () => {
                 type: 'TYPE',
               },
               direction: axis.direction,
-              paddingBox: getArea({
+              borderBox: getArea({
                 [axis.crossAxisStart]: 0,
                 [axis.crossAxisEnd]: 100,
                 [axis.start]: 0,
@@ -391,7 +391,7 @@ describe('get drag impact', () => {
                 [axis.end]: 200,
               }),
               closest: {
-                framePaddingBox: getArea({
+                frameBorderBox: getArea({
                   [axis.crossAxisStart]: 0,
                   [axis.crossAxisEnd]: 100,
                   [axis.start]: 0,
@@ -410,7 +410,7 @@ describe('get drag impact', () => {
                 droppableId: droppable.descriptor.id,
                 index: 0,
               },
-              paddingBox: getArea({
+              borderBox: getArea({
                 [axis.crossAxisStart]: 0,
                 [axis.crossAxisEnd]: 100,
                 [axis.start]: 0,
@@ -423,7 +423,7 @@ describe('get drag impact', () => {
                 droppableId: droppable.descriptor.id,
                 index: 1,
               },
-              paddingBox: getArea({
+              borderBox: getArea({
                 [axis.crossAxisStart]: 0,
                 [axis.crossAxisEnd]: 100,
                 // inside the frame, but not in the visible area
@@ -437,7 +437,7 @@ describe('get drag impact', () => {
                 droppableId: droppable.descriptor.id,
                 index: 2,
               },
-              paddingBox: getArea({
+              borderBox: getArea({
                 [axis.crossAxisStart]: 0,
                 [axis.crossAxisEnd]: 100,
                 // inside the frame, but not in the visible area
@@ -501,7 +501,7 @@ describe('get drag impact', () => {
                 type: 'TYPE',
               },
               direction: axis.direction,
-              paddingBox: getArea({
+              borderBox: getArea({
                 [axis.crossAxisStart]: 0,
                 [axis.crossAxisEnd]: 100,
                 [axis.start]: 0,
@@ -514,7 +514,7 @@ describe('get drag impact', () => {
                 droppableId: droppable.descriptor.id,
                 index: 0,
               },
-              paddingBox: getArea({
+              borderBox: getArea({
                 [axis.crossAxisStart]: 0,
                 [axis.crossAxisEnd]: 100,
                 [axis.start]: 0,
@@ -527,7 +527,7 @@ describe('get drag impact', () => {
                 droppableId: droppable.descriptor.id,
                 index: 1,
               },
-              paddingBox: getArea({
+              borderBox: getArea({
                 [axis.crossAxisStart]: 0,
                 [axis.crossAxisEnd]: 100,
                 // inside the droppable, but not in the visible area
@@ -541,7 +541,7 @@ describe('get drag impact', () => {
                 droppableId: droppable.descriptor.id,
                 index: 2,
               },
-              paddingBox: getArea({
+              borderBox: getArea({
                 [axis.crossAxisStart]: 0,
                 [axis.crossAxisEnd]: 100,
                 // inside the droppable, but not in the visible area
@@ -608,7 +608,7 @@ describe('get drag impact', () => {
             [foreign.descriptor.id]: disabled,
           };
           // choosing the center of inForeign1 which should have an impact
-          const pageCenter: Position = inForeign1.page.paddingBox.center;
+          const pageCenter: Position = inForeign1.page.borderBox.center;
 
           const impact: DragImpact = getDragImpact({
             pageCenter,
@@ -628,8 +628,8 @@ describe('get drag impact', () => {
             const pageCenter: Position = patch(
               axis.line,
               // just before the end of the dimension which is the cut off
-              inForeign1.page.paddingBox[axis.end] - 1,
-              inForeign1.page.paddingBox.center[axis.crossAxisLine],
+              inForeign1.page.borderBox[axis.end] - 1,
+              inForeign1.page.borderBox.center[axis.crossAxisLine],
             );
             const expected: DragImpact = {
               movement: {
@@ -686,8 +686,8 @@ describe('get drag impact', () => {
           it('should move everything after inHome2 forward', () => {
             const pageCenter: Position = patch(
               axis.line,
-              inForeign2.page.paddingBox[axis.end] - 1,
-              inForeign2.page.paddingBox.center[axis.crossAxisLine],
+              inForeign2.page.borderBox[axis.end] - 1,
+              inForeign2.page.borderBox.center[axis.crossAxisLine],
             );
             const expected: DragImpact = {
               movement: {
@@ -739,8 +739,8 @@ describe('get drag impact', () => {
           it('should not displace anything', () => {
             const pageCenter: Position = patch(
               axis.line,
-              inForeign4.page.paddingBox[axis.end],
-              inForeign4.page.paddingBox.center[axis.crossAxisLine],
+              inForeign4.page.borderBox[axis.end],
+              inForeign4.page.borderBox.center[axis.crossAxisLine],
             );
             const expected: DragImpact = {
               movement: {
@@ -774,7 +774,7 @@ describe('get drag impact', () => {
         describe('moving to an empty droppable', () => {
           it('should not displace anything an move into the first position', () => {
             // over the center of the empty droppable
-            const pageCenter: Position = emptyForeign.page.paddingBox.center;
+            const pageCenter: Position = emptyForeign.page.borderBox.center;
             const expected: DragImpact = {
               movement: {
                 amount: patch(axis.line, inHome1.page.marginBox[axis.size]),
@@ -806,8 +806,8 @@ describe('get drag impact', () => {
         describe('home droppable is updated during a drag', () => {
           const pageCenter: Position = patch(
             axis.line,
-            inForeign2.page.paddingBox[axis.end] - 1,
-            inForeign2.page.paddingBox.center[axis.crossAxisLine],
+            inForeign2.page.borderBox[axis.end] - 1,
+            inForeign2.page.borderBox.center[axis.crossAxisLine],
           );
 
           it('should have no impact impact the destination (actual)', () => {
@@ -911,8 +911,8 @@ describe('get drag impact', () => {
 
           const pageCenter: Position = patch(
             axis.line,
-            inForeign2.page.paddingBox[axis.end] - 1,
-            inForeign2.page.paddingBox.center[axis.crossAxisLine],
+            inForeign2.page.borderBox[axis.end] - 1,
+            inForeign2.page.borderBox.center[axis.crossAxisLine],
           );
 
           it('should impact the destination (actual)', () => {
@@ -1011,7 +1011,7 @@ describe('get drag impact', () => {
                 type: 'TYPE',
               },
               direction: axis.direction,
-              paddingBox: getArea({
+              borderBox: getArea({
                 [axis.crossAxisStart]: 0,
                 [axis.crossAxisEnd]: 100,
                 [axis.start]: 0,
@@ -1024,7 +1024,7 @@ describe('get drag impact', () => {
                 droppableId: source.descriptor.id,
                 index: 0,
               },
-              paddingBox: getArea({
+              borderBox: getArea({
                 [axis.crossAxisStart]: 0,
                 [axis.crossAxisEnd]: 100,
                 [axis.start]: 0,
@@ -1041,7 +1041,7 @@ describe('get drag impact', () => {
                 type: 'TYPE',
               },
               direction: axis.direction,
-              paddingBox: getArea({
+              borderBox: getArea({
                 [axis.crossAxisStart]: foreignCrossAxisStart,
                 [axis.crossAxisEnd]: foreignCrossAxisEnd,
                 [axis.start]: 0,
@@ -1049,7 +1049,7 @@ describe('get drag impact', () => {
                 [axis.end]: 200,
               }),
               closest: {
-                framePaddingBox: getArea({
+                frameBorderBox: getArea({
                   [axis.crossAxisStart]: foreignCrossAxisStart,
                   [axis.crossAxisEnd]: foreignCrossAxisEnd,
                   [axis.start]: 0,
@@ -1068,7 +1068,7 @@ describe('get drag impact', () => {
                 droppableId: destination.descriptor.id,
                 index: 0,
               },
-              paddingBox: getArea({
+              borderBox: getArea({
                 [axis.crossAxisStart]: foreignCrossAxisStart,
                 [axis.crossAxisEnd]: foreignCrossAxisEnd,
                 [axis.start]: 0,
@@ -1081,7 +1081,7 @@ describe('get drag impact', () => {
                 droppableId: destination.descriptor.id,
                 index: 1,
               },
-              paddingBox: getArea({
+              borderBox: getArea({
                 [axis.crossAxisStart]: foreignCrossAxisStart,
                 [axis.crossAxisEnd]: foreignCrossAxisEnd,
                 // inside the droppable, but not in the visible area
@@ -1150,7 +1150,7 @@ describe('get drag impact', () => {
                 type: 'TYPE',
               },
               direction: axis.direction,
-              paddingBox: getArea({
+              borderBox: getArea({
                 [axis.crossAxisStart]: 0,
                 [axis.crossAxisEnd]: 100,
                 [axis.start]: 0,
@@ -1163,7 +1163,7 @@ describe('get drag impact', () => {
                 droppableId: source.descriptor.id,
                 index: 0,
               },
-              paddingBox: getArea({
+              borderBox: getArea({
                 [axis.crossAxisStart]: 0,
                 [axis.crossAxisEnd]: 100,
                 [axis.start]: 0,
@@ -1178,7 +1178,7 @@ describe('get drag impact', () => {
                 type: 'TYPE',
               },
               direction: axis.direction,
-              paddingBox: getArea({
+              borderBox: getArea({
                 [axis.crossAxisStart]: foreignCrossAxisStart,
                 [axis.crossAxisEnd]: foreignCrossAxisEnd,
                 [axis.start]: 0,
@@ -1192,7 +1192,7 @@ describe('get drag impact', () => {
                 droppableId: destination.descriptor.id,
                 index: 0,
               },
-              paddingBox: getArea({
+              borderBox: getArea({
                 [axis.crossAxisStart]: foreignCrossAxisStart,
                 [axis.crossAxisEnd]: foreignCrossAxisEnd,
                 [axis.start]: 0,
@@ -1205,7 +1205,7 @@ describe('get drag impact', () => {
                 droppableId: destination.descriptor.id,
                 index: 1,
               },
-              paddingBox: getArea({
+              borderBox: getArea({
                 [axis.crossAxisStart]: foreignCrossAxisStart,
                 [axis.crossAxisEnd]: foreignCrossAxisEnd,
                 // inside the droppable, but not in the visible area

--- a/test/unit/state/get-droppable-over.spec.js
+++ b/test/unit/state/get-droppable-over.spec.js
@@ -41,7 +41,7 @@ describe('get droppable over', () => {
       const draggable: DraggableDimension = preset.draggables[id];
 
       const result: ?DroppableId = getDroppableOver({
-        target: draggable.page.paddingBox.center,
+        target: draggable.page.borderBox.center,
         draggable,
         draggables: preset.draggables,
         droppables: preset.droppables,
@@ -53,7 +53,7 @@ describe('get droppable over', () => {
   });
 
   it('should ignore droppables that are disabled', () => {
-    const target: Position = preset.inHome1.page.paddingBox.center;
+    const target: Position = preset.inHome1.page.borderBox.center;
     const withDisabled: DroppableDimensionMap = {
       ...preset.droppables,
       [preset.home.descriptor.id]: disableDroppable(preset.home),
@@ -84,12 +84,12 @@ describe('get droppable over', () => {
         id: 'partially hidden subject',
         type: 'TYPE',
       },
-      paddingBox: getArea({
+      borderBox: getArea({
         top: 0, left: 0, right: 100, bottom: 100,
       }),
       closest: {
         // will partially hide the subject
-        framePaddingBox: getArea({
+        frameBorderBox: getArea({
           top: 0, left: 0, right: 50, bottom: 100,
         }),
         scrollHeight: 100,
@@ -104,7 +104,7 @@ describe('get droppable over', () => {
         droppableId: droppable.descriptor.type,
         index: 0,
       },
-      paddingBox: getArea({
+      borderBox: getArea({
         top: 0, left: 0, right: 50, bottom: 50,
       }),
     });
@@ -127,13 +127,13 @@ describe('get droppable over', () => {
         id: 'hidden subject',
         type: 'TYPE',
       },
-      paddingBox: getArea({
+      borderBox: getArea({
         top: 0, left: 0, right: 100, bottom: 100,
       }),
       closest: {
         // will partially hide the subject
         // will totally hide the subject
-        framePaddingBox: getArea({
+        frameBorderBox: getArea({
           top: 0, left: 101, right: 200, bottom: 100,
         }),
         scrollHeight: 100,
@@ -148,7 +148,7 @@ describe('get droppable over', () => {
         droppableId: droppable.descriptor.type,
         index: 0,
       },
-      paddingBox: getArea({
+      borderBox: getArea({
         top: 0, left: 0, right: 50, bottom: 50,
       }),
     });
@@ -179,7 +179,7 @@ describe('get droppable over', () => {
         id: 'home',
         type: 'TYPE',
       },
-      paddingBox: droppablePaddingBox,
+      borderBox: droppablePaddingBox,
       margin,
     });
     const inHome1: DraggableDimension = getDraggableDimension({
@@ -188,7 +188,7 @@ describe('get droppable over', () => {
         droppableId: home.descriptor.id,
         index: 0,
       },
-      paddingBox: getArea({
+      borderBox: getArea({
         top: 10,
         left: 10,
         right: 90,
@@ -203,7 +203,7 @@ describe('get droppable over', () => {
         droppableId: 'foreign',
         index: 0,
       },
-      paddingBox: getArea({
+      borderBox: getArea({
         // to the right of inHome1
         left: 200,
         right: 250,
@@ -360,7 +360,7 @@ describe('get droppable over', () => {
                 id: 'empty',
                 type: 'TYPE',
               },
-              paddingBox: getArea({
+              borderBox: getArea({
                 top: 1000,
                 left: 1000,
                 right: 2000,
@@ -409,7 +409,7 @@ describe('get droppable over', () => {
                 id: 'empty',
                 type: 'TYPE',
               },
-              paddingBox: getArea({
+              borderBox: getArea({
                 top: 1000,
                 left: 1000,
                 right: 2000,
@@ -464,7 +464,7 @@ describe('get droppable over', () => {
               id: 'has-a-scroll-parent',
               type: 'TYPE',
             },
-            paddingBox: getArea({
+            borderBox: getArea({
               top: 0,
               left: 0,
               right: 100,
@@ -472,7 +472,7 @@ describe('get droppable over', () => {
               bottom: 120,
             }),
             closest: {
-              framePaddingBox: getArea({
+              frameBorderBox: getArea({
                 top: 0,
                 left: 0,
                 right: 100,
@@ -515,7 +515,7 @@ describe('get droppable over', () => {
               id: 'my-custom-foreign',
               type: 'TYPE',
             },
-            paddingBox: getArea({
+            borderBox: getArea({
               top: 0,
               left: 0,
               right: 100,
@@ -523,7 +523,7 @@ describe('get droppable over', () => {
               bottom: inHome1.page.marginBox.height - 1,
             }),
             closest: {
-              framePaddingBox: getArea({
+              frameBorderBox: getArea({
                 top: 0,
                 left: 0,
                 right: 100,

--- a/test/unit/state/move-cross-axis/get-best-cross-axis-droppable.spec.js
+++ b/test/unit/state/move-cross-axis/get-best-cross-axis-droppable.spec.js
@@ -26,7 +26,7 @@ describe('get best cross axis droppable', () => {
           type: 'TYPE',
         },
         direction: axis.direction,
-        paddingBox: getArea({
+        borderBox: getArea({
           top: 0,
           left: 20,
           right: 30,
@@ -39,7 +39,7 @@ describe('get best cross axis droppable', () => {
           type: 'TYPE',
         },
         direction: axis.direction,
-        paddingBox: getArea({
+        borderBox: getArea({
           top: 0,
           left: 30,
           right: 40,
@@ -69,7 +69,7 @@ describe('get best cross axis droppable', () => {
           type: 'TYPE',
         },
         direction: axis.direction,
-        paddingBox: getArea({
+        borderBox: getArea({
           top: 0,
           left: 20,
           right: 30,
@@ -82,7 +82,7 @@ describe('get best cross axis droppable', () => {
           type: 'TYPE',
         },
         direction: axis.direction,
-        paddingBox: getArea({
+        borderBox: getArea({
           top: 0,
           left: 30,
           right: 40,
@@ -113,7 +113,7 @@ describe('get best cross axis droppable', () => {
           type: 'TYPE',
         },
         direction: axis.direction,
-        paddingBox: getArea({
+        borderBox: getArea({
           top: 0,
           left: 20,
           right: 30,
@@ -126,7 +126,7 @@ describe('get best cross axis droppable', () => {
           type: 'TYPE',
         },
         direction: axis.direction,
-        paddingBox: getArea({
+        borderBox: getArea({
           top: 0,
           left: 0,
           right: 10,
@@ -165,7 +165,7 @@ describe('get best cross axis droppable', () => {
           type: 'TYPE',
         },
         direction: axis.direction,
-        paddingBox: getArea({
+        borderBox: getArea({
           top: 0,
           left: 20,
           right: 30,
@@ -179,7 +179,7 @@ describe('get best cross axis droppable', () => {
         },
         isEnabled: false,
         direction: axis.direction,
-        paddingBox: getArea({
+        borderBox: getArea({
           top: 0,
           left: 30,
           right: 40,
@@ -209,7 +209,7 @@ describe('get best cross axis droppable', () => {
           type: 'TYPE',
         },
         direction: axis.direction,
-        paddingBox: getArea({
+        borderBox: getArea({
           top: 0,
           left: 20,
           right: 30,
@@ -222,7 +222,7 @@ describe('get best cross axis droppable', () => {
           type: 'TYPE',
         },
         direction: axis.direction,
-        paddingBox: getArea({
+        borderBox: getArea({
           left: 30,
           right: 40,
           top: viewport.subject.bottom + 1,
@@ -252,7 +252,7 @@ describe('get best cross axis droppable', () => {
           type: 'TYPE',
         },
         direction: axis.direction,
-        paddingBox: getArea({
+        borderBox: getArea({
           top: 0,
           left: 20,
           right: 30,
@@ -265,7 +265,7 @@ describe('get best cross axis droppable', () => {
           type: 'TYPE',
         },
         direction: axis.direction,
-        paddingBox: getArea({
+        borderBox: getArea({
           // top is below where the source ended
           top: 11,
           left: 30,
@@ -298,7 +298,7 @@ describe('get best cross axis droppable', () => {
           type: 'TYPE',
         },
         direction: axis.direction,
-        paddingBox: getArea({
+        borderBox: getArea({
           top: 0,
           left: 0,
           right: 20,
@@ -311,7 +311,7 @@ describe('get best cross axis droppable', () => {
           type: 'TYPE',
         },
         direction: axis.direction,
-        paddingBox: getArea({
+        borderBox: getArea({
           top: 20,
           left: 20,
           right: 40,
@@ -319,7 +319,7 @@ describe('get best cross axis droppable', () => {
           bottom: 80,
         }),
         closest: {
-          framePaddingBox: getArea({
+          frameBorderBox: getArea({
             // not the same top value as source
             top: 20,
             // shares the left edge with the source
@@ -339,7 +339,7 @@ describe('get best cross axis droppable', () => {
           type: 'TYPE',
         },
         direction: axis.direction,
-        paddingBox: getArea({
+        borderBox: getArea({
           // shares the bottom edge with sibling1
           top: 40,
           // shares the left edge with the source
@@ -455,7 +455,7 @@ describe('get best cross axis droppable', () => {
           type: 'TYPE',
         },
         direction: axis.direction,
-        paddingBox: getArea({
+        borderBox: getArea({
           top: 0,
           left: 0,
           right: 20,
@@ -468,7 +468,7 @@ describe('get best cross axis droppable', () => {
           type: 'TYPE',
         },
         direction: axis.direction,
-        paddingBox: getArea({
+        borderBox: getArea({
           top: 20,
           left: 0,
           right: 20,
@@ -498,7 +498,7 @@ describe('get best cross axis droppable', () => {
           type: 'TYPE',
         },
         direction: axis.direction,
-        paddingBox: getArea({
+        borderBox: getArea({
           top: 0,
           left: 0,
           right: 20,
@@ -511,7 +511,7 @@ describe('get best cross axis droppable', () => {
           type: 'TYPE',
         },
         direction: axis.direction,
-        paddingBox: getArea({
+        borderBox: getArea({
           top: 10,
           left: 0,
           right: 20,
@@ -542,7 +542,7 @@ describe('get best cross axis droppable', () => {
           type: 'TYPE',
         },
         direction: axis.direction,
-        paddingBox: getArea({
+        borderBox: getArea({
           top: 0,
           left: 0,
           right: 20,
@@ -555,7 +555,7 @@ describe('get best cross axis droppable', () => {
           type: 'TYPE',
         },
         direction: axis.direction,
-        paddingBox: getArea({
+        borderBox: getArea({
           top: 10,
           left: 0,
           right: 20,
@@ -595,7 +595,7 @@ describe('get best cross axis droppable', () => {
           type: 'TYPE',
         },
         direction: axis.direction,
-        paddingBox: getArea({
+        borderBox: getArea({
           top: 0,
           left: 20,
           right: 30,
@@ -609,7 +609,7 @@ describe('get best cross axis droppable', () => {
         },
         isEnabled: false,
         direction: axis.direction,
-        paddingBox: getArea({
+        borderBox: getArea({
           top: 0,
           left: 30,
           right: 40,
@@ -639,7 +639,7 @@ describe('get best cross axis droppable', () => {
           type: 'TYPE',
         },
         direction: axis.direction,
-        paddingBox: getArea({
+        borderBox: getArea({
           [axis.start]: 0,
           [axis.end]: 100,
           [axis.crossAxisStart]: 0,
@@ -653,7 +653,7 @@ describe('get best cross axis droppable', () => {
         },
         direction: axis.direction,
         // totally hidden by frame
-        paddingBox: getArea({
+        borderBox: getArea({
           [axis.start]: 0,
           [axis.end]: 100,
           // would normally be a good candidate
@@ -661,7 +661,7 @@ describe('get best cross axis droppable', () => {
           [axis.crossAxisEnd]: 300,
         }),
         closest: {
-          framePaddingBox: getArea({
+          frameBorderBox: getArea({
             [axis.start]: 0,
             [axis.end]: 100,
             // frame hides subject
@@ -697,7 +697,7 @@ describe('get best cross axis droppable', () => {
           type: 'TYPE',
         },
         direction: axis.direction,
-        paddingBox: getArea({
+        borderBox: getArea({
           top: 0,
           bottom: 10,
           left: 20,
@@ -710,7 +710,7 @@ describe('get best cross axis droppable', () => {
           type: 'TYPE',
         },
         direction: axis.direction,
-        paddingBox: getArea({
+        borderBox: getArea({
           top: 0,
           bottom: 10,
           left: viewport.subject.right + 1,
@@ -740,7 +740,7 @@ describe('get best cross axis droppable', () => {
           type: 'TYPE',
         },
         direction: axis.direction,
-        paddingBox: getArea({
+        borderBox: getArea({
           top: 0,
           left: 0,
           right: 20,
@@ -753,7 +753,7 @@ describe('get best cross axis droppable', () => {
           type: 'TYPE',
         },
         direction: axis.direction,
-        paddingBox: getArea({
+        borderBox: getArea({
           // comes after the source
           top: 10,
           // but its left value is > the rigt of the source
@@ -787,7 +787,7 @@ describe('get best cross axis droppable', () => {
           type: 'TYPE',
         },
         direction: axis.direction,
-        paddingBox: getArea({
+        borderBox: getArea({
           top: 0,
           left: 0,
           right: 100,
@@ -800,7 +800,7 @@ describe('get best cross axis droppable', () => {
           type: 'TYPE',
         },
         direction: axis.direction,
-        paddingBox: getArea({
+        borderBox: getArea({
           // shares an edge with the source
           top: 10,
           // shares the left edge with the source
@@ -815,7 +815,7 @@ describe('get best cross axis droppable', () => {
           type: 'TYPE',
         },
         direction: axis.direction,
-        paddingBox: getArea({
+        borderBox: getArea({
           // shares an edge with the source
           top: 10,
           // shares the left edge with the source

--- a/test/unit/state/move-cross-axis/get-closest-draggable.spec.js
+++ b/test/unit/state/move-cross-axis/get-closest-draggable.spec.js
@@ -25,7 +25,7 @@ describe('get closest draggable', () => {
       const crossAxisStart: number = 0;
       const crossAxisEnd: number = 20;
 
-      const paddingBox: Area = getArea({
+      const borderBox: Area = getArea({
         [axis.start]: start,
         [axis.end]: end,
         [axis.crossAxisStart]: crossAxisStart,
@@ -38,7 +38,7 @@ describe('get closest draggable', () => {
           type: 'TYPE',
         },
         direction: axis.direction,
-        paddingBox,
+        borderBox,
       });
 
       const hiddenBackwards: DraggableDimension = getDraggableDimension({
@@ -47,7 +47,7 @@ describe('get closest draggable', () => {
           droppableId: droppable.descriptor.id,
           index: 0,
         },
-        paddingBox: getArea({
+        borderBox: getArea({
           [axis.crossAxisStart]: crossAxisStart,
           [axis.crossAxisEnd]: crossAxisEnd,
           [axis.start]: -30, // -10
@@ -62,7 +62,7 @@ describe('get closest draggable', () => {
           droppableId: droppable.descriptor.id,
           index: 1,
         },
-        paddingBox: getArea({
+        borderBox: getArea({
           [axis.crossAxisStart]: crossAxisStart,
           [axis.crossAxisEnd]: crossAxisEnd,
           [axis.start]: -10, // -10
@@ -76,7 +76,7 @@ describe('get closest draggable', () => {
           droppableId: droppable.descriptor.id,
           index: 2,
         },
-        paddingBox: getArea({
+        borderBox: getArea({
           [axis.crossAxisStart]: crossAxisStart,
           [axis.crossAxisEnd]: crossAxisEnd,
           [axis.start]: 20,
@@ -90,7 +90,7 @@ describe('get closest draggable', () => {
           droppableId: droppable.descriptor.id,
           index: 3,
         },
-        paddingBox: getArea({
+        borderBox: getArea({
           [axis.crossAxisStart]: crossAxisStart,
           [axis.crossAxisEnd]: crossAxisEnd,
           [axis.start]: 40,
@@ -105,7 +105,7 @@ describe('get closest draggable', () => {
           droppableId: droppable.descriptor.id,
           index: 4,
         },
-        paddingBox: getArea({
+        borderBox: getArea({
           [axis.crossAxisStart]: crossAxisStart,
           [axis.crossAxisEnd]: crossAxisEnd,
           [axis.start]: 60,
@@ -120,7 +120,7 @@ describe('get closest draggable', () => {
           droppableId: droppable.descriptor.id,
           index: 5,
         },
-        paddingBox: getArea({
+        borderBox: getArea({
           [axis.crossAxisStart]: crossAxisStart,
           [axis.crossAxisEnd]: crossAxisEnd,
           [axis.start]: 120,
@@ -134,7 +134,7 @@ describe('get closest draggable', () => {
           droppableId: droppable.descriptor.id,
           index: 6,
         },
-        paddingBox: getArea({
+        borderBox: getArea({
           [axis.crossAxisStart]: crossAxisStart,
           [axis.crossAxisEnd]: crossAxisEnd,
           [axis.start]: viewport.subject[axis.end] + 1,
@@ -155,7 +155,7 @@ describe('get closest draggable', () => {
       it('should return the closest draggable', () => {
         // closet to visible1
         const center1: Position = patch(
-          axis.line, visible1.page.paddingBox.center[axis.line], 100
+          axis.line, visible1.page.borderBox.center[axis.line], 100
         );
         const result1: ?DraggableDimension = getClosestDraggable({
           axis,
@@ -168,7 +168,7 @@ describe('get closest draggable', () => {
 
         // closest to visible2
         const center2: Position = patch(
-          axis.line, visible2.page.paddingBox.center[axis.line], 100
+          axis.line, visible2.page.borderBox.center[axis.line], 100
         );
         const result2: ?DraggableDimension = getClosestDraggable({
           axis,
@@ -201,11 +201,11 @@ describe('get closest draggable', () => {
         const scrollable: DroppableDimension = getDroppableDimension({
           descriptor: droppable.descriptor,
           direction: axis.direction,
-          paddingBox,
+          borderBox,
           closest: {
-            framePaddingBox: getArea(expandByPosition(paddingBox, patch(axis.line, 100))),
-            scrollHeight: paddingBox.width + 100,
-            scrollWidth: paddingBox.height + 100,
+            frameBorderBox: getArea(expandByPosition(borderBox, patch(axis.line, 100))),
+            scrollHeight: borderBox.width + 100,
+            scrollWidth: borderBox.height + 100,
             scroll: { x: 0, y: 0 },
             shouldClipSubject: true,
           },
@@ -216,7 +216,7 @@ describe('get closest draggable', () => {
         );
         const center: Position = patch(
           axis.line,
-          visible1.page.paddingBox.center[axis.line],
+          visible1.page.borderBox.center[axis.line],
           100
         );
 
@@ -245,7 +245,7 @@ describe('get closest draggable', () => {
         it('should ignore draggables backward that have no total visiblity', () => {
           const center: Position = patch(
             axis.line,
-            hiddenBackwards.page.paddingBox.center[axis.line],
+            hiddenBackwards.page.borderBox.center[axis.line],
             100,
           );
 
@@ -263,7 +263,7 @@ describe('get closest draggable', () => {
         it('should ignore draggables that have backwards partial visiblility', () => {
           const center: Position = patch(
             axis.line,
-            partiallyHiddenBackwards.page.paddingBox.center[axis.line],
+            partiallyHiddenBackwards.page.borderBox.center[axis.line],
             100,
           );
 
@@ -280,7 +280,7 @@ describe('get closest draggable', () => {
 
         it('should ignore draggables that have forward partial visiblility', () => {
           const center: Position = patch(
-            axis.line, partiallyHiddenForwards.page.paddingBox.center[axis.line], 100
+            axis.line, partiallyHiddenForwards.page.borderBox.center[axis.line], 100
           );
 
           const result: ?DraggableDimension = getClosestDraggable({
@@ -296,7 +296,7 @@ describe('get closest draggable', () => {
 
         it('should ignore draggables forward that have no visiblity', () => {
           const center: Position = patch(
-            axis.line, hiddenForwards.page.paddingBox.center[axis.line], 100
+            axis.line, hiddenForwards.page.borderBox.center[axis.line], 100
           );
 
           const result: ?DraggableDimension = getClosestDraggable({
@@ -312,7 +312,7 @@ describe('get closest draggable', () => {
 
         it('should ignore draggables that are outside of the viewport', () => {
           const center: Position = patch(
-            axis.line, outOfViewport.page.paddingBox.center[axis.line], 100
+            axis.line, outOfViewport.page.borderBox.center[axis.line], 100
           );
 
           const result: ?DraggableDimension = getClosestDraggable({
@@ -354,7 +354,7 @@ describe('get closest draggable', () => {
         const center: Position = patch(
           axis.line,
           // this is shared edge
-          visible2.page.paddingBox[axis.start],
+          visible2.page.borderBox[axis.start],
           100
         );
 
@@ -371,8 +371,8 @@ describe('get closest draggable', () => {
         // validating test assumptions
 
         // 1. that they have equal distances
-        expect(distance(center, visible1.page.paddingBox.center))
-          .toEqual(distance(center, visible2.page.paddingBox.center));
+        expect(distance(center, visible1.page.borderBox.center))
+          .toEqual(distance(center, visible2.page.borderBox.center));
 
         // 2. if we move beyond the edge visible2 will be selected
         const result2: ?DraggableDimension = getClosestDraggable({

--- a/test/unit/state/move-cross-axis/move-cross-axis.spec.js
+++ b/test/unit/state/move-cross-axis/move-cross-axis.spec.js
@@ -27,7 +27,7 @@ describe('move cross axis', () => {
         id: 'custom',
         type: 'TYPE',
       },
-      paddingBox: getArea({
+      borderBox: getArea({
         left: preset.home.client.marginBox.left + 1,
         right: preset.home.client.marginBox.left + 10,
         top: 0,
@@ -40,7 +40,7 @@ describe('move cross axis', () => {
         droppableId: custom.descriptor.id,
         index: 0,
       },
-      paddingBox: getArea({
+      borderBox: getArea({
         left: preset.home.client.marginBox.left + 1,
         right: preset.home.client.marginBox.left + 10,
         // outside of the viewport

--- a/test/unit/state/move-cross-axis/move-to-new-droppable.spec.js
+++ b/test/unit/state/move-cross-axis/move-to-new-droppable.spec.js
@@ -111,7 +111,7 @@ describe('move to new droppable', () => {
             }
 
             it('should return the original center without margin', () => {
-              expect(result.pageCenter).toBe(inHome2.page.paddingBox.center);
+              expect(result.pageCenter).toBe(inHome2.page.borderBox.center);
               expect(result.pageCenter).not.toEqual(inHome2.page.marginBox.center);
             });
 
@@ -158,7 +158,7 @@ describe('move to new droppable', () => {
             }
 
             it('should account for changes in droppable scroll', () => {
-              const expected: Position = add(inHome2.page.paddingBox.center, displacement);
+              const expected: Position = add(inHome2.page.borderBox.center, displacement);
 
               expect(result.pageCenter).toEqual(expected);
             });
@@ -205,7 +205,7 @@ describe('move to new droppable', () => {
 
             it('should align to the start of the target', () => {
               const expected: Position = moveToEdge({
-                source: inHome4.page.paddingBox,
+                source: inHome4.page.borderBox,
                 sourceEdge: 'start',
                 destination: inHome2.page.marginBox,
                 destinationEdge: 'start',
@@ -272,7 +272,7 @@ describe('move to new droppable', () => {
 
             it('should account for changes in droppable scroll', () => {
               const withoutScroll: Position = moveToEdge({
-                source: inHome4.page.paddingBox,
+                source: inHome4.page.borderBox,
                 sourceEdge: 'start',
                 destination: inHome2.page.marginBox,
                 destinationEdge: 'start',
@@ -308,9 +308,9 @@ describe('move to new droppable', () => {
 
             it('should align to the bottom of the target', () => {
               const expected: Position = moveToEdge({
-                source: inHome1.page.paddingBox,
+                source: inHome1.page.borderBox,
                 sourceEdge: 'end',
-                destination: inHome4.page.paddingBox,
+                destination: inHome4.page.borderBox,
                 destinationEdge: 'end',
                 destinationAxis: axis,
               });
@@ -381,9 +381,9 @@ describe('move to new droppable', () => {
 
             it('should account for changes in droppable scroll', () => {
               const withoutScroll: Position = moveToEdge({
-                source: inHome1.page.paddingBox,
+                source: inHome1.page.borderBox,
                 sourceEdge: 'end',
-                destination: inHome4.page.paddingBox,
+                destination: inHome4.page.borderBox,
                 destinationEdge: 'end',
                 destinationAxis: axis,
               });
@@ -402,7 +402,7 @@ describe('move to new droppable', () => {
                 type: 'TYPE',
               },
               direction: axis.direction,
-              paddingBox: getArea({
+              borderBox: getArea({
                 [axis.crossAxisStart]: 0,
                 [axis.crossAxisEnd]: 100,
                 [axis.start]: 0,
@@ -410,7 +410,7 @@ describe('move to new droppable', () => {
                 [axis.end]: 200,
               }),
               closest: {
-                framePaddingBox: getArea({
+                frameBorderBox: getArea({
                   [axis.crossAxisStart]: 0,
                   [axis.crossAxisEnd]: 100,
                   [axis.start]: 0,
@@ -429,7 +429,7 @@ describe('move to new droppable', () => {
                 droppableId: droppable.descriptor.id,
                 index: 0,
               },
-              paddingBox: getArea({
+              borderBox: getArea({
                 [axis.crossAxisStart]: 0,
                 [axis.crossAxisEnd]: 100,
                 [axis.start]: 0,
@@ -442,7 +442,7 @@ describe('move to new droppable', () => {
                 droppableId: droppable.descriptor.id,
                 index: 1,
               },
-              paddingBox: getArea({
+              borderBox: getArea({
                 [axis.crossAxisStart]: 0,
                 [axis.crossAxisEnd]: 100,
                 // outside of the frame
@@ -500,7 +500,7 @@ describe('move to new droppable', () => {
                 type: 'TYPE',
               },
               direction: axis.direction,
-              paddingBox: getArea({
+              borderBox: getArea({
                 [axis.crossAxisStart]: 0,
                 [axis.crossAxisEnd]: 100,
                 [axis.start]: 0,
@@ -514,7 +514,7 @@ describe('move to new droppable', () => {
                 droppableId: droppable.descriptor.id,
                 index: 0,
               },
-              paddingBox: getArea({
+              borderBox: getArea({
                 [axis.crossAxisStart]: 0,
                 [axis.crossAxisEnd]: 100,
                 [axis.start]: 0,
@@ -527,7 +527,7 @@ describe('move to new droppable', () => {
                 droppableId: droppable.descriptor.id,
                 index: 1,
               },
-              paddingBox: getArea({
+              borderBox: getArea({
                 [axis.crossAxisStart]: 0,
                 [axis.crossAxisEnd]: 100,
                 // outside of the viewport but inside the droppable
@@ -625,7 +625,7 @@ describe('move to new droppable', () => {
 
             it('should move to the start edge of the droppable (including its padding)', () => {
               const expected: Position = moveToEdge({
-                source: inHome1.page.paddingBox,
+                source: inHome1.page.borderBox,
                 sourceEdge: 'start',
                 destination: foreign.page.contentBox,
                 destinationEdge: 'start',
@@ -679,7 +679,7 @@ describe('move to new droppable', () => {
 
             it('should account for changes in droppable scroll', () => {
               const withoutScroll: Position = moveToEdge({
-                source: inHome1.page.paddingBox,
+                source: inHome1.page.borderBox,
                 sourceEdge: 'start',
                 destination: foreign.page.contentBox,
                 destinationEdge: 'start',
@@ -715,7 +715,7 @@ describe('move to new droppable', () => {
 
             it('should move before the target', () => {
               const expected: Position = moveToEdge({
-                source: inHome1.page.paddingBox,
+                source: inHome1.page.borderBox,
                 sourceEdge: 'start',
                 destination: inForeign2.page.marginBox,
                 destinationEdge: 'start',
@@ -787,7 +787,7 @@ describe('move to new droppable', () => {
 
             it('should account for changes in droppable scroll', () => {
               const withoutScroll: Position = moveToEdge({
-                source: inHome1.page.paddingBox,
+                source: inHome1.page.borderBox,
                 sourceEdge: 'start',
                 destination: inForeign2.page.marginBox,
                 destinationEdge: 'start',
@@ -823,7 +823,7 @@ describe('move to new droppable', () => {
 
             it('should move after the target', () => {
               const expected = moveToEdge({
-                source: inHome4.page.paddingBox,
+                source: inHome4.page.borderBox,
                 sourceEdge: 'start',
                 destination: inForeign2.page.marginBox,
                 // going after
@@ -891,7 +891,7 @@ describe('move to new droppable', () => {
 
             it('should account for changes in droppable scroll', () => {
               const withoutScroll: Position = moveToEdge({
-                source: inHome4.page.paddingBox,
+                source: inHome4.page.borderBox,
                 sourceEdge: 'start',
                 destination: inForeign2.page.marginBox,
                 // going after
@@ -913,7 +913,7 @@ describe('move to new droppable', () => {
                 type: 'TYPE',
               },
               direction: axis.direction,
-              paddingBox: getArea({
+              borderBox: getArea({
                 [axis.crossAxisStart]: 0,
                 [axis.crossAxisEnd]: 100,
                 [axis.start]: 0,
@@ -926,7 +926,7 @@ describe('move to new droppable', () => {
                 droppableId: customHome.descriptor.id,
                 index: 0,
               },
-              paddingBox: getArea({
+              borderBox: getArea({
                 [axis.crossAxisStart]: 0,
                 [axis.crossAxisEnd]: 100,
                 [axis.start]: 0,
@@ -939,7 +939,7 @@ describe('move to new droppable', () => {
                 type: 'TYPE',
               },
               direction: axis.direction,
-              paddingBox: getArea({
+              borderBox: getArea({
                 top: 0,
                 left: 0,
                 right: 100,
@@ -947,7 +947,7 @@ describe('move to new droppable', () => {
                 bottom: 200,
               }),
               closest: {
-                framePaddingBox: getArea({
+                frameBorderBox: getArea({
                   top: 0,
                   left: 0,
                   right: 100,
@@ -966,7 +966,7 @@ describe('move to new droppable', () => {
                 droppableId: customForeign.descriptor.id,
                 index: 0,
               },
-              paddingBox: getArea({
+              borderBox: getArea({
                 [axis.crossAxisStart]: 0,
                 [axis.crossAxisEnd]: 100,
                 // outside of the foreign frame
@@ -1026,7 +1026,7 @@ describe('move to new droppable', () => {
                 type: 'TYPE',
               },
               direction: axis.direction,
-              paddingBox: getArea({
+              borderBox: getArea({
                 [axis.crossAxisStart]: 0,
                 [axis.crossAxisEnd]: 100,
                 [axis.start]: 0,
@@ -1039,7 +1039,7 @@ describe('move to new droppable', () => {
                 droppableId: customHome.descriptor.id,
                 index: 0,
               },
-              paddingBox: getArea({
+              borderBox: getArea({
                 [axis.crossAxisStart]: 0,
                 [axis.crossAxisEnd]: 100,
                 [axis.start]: 0,
@@ -1052,7 +1052,7 @@ describe('move to new droppable', () => {
                 type: 'TYPE',
               },
               direction: axis.direction,
-              paddingBox: getArea({
+              borderBox: getArea({
                 bottom: viewport.subject.bottom + 100,
                 [axis.crossAxisStart]: 0,
                 [axis.crossAxisEnd]: 100,
@@ -1067,7 +1067,7 @@ describe('move to new droppable', () => {
                 droppableId: customForeign.descriptor.id,
                 index: 0,
               },
-              paddingBox: getArea({
+              borderBox: getArea({
                 [axis.crossAxisStart]: 0,
                 [axis.crossAxisEnd]: 100,
                 // outside of the viewport but inside the droppable

--- a/test/unit/state/move-to-next-index.spec.js
+++ b/test/unit/state/move-to-next-index.spec.js
@@ -52,7 +52,7 @@ describe('move to next index', () => {
         const result: ?Result = moveToNextIndex({
           isMovingForward: true,
           draggableId: preset.inHome1.descriptor.id,
-          previousPageCenter: preset.inHome1.page.paddingBox.center,
+          previousPageCenter: preset.inHome1.page.borderBox.center,
           previousImpact: noImpact,
           droppable: disabled,
           draggables: preset.draggables,
@@ -80,7 +80,7 @@ describe('move to next index', () => {
               isMovingForward: true,
               draggableId: preset.inHome3.descriptor.id,
               previousImpact,
-              previousPageCenter: preset.inHome3.page.paddingBox.center,
+              previousPageCenter: preset.inHome3.page.borderBox.center,
               droppable: preset.home,
               draggables: preset.draggables,
               viewport: customViewport,
@@ -105,7 +105,7 @@ describe('move to next index', () => {
                 isMovingForward: true,
                 draggableId: preset.inHome1.descriptor.id,
                 previousImpact,
-                previousPageCenter: preset.inHome1.page.paddingBox.center,
+                previousPageCenter: preset.inHome1.page.borderBox.center,
                 draggables: preset.draggables,
                 droppable: preset.home,
                 viewport: customViewport,
@@ -117,9 +117,9 @@ describe('move to next index', () => {
 
               it('should move the end of the dragging item to the end of the next item', () => {
                 const expected: Position = moveToEdge({
-                  source: preset.inHome1.page.paddingBox,
+                  source: preset.inHome1.page.borderBox,
                   sourceEdge: 'end',
-                  destination: preset.inHome2.page.paddingBox,
+                  destination: preset.inHome2.page.borderBox,
                   destinationEdge: 'end',
                   destinationAxis: axis,
                 });
@@ -164,7 +164,7 @@ describe('move to next index', () => {
                 isMovingForward: true,
                 draggableId: preset.inHome2.descriptor.id,
                 previousImpact,
-                previousPageCenter: preset.inHome2.page.paddingBox.center,
+                previousPageCenter: preset.inHome2.page.borderBox.center,
                 draggables: preset.draggables,
                 droppable: preset.home,
                 viewport: customViewport,
@@ -176,9 +176,9 @@ describe('move to next index', () => {
 
               it('should move the end of the dragging item to the end of the next item', () => {
                 const expected: Position = moveToEdge({
-                  source: preset.inHome2.page.paddingBox,
+                  source: preset.inHome2.page.borderBox,
                   sourceEdge: 'end',
-                  destination: preset.inHome3.page.paddingBox,
+                  destination: preset.inHome3.page.borderBox,
                   destinationEdge: 'end',
                   destinationAxis: axis,
                 });
@@ -235,7 +235,7 @@ describe('move to next index', () => {
                 previousImpact,
                 // roughly correct previous page center
                 // not calculating the exact point as it is not required for this test
-                previousPageCenter: preset.inHome2.page.paddingBox.center,
+                previousPageCenter: preset.inHome2.page.borderBox.center,
                 draggables: preset.draggables,
                 droppable: preset.home,
                 viewport: customViewport,
@@ -248,9 +248,9 @@ describe('move to next index', () => {
               it('should move the end of the dragging item to the end of the next item', () => {
                 // next dimension from the current index is draggable3
                 const expected: Position = moveToEdge({
-                  source: preset.inHome1.page.paddingBox,
+                  source: preset.inHome1.page.borderBox,
                   sourceEdge: 'end',
-                  destination: preset.inHome3.page.paddingBox,
+                  destination: preset.inHome3.page.borderBox,
                   destinationEdge: 'end',
                   destinationAxis: axis,
                 });
@@ -316,7 +316,7 @@ describe('move to next index', () => {
                 draggableId: preset.inHome2.descriptor.id,
                 previousImpact,
                 // roughly correct:
-                previousPageCenter: preset.inHome1.page.paddingBox.center,
+                previousPageCenter: preset.inHome1.page.borderBox.center,
                 draggables: preset.draggables,
                 viewport: customViewport,
                 droppable: preset.home,
@@ -328,16 +328,16 @@ describe('move to next index', () => {
 
               it('should move the start of the dragging item to the end of the previous item (which its original position)', () => {
                 const expected: Position = moveToEdge({
-                  source: preset.inHome2.page.paddingBox,
+                  source: preset.inHome2.page.borderBox,
                   sourceEdge: 'start',
-                  destination: preset.inHome2.page.paddingBox,
+                  destination: preset.inHome2.page.borderBox,
                   destinationEdge: 'start',
                   destinationAxis: axis,
                 });
 
                 expect(result.pageCenter).toEqual(expected);
                 // is now back at its original position
-                expect(result.pageCenter).toEqual(preset.inHome2.page.paddingBox.center);
+                expect(result.pageCenter).toEqual(preset.inHome2.page.borderBox.center);
               });
 
               it('should return an empty impact', () => {
@@ -392,7 +392,7 @@ describe('move to next index', () => {
                 draggableId: preset.inHome3.descriptor.id,
                 previousImpact,
                 // this is roughly correct
-                previousPageCenter: preset.inHome1.page.paddingBox.center,
+                previousPageCenter: preset.inHome1.page.borderBox.center,
                 draggables: preset.draggables,
                 viewport: customViewport,
                 droppable: preset.home,
@@ -404,9 +404,9 @@ describe('move to next index', () => {
 
               it('should move to the start of the draggable item to the start position of the destination draggable', () => {
                 const expected: Position = moveToEdge({
-                  source: preset.inHome3.page.paddingBox,
+                  source: preset.inHome3.page.borderBox,
                   sourceEdge: 'start',
-                  destination: preset.inHome2.page.paddingBox,
+                  destination: preset.inHome2.page.borderBox,
                   destinationEdge: 'start',
                   destinationAxis: axis,
                 });
@@ -453,14 +453,14 @@ describe('move to next index', () => {
                   type: 'TYPE',
                 },
                 direction: axis.direction,
-                paddingBox: getArea({
+                borderBox: getArea({
                   [axis.crossAxisStart]: crossAxisStart,
                   [axis.crossAxisEnd]: crossAxisEnd,
                   [axis.start]: 0,
                   [axis.end]: 400,
                 }),
                 closest: {
-                  framePaddingBox: getArea({
+                  frameBorderBox: getArea({
                     [axis.crossAxisStart]: crossAxisStart,
                     [axis.crossAxisEnd]: crossAxisEnd,
                     [axis.start]: 0,
@@ -483,7 +483,7 @@ describe('move to next index', () => {
                   droppableId: home.descriptor.id,
                   index: 0,
                 },
-                paddingBox: getArea({
+                borderBox: getArea({
                   [axis.crossAxisStart]: crossAxisStart,
                   [axis.crossAxisEnd]: crossAxisEnd,
                   [axis.start]: 0,
@@ -497,7 +497,7 @@ describe('move to next index', () => {
                   droppableId: home.descriptor.id,
                   index: 1,
                 },
-                paddingBox: getArea({
+                borderBox: getArea({
                   [axis.crossAxisStart]: crossAxisStart,
                   [axis.crossAxisEnd]: crossAxisEnd,
                   [axis.start]: 50,
@@ -511,7 +511,7 @@ describe('move to next index', () => {
                   droppableId: home.descriptor.id,
                   index: 2,
                 },
-                paddingBox: getArea({
+                borderBox: getArea({
                   [axis.crossAxisStart]: crossAxisStart,
                   [axis.crossAxisEnd]: crossAxisEnd,
                   [axis.start]: 100,
@@ -525,7 +525,7 @@ describe('move to next index', () => {
                   droppableId: home.descriptor.id,
                   index: 3,
                 },
-                paddingBox: getArea({
+                borderBox: getArea({
                   [axis.crossAxisStart]: crossAxisStart,
                   [axis.crossAxisEnd]: crossAxisEnd,
                   [axis.start]: 200,
@@ -539,7 +539,7 @@ describe('move to next index', () => {
                   droppableId: home.descriptor.id,
                   index: 4,
                 },
-                paddingBox: getArea({
+                borderBox: getArea({
                   [axis.crossAxisStart]: crossAxisStart,
                   [axis.crossAxisEnd]: crossAxisEnd,
                   [axis.start]: 300,
@@ -553,7 +553,7 @@ describe('move to next index', () => {
                   droppableId: home.descriptor.id,
                   index: 5,
                 },
-                paddingBox: getArea({
+                borderBox: getArea({
                   [axis.crossAxisStart]: crossAxisStart,
                   [axis.crossAxisEnd]: crossAxisEnd,
                   [axis.start]: 350,
@@ -693,7 +693,7 @@ describe('move to next index', () => {
                   draggableId: inHome1.descriptor.id,
                   previousImpact,
                   // roughly correct:
-                  previousPageCenter: inHome1.page.paddingBox.center,
+                  previousPageCenter: inHome1.page.borderBox.center,
                   draggables,
                   viewport: customViewport,
                   droppable: scrolled,
@@ -728,7 +728,7 @@ describe('move to next index', () => {
               isMovingForward: false,
               draggableId: preset.inHome1.descriptor.id,
               previousImpact,
-              previousPageCenter: preset.inHome1.page.paddingBox.center,
+              previousPageCenter: preset.inHome1.page.borderBox.center,
               draggables: preset.draggables,
               droppable: preset.home,
               viewport: customViewport,
@@ -756,7 +756,7 @@ describe('move to next index', () => {
                 isMovingForward: false,
                 draggableId: preset.inHome2.descriptor.id,
                 previousImpact,
-                previousPageCenter: preset.inHome2.page.paddingBox.center,
+                previousPageCenter: preset.inHome2.page.borderBox.center,
                 draggables: preset.draggables,
                 droppable: preset.home,
                 viewport: customViewport,
@@ -768,9 +768,9 @@ describe('move to next index', () => {
 
               it('should move the start of the draggable to the start of the previous draggable', () => {
                 const expected: Position = moveToEdge({
-                  source: preset.inHome2.page.paddingBox,
+                  source: preset.inHome2.page.borderBox,
                   sourceEdge: 'start',
-                  destination: preset.inHome1.page.paddingBox,
+                  destination: preset.inHome1.page.borderBox,
                   destinationEdge: 'start',
                   destinationAxis: axis,
                 });
@@ -818,7 +818,7 @@ describe('move to next index', () => {
                 isMovingForward: false,
                 draggableId: preset.inHome3.descriptor.id,
                 previousImpact,
-                previousPageCenter: preset.inHome3.page.paddingBox.center,
+                previousPageCenter: preset.inHome3.page.borderBox.center,
                 draggables: preset.draggables,
                 droppable: preset.home,
                 viewport: customViewport,
@@ -830,9 +830,9 @@ describe('move to next index', () => {
 
               it('should move the start of the draggable to the start of the previous draggable', () => {
                 const expected: Position = moveToEdge({
-                  source: preset.inHome3.page.paddingBox,
+                  source: preset.inHome3.page.borderBox,
                   sourceEdge: 'start',
-                  destination: preset.inHome2.page.paddingBox,
+                  destination: preset.inHome2.page.borderBox,
                   destinationEdge: 'start',
                   destinationAxis: axis,
                 });
@@ -889,7 +889,7 @@ describe('move to next index', () => {
                 draggableId: preset.inHome2.descriptor.id,
                 previousImpact,
                 // roughly correct
-                previousPageCenter: preset.inHome3.page.paddingBox.center,
+                previousPageCenter: preset.inHome3.page.borderBox.center,
                 draggables: preset.draggables,
                 viewport: customViewport,
                 droppable: preset.home,
@@ -901,17 +901,17 @@ describe('move to next index', () => {
 
               it('should move the end of the draggable to the end of the next draggable (which is its original position)', () => {
                 const expected: Position = moveToEdge({
-                  source: preset.inHome2.page.paddingBox,
+                  source: preset.inHome2.page.borderBox,
                   sourceEdge: 'end',
                   // destination is itself as moving back to home
-                  destination: preset.inHome2.page.paddingBox,
+                  destination: preset.inHome2.page.borderBox,
                   destinationEdge: 'end',
                   destinationAxis: axis,
                 });
 
                 expect(result.pageCenter).toEqual(expected);
                 // moved back to its original position
-                expect(result.pageCenter).toEqual(preset.inHome2.page.paddingBox.center);
+                expect(result.pageCenter).toEqual(preset.inHome2.page.borderBox.center);
               });
 
               it('should return an empty impact', () => {
@@ -965,7 +965,7 @@ describe('move to next index', () => {
                 draggableId: preset.inHome1.descriptor.id,
                 previousImpact,
                 // roughly correct
-                previousPageCenter: preset.inHome3.page.paddingBox.center,
+                previousPageCenter: preset.inHome3.page.borderBox.center,
                 draggables: preset.draggables,
                 viewport: customViewport,
                 droppable: preset.home,
@@ -977,9 +977,9 @@ describe('move to next index', () => {
 
               it('should move the end of the draggable to the end of the previous draggable', () => {
                 const expected: Position = moveToEdge({
-                  source: preset.inHome1.page.paddingBox,
+                  source: preset.inHome1.page.borderBox,
                   sourceEdge: 'end',
-                  destination: preset.inHome2.page.paddingBox,
+                  destination: preset.inHome2.page.borderBox,
                   destinationEdge: 'end',
                   destinationAxis: axis,
                 });
@@ -1020,7 +1020,7 @@ describe('move to next index', () => {
                 type: 'huge',
               },
               direction: axis.direction,
-              paddingBox: getArea({
+              borderBox: getArea({
                 top: 0,
                 right: 10000,
                 bottom: 10000,
@@ -1035,7 +1035,7 @@ describe('move to next index', () => {
                   index: 0,
                   droppableId: droppable.descriptor.id,
                 },
-                paddingBox: customViewport.subject,
+                borderBox: customViewport.subject,
               });
               const outsideViewport: DraggableDimension = getDraggableDimension({
                 descriptor: {
@@ -1043,7 +1043,7 @@ describe('move to next index', () => {
                   index: 1,
                   droppableId: droppable.descriptor.id,
                 },
-                paddingBox: getArea({
+                borderBox: getArea({
                   // is bottom left of the viewport
                   top: customViewport.subject.bottom + 1,
                   right: customViewport.subject.right + 100,
@@ -1065,13 +1065,13 @@ describe('move to next index', () => {
                 [outsideViewport.descriptor.id]: outsideViewport,
               };
               const expectedCenter = moveToEdge({
-                source: asBigAsViewport.page.paddingBox,
+                source: asBigAsViewport.page.borderBox,
                 sourceEdge: 'end',
                 destination: outsideViewport.page.marginBox,
                 destinationEdge: 'end',
                 destinationAxis: axis,
               });
-              const previousPageCenter: Position = asBigAsViewport.page.paddingBox.center;
+              const previousPageCenter: Position = asBigAsViewport.page.borderBox.center;
               const expectedScrollJump: Position = subtract(expectedCenter, previousPageCenter);
               const expectedImpact: DragImpact = {
                 movement: {
@@ -1119,7 +1119,7 @@ describe('move to next index', () => {
                   index: 0,
                   droppableId: droppable.descriptor.id,
                 },
-                paddingBox: getArea({
+                borderBox: getArea({
                   top: 0,
                   left: 0,
                   right: customViewport.subject.right - 100,
@@ -1132,7 +1132,7 @@ describe('move to next index', () => {
                   index: 1,
                   droppableId: droppable.descriptor.id,
                 },
-                paddingBox: getArea({
+                borderBox: getArea({
                   top: customViewport.subject.bottom + 1,
                   left: customViewport.subject.right + 1,
                   bottom: customViewport.subject.bottom + 100,
@@ -1152,7 +1152,7 @@ describe('move to next index', () => {
                 [visible.descriptor.id]: visible,
                 [invisible.descriptor.id]: invisible,
               };
-              const previousPageCenter: Position = visible.page.paddingBox.center;
+              const previousPageCenter: Position = visible.page.borderBox.center;
               const expectedImpact: DragImpact = {
                 movement: {
                   displaced: [{
@@ -1198,7 +1198,7 @@ describe('move to next index', () => {
                   type: 'huge',
                 },
                 direction: axis.direction,
-                paddingBox: getArea({
+                borderBox: getArea({
                   top: 0,
                   left: 0,
                   // cut off by frame
@@ -1206,7 +1206,7 @@ describe('move to next index', () => {
                   right: 200,
                 }),
                 closest: {
-                  framePaddingBox: getArea({
+                  frameBorderBox: getArea({
                     top: 0,
                     left: 0,
                     right: 100,
@@ -1224,7 +1224,7 @@ describe('move to next index', () => {
                   index: 0,
                   droppableId: droppable.descriptor.id,
                 },
-                paddingBox: getArea({
+                borderBox: getArea({
                   top: 0,
                   left: 0,
                   // bleeding over the frame
@@ -1238,7 +1238,7 @@ describe('move to next index', () => {
                   index: 1,
                   droppableId: droppable.descriptor.id,
                 },
-                paddingBox: getArea({
+                borderBox: getArea({
                   // in the droppable, but outside the frame
                   top: 120,
                   left: 120,
@@ -1258,9 +1258,9 @@ describe('move to next index', () => {
                 [inside.descriptor.id]: inside,
                 [outside.descriptor.id]: outside,
               };
-              const previousPageCenter: Position = inside.page.paddingBox.center;
+              const previousPageCenter: Position = inside.page.borderBox.center;
               const expectedCenter = moveToEdge({
-                source: inside.page.paddingBox,
+                source: inside.page.borderBox,
                 sourceEdge: 'end',
                 destination: outside.page.marginBox,
                 destinationEdge: 'end',
@@ -1349,7 +1349,7 @@ describe('move to next index', () => {
               isMovingForward: true,
               draggableId: preset.inHome1.descriptor.id,
               previousImpact,
-              previousPageCenter: preset.inHome1.page.paddingBox.center,
+              previousPageCenter: preset.inHome1.page.borderBox.center,
               droppable: preset.foreign,
               draggables: preset.draggables,
               viewport: customViewport,
@@ -1361,7 +1361,7 @@ describe('move to next index', () => {
 
             it('should move to the start edge of the dragging item to the start of foreign2', () => {
               const expected = moveToEdge({
-                source: preset.inHome1.page.paddingBox,
+                source: preset.inHome1.page.borderBox,
                 sourceEdge: 'start',
                 destination: preset.inForeign2.page.marginBox,
                 destinationEdge: 'start',
@@ -1426,7 +1426,7 @@ describe('move to next index', () => {
               isMovingForward: true,
               draggableId: preset.inHome1.descriptor.id,
               previousImpact,
-              previousPageCenter: preset.inHome1.page.paddingBox.center,
+              previousPageCenter: preset.inHome1.page.borderBox.center,
               droppable: preset.foreign,
               draggables: preset.draggables,
               viewport: customViewport,
@@ -1438,7 +1438,7 @@ describe('move to next index', () => {
 
             it('should move to the start edge of the dragging item to the end of foreign1', () => {
               const expected = moveToEdge({
-                source: preset.inHome1.page.paddingBox,
+                source: preset.inHome1.page.borderBox,
                 sourceEdge: 'start',
                 destination: preset.inForeign4.page.marginBox,
                 destinationEdge: 'end',
@@ -1488,7 +1488,7 @@ describe('move to next index', () => {
               draggableId: preset.inHome1.descriptor.id,
               previousImpact,
               // roughly correct
-              previousPageCenter: preset.inHome4.page.paddingBox.center,
+              previousPageCenter: preset.inHome4.page.borderBox.center,
               droppable: preset.foreign,
               viewport: customViewport,
               draggables: preset.draggables,
@@ -1544,7 +1544,7 @@ describe('move to next index', () => {
               draggableId: preset.inHome1.descriptor.id,
               previousImpact,
               // roughly correct
-              previousPageCenter: preset.inForeign1.page.paddingBox.center,
+              previousPageCenter: preset.inForeign1.page.borderBox.center,
               droppable: preset.foreign,
               viewport: customViewport,
               draggables: preset.draggables,
@@ -1578,7 +1578,7 @@ describe('move to next index', () => {
               draggableId: preset.inHome1.descriptor.id,
               previousImpact,
               // roughly correct
-              previousPageCenter: preset.inForeign4.page.paddingBox.center,
+              previousPageCenter: preset.inForeign4.page.borderBox.center,
               droppable: preset.foreign,
               viewport: customViewport,
               draggables: preset.draggables,
@@ -1590,7 +1590,7 @@ describe('move to next index', () => {
 
             it('should move to the start edge of foreign3', () => {
               const expected: Position = moveToEdge({
-                source: preset.inHome1.page.paddingBox,
+                source: preset.inHome1.page.borderBox,
                 sourceEdge: 'start',
                 destination: preset.inForeign3.page.marginBox,
                 destinationEdge: 'start',
@@ -1668,7 +1668,7 @@ describe('move to next index', () => {
               draggableId: preset.inHome1.descriptor.id,
               previousImpact,
               // roughly correct
-              previousPageCenter: preset.inForeign2.page.paddingBox.center,
+              previousPageCenter: preset.inForeign2.page.borderBox.center,
               droppable: preset.foreign,
               viewport: customViewport,
               draggables: preset.draggables,
@@ -1680,7 +1680,7 @@ describe('move to next index', () => {
 
             it('should move the start edge of home1 to the start edge of foreign1', () => {
               const expected: Position = moveToEdge({
-                source: preset.inHome1.page.paddingBox,
+                source: preset.inHome1.page.borderBox,
                 sourceEdge: 'start',
                 destination: preset.inForeign1.page.marginBox,
                 destinationEdge: 'start',

--- a/test/unit/state/visibility/is-partially-visible.spec.js
+++ b/test/unit/state/visibility/is-partially-visible.spec.js
@@ -22,7 +22,7 @@ const asBigAsViewport: DroppableDimension = getDroppableDimension({
     id: 'same-as-viewport',
     type: 'TYPE',
   },
-  paddingBox: viewport,
+  borderBox: viewport,
 });
 
 const inViewport1: Spacing = {
@@ -51,7 +51,7 @@ const asBigAsInViewport1: DroppableDimension = getDroppableDimension({
     id: 'subset',
     type: 'TYPE',
   },
-  paddingBox: getArea(inViewport1),
+  borderBox: getArea(inViewport1),
 });
 
 describe('is partially visible', () => {
@@ -109,7 +109,7 @@ describe('is partially visible', () => {
           id: 'clipped',
           type: 'TYPE',
         },
-        paddingBox: getArea({
+        borderBox: getArea({
           top: viewport.top,
           // stretches out the bottom of the viewport
           bottom: viewport.bottom + 100,
@@ -117,7 +117,7 @@ describe('is partially visible', () => {
           right: viewport.right,
         }),
         closest: {
-          framePaddingBox: viewport,
+          frameBorderBox: viewport,
           scrollWidth: viewport.width,
           scrollHeight: viewport.bottom + 100,
           scroll: { x: 0, y: 0 },
@@ -178,7 +178,7 @@ describe('is partially visible', () => {
   });
 
   describe('droppable', () => {
-    const paddingBox: Area = getArea({
+    const borderBox: Area = getArea({
       top: 0,
       left: 0,
       right: 600,
@@ -196,11 +196,11 @@ describe('is partially visible', () => {
         id: 'clipped',
         type: 'TYPE',
       },
-      paddingBox,
+      borderBox,
       closest: {
-        framePaddingBox: frame,
-        scrollHeight: paddingBox.height,
-        scrollWidth: paddingBox.width,
+        frameBorderBox: frame,
+        scrollHeight: borderBox.height,
+        scrollWidth: borderBox.width,
         scroll: { x: 0, y: 0 },
         shouldClipSubject: true,
       },
@@ -280,13 +280,13 @@ describe('is partially visible', () => {
             id: 'clipped',
             type: 'TYPE',
           },
-          paddingBox: getArea({
+          borderBox: getArea({
             ...ourFrame,
             // stretches out past frame
             bottom: 600,
           }),
           closest: {
-            framePaddingBox: getArea(ourFrame),
+            frameBorderBox: getArea(ourFrame),
             scrollHeight: 600,
             scrollWidth: getArea(ourFrame).width,
             scroll: { x: 0, y: 0 },
@@ -366,14 +366,14 @@ describe('is partially visible', () => {
             id: 'droppable',
             type: 'TYPE',
           },
-          paddingBox: getArea({
+          borderBox: getArea({
             top: 0,
             left: 0,
             bottom: 100,
             right: 100,
           }),
           closest: {
-            framePaddingBox: getArea({
+            frameBorderBox: getArea({
               top: 0,
               left: 0,
               bottom: 100,
@@ -440,7 +440,7 @@ describe('is partially visible', () => {
           id: 'not-visible',
           type: 'TYPE',
         },
-        paddingBox: getArea(notInViewport),
+        borderBox: getArea(notInViewport),
       });
 
       expect(isPartiallyVisible({

--- a/test/unit/state/visibility/is-totally-visible.spec.js
+++ b/test/unit/state/visibility/is-totally-visible.spec.js
@@ -22,7 +22,7 @@ const asBigAsViewport: DroppableDimension = getDroppableDimension({
     id: 'same-as-viewport',
     type: 'TYPE',
   },
-  paddingBox: viewport,
+  borderBox: viewport,
 });
 
 const inViewport1: Spacing = {
@@ -51,7 +51,7 @@ const asBigAsInViewport1: DroppableDimension = getDroppableDimension({
     id: 'subset',
     type: 'TYPE',
   },
-  paddingBox: getArea(inViewport1),
+  borderBox: getArea(inViewport1),
 });
 
 describe('is totally visible', () => {
@@ -116,7 +116,7 @@ describe('is totally visible', () => {
           id: 'clipped',
           type: 'TYPE',
         },
-        paddingBox: getArea({
+        borderBox: getArea({
           top: viewport.top,
           // stretches out the bottom of the viewport
           bottom: viewport.bottom + 100,
@@ -124,7 +124,7 @@ describe('is totally visible', () => {
           right: viewport.right,
         }),
         closest: {
-          framePaddingBox: viewport,
+          frameBorderBox: viewport,
           scrollWidth: viewport.width,
           scrollHeight: viewport.bottom + 100,
           scroll: { x: 0, y: 0 },
@@ -185,7 +185,7 @@ describe('is totally visible', () => {
   });
 
   describe('droppable', () => {
-    const paddingBox: Area = getArea({
+    const borderBox: Area = getArea({
       top: 0,
       left: 0,
       right: 600,
@@ -203,11 +203,11 @@ describe('is totally visible', () => {
         id: 'clipped',
         type: 'TYPE',
       },
-      paddingBox,
+      borderBox,
       closest: {
-        framePaddingBox: frame,
-        scrollHeight: paddingBox.height,
-        scrollWidth: paddingBox.width,
+        frameBorderBox: frame,
+        scrollHeight: borderBox.height,
+        scrollWidth: borderBox.width,
         scroll: { x: 0, y: 0 },
         shouldClipSubject: true,
       },
@@ -294,13 +294,13 @@ describe('is totally visible', () => {
             id: 'clipped',
             type: 'TYPE',
           },
-          paddingBox: getArea({
+          borderBox: getArea({
             ...ourFrame,
             // stretches out past frame
             bottom: 600,
           }),
           closest: {
-            framePaddingBox: getArea(ourFrame),
+            frameBorderBox: getArea(ourFrame),
             scrollHeight: 600,
             scrollWidth: getArea(ourFrame).width,
             scroll: { x: 0, y: 0 },
@@ -381,14 +381,14 @@ describe('is totally visible', () => {
             id: 'droppable',
             type: 'TYPE',
           },
-          paddingBox: getArea({
+          borderBox: getArea({
             top: 0,
             left: 0,
             bottom: 100,
             right: 100,
           }),
           closest: {
-            framePaddingBox: getArea({
+            frameBorderBox: getArea({
               top: 0,
               left: 0,
               bottom: 100,
@@ -455,7 +455,7 @@ describe('is totally visible', () => {
           id: 'not-visible',
           type: 'TYPE',
         },
-        paddingBox: getArea(notInViewport),
+        borderBox: getArea(notInViewport),
       });
 
       expect(isTotallyVisible({

--- a/test/unit/view/dimension-marshal.spec.js
+++ b/test/unit/view/dimension-marshal.spec.js
@@ -116,7 +116,7 @@ const ofAnotherType: DroppableDimension = getDroppableDimension({
     id: 'of-another-type',
     type: 'another-type',
   },
-  paddingBox: fakeArea,
+  borderBox: fakeArea,
 });
 const childOfAnotherType: DraggableDimension = getDraggableDimension({
   descriptor: {
@@ -124,7 +124,7 @@ const childOfAnotherType: DraggableDimension = getDraggableDimension({
     droppableId: ofAnotherType.descriptor.id,
     index: 0,
   },
-  paddingBox: fakeArea,
+  borderBox: fakeArea,
 });
 
 const immediate: ScrollOptions = {
@@ -1084,7 +1084,7 @@ describe('dimension marshal', () => {
               id: preset.home.descriptor.id,
               type: preset.home.descriptor.type,
             },
-            paddingBox: getArea({
+            borderBox: getArea({
               top: 0, left: 0, right: 100, bottom: 100,
             }),
           });
@@ -1160,7 +1160,7 @@ describe('dimension marshal', () => {
               droppableId: preset.inHome2.descriptor.droppableId,
               index: 400,
             },
-            paddingBox: getArea({
+            borderBox: getArea({
               top: 0, left: 0, right: 100, bottom: 100,
             }),
           });
@@ -1200,7 +1200,7 @@ describe('dimension marshal', () => {
               droppableId: preset.home.descriptor.id,
               index: preset.inHomeList.length,
             },
-            paddingBox: fakeArea,
+            borderBox: fakeArea,
           });
 
           // start a collection

--- a/test/unit/view/draggable-dimension-publisher.spec.js
+++ b/test/unit/view/draggable-dimension-publisher.spec.js
@@ -189,7 +189,7 @@ describe('DraggableDimensionPublisher', () => {
           droppableId: preset.home.descriptor.id,
           index: 10,
         },
-        paddingBox: getArea({
+        borderBox: getArea({
           top: 0,
           right: 100,
           bottom: 100,
@@ -198,12 +198,12 @@ describe('DraggableDimensionPublisher', () => {
       });
 
       jest.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(() => ({
-        top: expected.page.paddingBox.top,
-        bottom: expected.page.paddingBox.bottom,
-        left: expected.page.paddingBox.left,
-        right: expected.page.paddingBox.right,
-        height: expected.page.paddingBox.height,
-        width: expected.page.paddingBox.width,
+        top: expected.page.borderBox.top,
+        bottom: expected.page.borderBox.bottom,
+        left: expected.page.borderBox.left,
+        right: expected.page.borderBox.right,
+        height: expected.page.borderBox.height,
+        width: expected.page.borderBox.width,
       }));
       jest.spyOn(window, 'getComputedStyle').mockImplementation(() => noSpacing);
       const marshal: DimensionMarshal = getMarshalStub();
@@ -237,7 +237,7 @@ describe('DraggableDimensionPublisher', () => {
           droppableId: preset.home.descriptor.id,
           index: 10,
         },
-        paddingBox: getArea({
+        borderBox: getArea({
           top: 0,
           right: 100,
           bottom: 100,
@@ -246,12 +246,12 @@ describe('DraggableDimensionPublisher', () => {
         margin,
       });
       jest.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(() => ({
-        top: expected.page.paddingBox.top,
-        bottom: expected.page.paddingBox.bottom,
-        left: expected.page.paddingBox.left,
-        right: expected.page.paddingBox.right,
-        height: expected.page.paddingBox.height,
-        width: expected.page.paddingBox.width,
+        top: expected.page.borderBox.top,
+        bottom: expected.page.borderBox.bottom,
+        left: expected.page.borderBox.left,
+        right: expected.page.borderBox.right,
+        height: expected.page.borderBox.height,
+        width: expected.page.borderBox.width,
       }));
       jest.spyOn(window, 'getComputedStyle').mockImplementation(() => ({
         marginTop: `${margin.top}`,
@@ -287,7 +287,7 @@ describe('DraggableDimensionPublisher', () => {
         x: 100,
         y: 200,
       };
-      const paddingBox: Area = getArea({
+      const borderBox: Area = getArea({
         top: 0,
         right: 100,
         bottom: 100,
@@ -299,10 +299,10 @@ describe('DraggableDimensionPublisher', () => {
           droppableId: preset.home.descriptor.id,
           index: 10,
         },
-        paddingBox,
+        borderBox,
         windowScroll,
       });
-      jest.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(() => paddingBox);
+      jest.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(() => borderBox);
       jest.spyOn(window, 'getComputedStyle').mockImplementation(() => noSpacing);
       setWindowScroll(windowScroll);
 

--- a/test/unit/view/unconnected-draggable.spec.js
+++ b/test/unit/view/unconnected-draggable.spec.js
@@ -842,6 +842,8 @@ describe('Draggable - unconnected', () => {
         marginLeft: dimension.placeholder.margin.left,
         marginRight: dimension.placeholder.margin.right,
         display: dimension.placeholder.display,
+        flexShrink: '0',
+        flexGrow: '0',
         boxSizing: 'border-box',
         pointerEvents: 'none',
       });

--- a/test/unit/view/unconnected-draggable.spec.js
+++ b/test/unit/view/unconnected-draggable.spec.js
@@ -69,7 +69,7 @@ const droppable: DroppableDimension = getDroppableDimension({
     id: droppableId,
     type,
   },
-  paddingBox: getArea({
+  borderBox: getArea({
     top: 0,
     right: 100,
     bottom: 200,
@@ -83,7 +83,7 @@ const dimension: DraggableDimension = getDraggableDimension({
     droppableId,
     index: 0,
   },
-  paddingBox: getArea({
+  borderBox: getArea({
     top: 0,
     right: 100,
     bottom: 100,
@@ -835,8 +835,8 @@ describe('Draggable - unconnected', () => {
       const props: Object = child.props();
 
       expect(props.style).toEqual({
-        width: dimension.placeholder.paddingBox.width,
-        height: dimension.placeholder.paddingBox.height,
+        width: dimension.placeholder.borderBox.width,
+        height: dimension.placeholder.borderBox.height,
         marginTop: dimension.placeholder.margin.top,
         marginBottom: dimension.placeholder.margin.bottom,
         marginLeft: dimension.placeholder.margin.left,

--- a/test/utils/dimension.js
+++ b/test/utils/dimension.js
@@ -29,7 +29,7 @@ const emptyForeignCrossAxisEnd: number = 300;
 
 export const makeScrollable = (droppable: DroppableDimension, amount?: number = 20) => {
   const axis: Axis = droppable.axis;
-  const paddingBox: Area = droppable.client.paddingBox;
+  const borderBox: Area = droppable.client.borderBox;
 
   const horizontalGrowth: number = axis === vertical ? 0 : amount;
   const verticalGrowth: number = axis === vertical ? amount : 0;
@@ -38,17 +38,17 @@ export const makeScrollable = (droppable: DroppableDimension, amount?: number = 
   // this will leave 10px of scrollable area.
   // only expanding on one axis
   const newPaddingBox: Area = getArea({
-    top: paddingBox.top,
-    left: paddingBox.left,
+    top: borderBox.top,
+    left: borderBox.left,
     // growing the client to account for the scrollable area
-    right: paddingBox.right + horizontalGrowth,
-    bottom: paddingBox.bottom + verticalGrowth,
+    right: borderBox.right + horizontalGrowth,
+    bottom: borderBox.bottom + verticalGrowth,
   });
 
   // add scroll space on the main axis
   const scrollSize = {
-    width: paddingBox.width + horizontalGrowth,
-    height: paddingBox.height + verticalGrowth,
+    width: borderBox.width + horizontalGrowth,
+    height: borderBox.height + verticalGrowth,
   };
 
   return getDroppableDimension({
@@ -57,9 +57,9 @@ export const makeScrollable = (droppable: DroppableDimension, amount?: number = 
     padding,
     margin,
     windowScroll,
-    paddingBox: newPaddingBox,
+    borderBox: newPaddingBox,
     closest: {
-      framePaddingBox: paddingBox,
+      frameBorderBox: borderBox,
       scrollWidth: scrollSize.width,
       scrollHeight: scrollSize.height,
       scroll: { x: 0, y: 0 },
@@ -147,7 +147,7 @@ export const getPreset = (axis?: Axis = vertical) => {
     padding,
     margin,
     windowScroll,
-    paddingBox: getArea({
+    borderBox: getArea({
       // would be 0 but pushed forward by margin
       [axis.start]: 10,
       [axis.crossAxisStart]: crossAxisStart,
@@ -165,7 +165,7 @@ export const getPreset = (axis?: Axis = vertical) => {
     margin,
     windowScroll,
     direction: axis.direction,
-    paddingBox: getArea({
+    borderBox: getArea({
       // would be 0 but pushed forward by margin
       [axis.start]: 10,
       [axis.crossAxisStart]: foreignCrossAxisStart,
@@ -183,7 +183,7 @@ export const getPreset = (axis?: Axis = vertical) => {
     margin,
     windowScroll,
     direction: axis.direction,
-    paddingBox: getArea({
+    borderBox: getArea({
       // would be 0 but pushed forward by margin
       [axis.start]: 10,
       [axis.crossAxisStart]: emptyForeignCrossAxisStart,
@@ -201,7 +201,7 @@ export const getPreset = (axis?: Axis = vertical) => {
     },
     margin,
     windowScroll,
-    paddingBox: getArea({
+    borderBox: getArea({
       // starting at start of home
       [axis.start]: 10,
       [axis.crossAxisStart]: crossAxisStart,
@@ -219,7 +219,7 @@ export const getPreset = (axis?: Axis = vertical) => {
     // pushed forward by margin of inHome1
     margin,
     windowScroll,
-    paddingBox: getArea({
+    borderBox: getArea({
       [axis.start]: 30,
       [axis.crossAxisStart]: crossAxisStart,
       [axis.crossAxisEnd]: crossAxisEnd,
@@ -236,7 +236,7 @@ export const getPreset = (axis?: Axis = vertical) => {
     margin,
     windowScroll,
     // pushed forward by margin of inHome2
-    paddingBox: getArea({
+    borderBox: getArea({
       [axis.start]: 60,
       [axis.crossAxisStart]: crossAxisStart,
       [axis.crossAxisEnd]: crossAxisEnd,
@@ -253,7 +253,7 @@ export const getPreset = (axis?: Axis = vertical) => {
     // pushed forward by margin of inHome3
     margin,
     windowScroll,
-    paddingBox: getArea({
+    borderBox: getArea({
       [axis.start]: 100,
       [axis.crossAxisStart]: crossAxisStart,
       [axis.crossAxisEnd]: crossAxisEnd,
@@ -270,7 +270,7 @@ export const getPreset = (axis?: Axis = vertical) => {
     },
     margin,
     windowScroll,
-    paddingBox: getArea({
+    borderBox: getArea({
       [axis.start]: 10,
       [axis.crossAxisStart]: foreignCrossAxisStart,
       [axis.crossAxisEnd]: foreignCrossAxisEnd,
@@ -287,7 +287,7 @@ export const getPreset = (axis?: Axis = vertical) => {
     // pushed forward by margin of inForeign1
     margin,
     windowScroll,
-    paddingBox: getArea({
+    borderBox: getArea({
       [axis.start]: 30,
       [axis.crossAxisStart]: foreignCrossAxisStart,
       [axis.crossAxisEnd]: foreignCrossAxisEnd,
@@ -304,7 +304,7 @@ export const getPreset = (axis?: Axis = vertical) => {
     margin,
     windowScroll,
     // pushed forward by margin of inForeign2
-    paddingBox: getArea({
+    borderBox: getArea({
       [axis.start]: 60,
       [axis.crossAxisStart]: foreignCrossAxisStart,
       [axis.crossAxisEnd]: foreignCrossAxisEnd,
@@ -321,7 +321,7 @@ export const getPreset = (axis?: Axis = vertical) => {
     margin,
     windowScroll,
     // pushed forward by margin of inForeign3
-    paddingBox: getArea({
+    borderBox: getArea({
       [axis.start]: 100,
       [axis.crossAxisStart]: foreignCrossAxisStart,
       [axis.crossAxisEnd]: foreignCrossAxisEnd,


### PR DESCRIPTION
## Change 1: placeholder

When a placeholder is placed, it can be collapsed by flex siblings as it might have a smaller 'width' property. By avoiding flexshrink and flexgrow we avoid visual jank.

Use case:

- have multiple draggables side by side (horizontal list). They need to have a width property (say '200px')
- the draggables are flex siblings
- resize the screen so that the items need to shrink a little (so they are now ~150px)
- When you start a drag we give the placeholder the current size of 150px
- The placeholder is then collapsed as it has a lower base width (150px) then the other flex children which have 200px.

By opting out of flex-grow and flex-shrink on the placeholder we avoid the placeholder being pushed or pulled by flex siblings

## Change 2: internal box model cleanup

I have gone deep and improved the internal box model to be more accurate