### PR TITLE
replace react-motion with react-spring

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "dist/react-beautiful-dnd.js": {
-    "bundled": 399077,
-    "minified": 155345,
-    "gzipped": 46468
+    "bundled": 346612,
+    "minified": 136359,
+    "gzipped": 39394
   },
   "dist/react-beautiful-dnd.min.js": {
-    "bundled": 360429,
-    "minified": 138877,
-    "gzipped": 41518
+    "bundled": 308115,
+    "minified": 120270,
+    "gzipped": 34685
   },
   "dist/react-beautiful-dnd.esm.js": {
-    "bundled": 176172,
-    "minified": 88689,
-    "gzipped": 22490,
+    "bundled": 176294,
+    "minified": 88740,
+    "gzipped": 22529,
     "treeshaked": {
-      "rollup": 77412,
-      "webpack": 78994
+      "rollup": 77453,
+      "webpack": 79052
     }
   }
 }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "dist/react-beautiful-dnd.js": {
-    "bundled": 372617,
-    "minified": 142790,
-    "gzipped": 40319
+    "bundled": 388896,
+    "minified": 154817,
+    "gzipped": 46416
   },
   "dist/react-beautiful-dnd.min.js": {
-    "bundled": 333972,
-    "minified": 126619,
-    "gzipped": 35549
+    "bundled": 350133,
+    "minified": 138467,
+    "gzipped": 41546
   },
   "dist/react-beautiful-dnd.esm.js": {
-    "bundled": 176774,
-    "minified": 88946,
-    "gzipped": 22589,
+    "bundled": 175984,
+    "minified": 88541,
+    "gzipped": 22448,
     "treeshaked": {
-      "rollup": 77588,
-      "webpack": 79186
+      "rollup": 77293,
+      "webpack": 78875
     }
   }
 }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "dist/react-beautiful-dnd.js": {
-    "bundled": 388896,
-    "minified": 154817,
-    "gzipped": 46416
+    "bundled": 399077,
+    "minified": 155345,
+    "gzipped": 46468
   },
   "dist/react-beautiful-dnd.min.js": {
-    "bundled": 350133,
-    "minified": 138467,
-    "gzipped": 41546
+    "bundled": 360429,
+    "minified": 138877,
+    "gzipped": 41518
   },
   "dist/react-beautiful-dnd.esm.js": {
-    "bundled": 175984,
-    "minified": 88541,
-    "gzipped": 22448,
+    "bundled": 176172,
+    "minified": 88689,
+    "gzipped": 22490,
     "treeshaked": {
-      "rollup": 77293,
-      "webpack": 78875
+      "rollup": 77412,
+      "webpack": 78994
     }
   }
 }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "dist/react-beautiful-dnd.js": {
-    "bundled": 346612,
-    "minified": 136359,
-    "gzipped": 39394
+    "bundled": 346059,
+    "minified": 136107,
+    "gzipped": 39322
   },
   "dist/react-beautiful-dnd.min.js": {
-    "bundled": 308115,
-    "minified": 120270,
-    "gzipped": 34685
+    "bundled": 307562,
+    "minified": 120018,
+    "gzipped": 34613
   },
   "dist/react-beautiful-dnd.esm.js": {
-    "bundled": 176294,
-    "minified": 88740,
-    "gzipped": 22529,
+    "bundled": 176287,
+    "minified": 88729,
+    "gzipped": 22524,
     "treeshaked": {
-      "rollup": 77453,
-      "webpack": 79052
+      "rollup": 77452,
+      "webpack": 79034
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "prop-types": "^15.6.0",
     "raf-schd": "^2.1.1",
     "react-redux": "^5.0.6",
-    "react-spring": "^4.1.5",
+    "react-spring": "4.1.8-beta.2",
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0",
     "reselect": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "memoize-one": "^3.1.1",
     "prop-types": "^15.6.0",
     "raf-schd": "^2.1.1",
-    "react-motion": "^0.5.2",
     "react-redux": "^5.0.6",
+    "react-spring": "^4.1.3",
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0",
     "reselect": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "prop-types": "^15.6.0",
     "raf-schd": "^2.1.1",
     "react-redux": "^5.0.6",
-    "react-spring": "^4.1.3",
+    "react-spring": "^4.1.5",
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0",
     "reselect": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "prop-types": "^15.6.0",
     "raf-schd": "^2.1.1",
     "react-redux": "^5.0.6",
-    "react-spring": "4.1.8-beta.2",
+    "react-spring-numerical": "^1.0.3",
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0",
     "reselect": "^3.0.1"

--- a/src/view/animation.js
+++ b/src/view/animation.js
@@ -4,6 +4,8 @@ export const physics = (() => {
     tension: 1000, // fast
     // tension: 100, // slow
     friction: 60,
+    restSpeedThreshold: 0.9,
+    restDisplacementThreshold: 0.9,
   };
 
   const standard = {

--- a/src/view/animation.js
+++ b/src/view/animation.js
@@ -1,22 +1,18 @@
 // @flow
-import type { SpringHelperConfig } from 'react-motion/lib/Types';
-
 export const physics = (() => {
   const base = {
-    stiffness: 1000, // fast
-    // stiffness: 100, // slow
-    damping: 60,
-    // precision: 0.5,
-    precision: 0.99,
+    tension: 1000, // fast
+    // tension: 100, // slow
+    friction: 60,
   };
 
-  const standard: SpringHelperConfig = {
+  const standard = {
     ...base,
   };
 
-  const fast: SpringHelperConfig = {
+  const fast = {
     ...base,
-    stiffness: base.stiffness * 2,
+    stiffness: base.tension * 2,
   };
 
   return { standard, fast };

--- a/src/view/animation.js
+++ b/src/view/animation.js
@@ -4,8 +4,8 @@ export const physics = (() => {
     tension: 1000, // fast
     // tension: 100, // slow
     friction: 60,
-    restSpeedThreshold: 0.9,
-    restDisplacementThreshold: 0.9,
+    restSpeedThreshold: 0.9999,
+    restDisplacementThreshold: 0.9999,
   };
 
   const standard = {

--- a/src/view/moveable/moveable.jsx
+++ b/src/view/moveable/moveable.jsx
@@ -1,6 +1,6 @@
 // @flow
 import React, { Component } from 'react';
-import Spring from 'react-spring/dist/NumericalSpring';
+import { Spring } from 'react-spring-numerical';
 import { physics } from '../animation';
 import type { Position } from '../../types';
 import type { Props, DefaultProps, Style } from './moveable-types';

--- a/src/view/moveable/moveable.jsx
+++ b/src/view/moveable/moveable.jsx
@@ -1,6 +1,6 @@
 // @flow
 import React, { Component } from 'react';
-import { Spring } from 'react-spring';
+import Spring from 'react-spring/dist/NumericalSpring';
 import { physics } from '../animation';
 import type { Position } from '../../types';
 import type { Props, DefaultProps, Style } from './moveable-types';
@@ -33,12 +33,12 @@ export default class Movable extends Component<Props> {
     const speed = this.props.speed;
     const destination = this.props.destination;
     const immediate = speed === 'INSTANT';
-    const from = { transform: `translate(${origin.x}px, ${origin.y}px)` };
-    const to = { transform: `translate(${destination.x}px, ${destination.y}px)` };
+    const from = { x: origin.x, y: origin.y };
+    const to = { x: destination.x, y: destination.y };
     const config = speed === 'FAST' ? physics.fast : physics.standard;
     return (
       <Spring immediate={immediate} config={config} from={from} to={to} onRest={this.onRest}>
-        {this.props.children}
+        {({ x, y }) => this.props.children({ transform: `translate3d(${x}px, ${y}px, 0)` })}
       </Spring>
     );
   }

--- a/src/view/moveable/moveable.jsx
+++ b/src/view/moveable/moveable.jsx
@@ -13,9 +13,6 @@ export default class Movable extends Component<Props> {
       return;
     }
 
-    // This needs to be async otherwise Motion will not re-execute if
-    // offset or start change
-
     // Could check to see if another move has started
     // and abort the previous onMoveEnd
     setTimeout(() => onMoveEnd());

--- a/src/view/moveable/moveable.jsx
+++ b/src/view/moveable/moveable.jsx
@@ -3,9 +3,19 @@ import React, { Component } from 'react';
 import { Spring } from 'react-spring';
 import { physics } from '../animation';
 import type { Position } from '../../types';
-import type { Props, Style } from './moveable-types';
+import type { Props, DefaultProps, Style } from './moveable-types';
+
+const origin: Position = {
+  x: 0,
+  y: 0,
+};
 
 export default class Movable extends Component<Props> {
+  /* eslint-disable react/sort-comp */
+
+  static defaultProps: DefaultProps = {
+    destination: origin,
+  }
   /* eslint-enable */
   onRest = () => {
     const { onMoveEnd } = this.props;
@@ -21,9 +31,9 @@ export default class Movable extends Component<Props> {
 
   render() {
     const speed = this.props.speed;
-    const destination: Position = this.props.destination;
+    const destination = this.props.destination;
     const immediate = speed === 'INSTANT';
-    const from = { transform: `translate(0px, 0px)` };
+    const from = { transform: `translate(${origin.x}px, ${origin.y}px)` };
     const to = { transform: `translate(${destination.x}px, ${destination.y}px)` };
     const config = speed === 'FAST' ? physics.fast : physics.standard;
     return (

--- a/src/view/moveable/moveable.jsx
+++ b/src/view/moveable/moveable.jsx
@@ -1,51 +1,11 @@
 // @flow
 import React, { Component } from 'react';
-import { Motion, spring } from 'react-motion';
+import { Spring } from 'react-spring';
 import { physics } from '../animation';
-import type { Position } from '../../types';
-import type { Props, DefaultProps, Style } from './moveable-types';
-
-type PositionLike = {|
-  x: any,
-  y: any,
-|};
-
-const origin: Position = {
-  x: 0,
-  y: 0,
-};
-
-const noMovement: Style = {
-  transform: null,
-};
-
-const isAtOrigin = (point: PositionLike): boolean =>
-  point.x === origin.x && point.y === origin.y;
-
-const getStyle = (isNotMoving: boolean, x: number, y: number): Style => {
-  if (isNotMoving) {
-    return noMovement;
-  }
-
-  const point: Position = { x, y };
-  // not applying any transforms when not moving
-  if (isAtOrigin(point)) {
-    return noMovement;
-  }
-  const style: Style = {
-    transform: `translate(${point.x}px, ${point.y}px)`,
-  };
-  return style;
-};
+import type { Props, Style } from './moveable-types';
 
 export default class Movable extends Component<Props> {
-  /* eslint-disable react/sort-comp */
-
-  static defaultProps: DefaultProps = {
-    destination: origin,
-  }
   /* eslint-enable */
-
   onRest = () => {
     const { onMoveEnd } = this.props;
 
@@ -61,40 +21,16 @@ export default class Movable extends Component<Props> {
     setTimeout(() => onMoveEnd());
   }
 
-  getFinal = (): PositionLike => {
-    const destination: Position = this.props.destination;
-    const speed = this.props.speed;
-
-    if (speed === 'INSTANT') {
-      return destination;
-    }
-
-    const selected = speed === 'FAST' ? physics.fast : physics.standard;
-
-    return {
-      x: spring(destination.x, selected),
-      y: spring(destination.y, selected),
-    };
-  }
-
   render() {
-    const final = this.getFinal();
-
-    // bug with react-motion: https://github.com/chenglou/react-motion/issues/437
-    // even if both defaultStyle and style are {x: 0, y: 0 } if there was
-    // a previous animation it uses the last value rather than the final value
-    const isNotMoving: boolean = isAtOrigin(final);
-
+    const { destination, speed, children } = this.props
+    const immediate = speed === 'INSTANT';
+    const from = { transform: `translate(0px, 0px)` }
+    const to = { transform: `translate(${destination.x}px, ${destination.y}px)` }
+    const config = speed === 'FAST' ? physics.fast : physics.standard;
     return (
-      // Expecting a flow error
-      // React Motion type: children: (interpolatedStyle: PlainStyle) => ReactElement
-      // Our type: children: (Position) => (Style) => React.Node
-      <Motion defaultStyle={origin} style={final} onRest={this.onRest}>
-        {(current: { [string]: number }): any =>
-          this.props.children(
-            getStyle(isNotMoving, current.x, current.y)
-          )}
-      </Motion>
+      <Spring immediate={immediate} config={config} from={from} to={to} onRest={this.onRest}>
+        {children}
+      </Spring>
     );
   }
 }

--- a/src/view/moveable/moveable.jsx
+++ b/src/view/moveable/moveable.jsx
@@ -2,6 +2,7 @@
 import React, { Component } from 'react';
 import { Spring } from 'react-spring';
 import { physics } from '../animation';
+import type { Position } from '../../types';
 import type { Props, Style } from './moveable-types';
 
 export default class Movable extends Component<Props> {
@@ -19,14 +20,15 @@ export default class Movable extends Component<Props> {
   }
 
   render() {
-    const { destination, speed, children } = this.props
+    const speed = this.props.speed;
+    const destination: Position = this.props.destination;
     const immediate = speed === 'INSTANT';
-    const from = { transform: `translate(0px, 0px)` }
-    const to = { transform: `translate(${destination.x}px, ${destination.y}px)` }
+    const from = { transform: `translate(0px, 0px)` };
+    const to = { transform: `translate(${destination.x}px, ${destination.y}px)` };
     const config = speed === 'FAST' ? physics.fast : physics.standard;
     return (
       <Spring immediate={immediate} config={config} from={from} to={to} onRest={this.onRest}>
-        {children}
+        {this.props.children}
       </Spring>
     );
   }

--- a/test/unit/view/moveable.spec.js
+++ b/test/unit/view/moveable.spec.js
@@ -119,7 +119,7 @@ describe('Moveable', () => {
 
   it('should return no movement if the item is at the origin', () => {
     const expected: Style = {
-      transform: null,
+      transform: 'translate(0px, 0px)',
     };
 
     moveTo({ x: 0, y: 0 });

--- a/test/unit/view/unconnected-draggable.spec.js
+++ b/test/unit/view/unconnected-draggable.spec.js
@@ -869,7 +869,7 @@ describe('Draggable - unconnected', () => {
       const notDraggingProvided: Provided = getLastCall(notDraggingMock)[0].provided;
       const notDraggingStyle: NotDraggingStyle = (notDraggingProvided.draggableProps.style : any);
       const notDraggingExpected: NotDraggingStyle = {
-        transform: null,
+        transform: 'translate(0px, 0px)',
         transition: null,
       };
 
@@ -913,7 +913,7 @@ describe('Draggable - unconnected', () => {
         margin: 0,
         pointerEvents: 'none',
         transition: 'none',
-        transform: null,
+        transform: 'translate(0px, 0px)',
         zIndex: zIndexOptions.dragging,
       };
 
@@ -1124,7 +1124,7 @@ describe('Draggable - unconnected', () => {
       const droppingStyle: DraggingStyle = (droppingProvided.draggableProps.style : any);
       const expectedNotDraggingStyle: NotDraggingStyle = {
         transition: null,
-        transform: null,
+        transform: 'translate(0px, 0px)',
       };
 
       expect(droppingStyle.zIndex).toBe(zIndexOptions.dropAnimating);
@@ -1187,7 +1187,7 @@ describe('Draggable - unconnected', () => {
 
     it('should not be moved from its original position', () => {
       const style: NotDraggingStyle = {
-        transform: null,
+        transform: 'translate(0px, 0px)',
         transition: null,
       };
 
@@ -1221,7 +1221,7 @@ describe('Draggable - unconnected', () => {
 
       it('should have base inline styles', () => {
         const expected: NotDraggingStyle = {
-          transform: null,
+          transform: 'translate(0px, 0px)',
           transition: null,
         };
 
@@ -1257,7 +1257,7 @@ describe('Draggable - unconnected', () => {
           const expected: NotDraggingStyle = {
             // relying on the style marshal
             transition: null,
-            transform: null,
+            transform: 'translate(0px, 0px)',
           };
           expect(provided.draggableProps.style).toEqual(expected);
         });
@@ -1276,7 +1276,7 @@ describe('Draggable - unconnected', () => {
           };
           const expected: NotDraggingStyle = {
             transition: 'none',
-            transform: null,
+            transform: 'translate(0px, 0px)',
           };
 
           const customWrapper = mountDraggable({

--- a/yarn.lock
+++ b/yarn.lock
@@ -5673,6 +5673,10 @@ nopt@^4.0.1:
     abbrev "1"
     osenv "^0.1.4"
 
+normalize-css-color@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/normalize-css-color/-/normalize-css-color-1.0.2.tgz#02991e97cccec6623fe573afbbf0de6a1f3e9f8d"
+
 normalize-package-data@^2.3.2:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
@@ -6585,12 +6589,6 @@ raf-stub@^2.0.2:
   dependencies:
     performance-now "2.1.0"
 
-raf@^3.1.0:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/raf/-/raf-3.3.2.tgz#0c13be0b5b49b46f76d6669248d527cf2b02fe27"
-  dependencies:
-    performance-now "^2.1.0"
-
 raf@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.0.tgz#a28876881b4bc2ca9117d4138163ddb80f781575"
@@ -6742,14 +6740,6 @@ react-modal@^3.3.2:
     prop-types "^15.5.10"
     warning "^3.0.0"
 
-react-motion@^0.5.2:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/react-motion/-/react-motion-0.5.2.tgz#0dd3a69e411316567927917c6626551ba0607316"
-  dependencies:
-    performance-now "^0.2.0"
-    prop-types "^15.5.8"
-    raf "^3.1.0"
-
 react-reconciler@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.7.0.tgz#9614894103e5f138deeeb5eabaf3ee80eb1d026d"
@@ -6777,6 +6767,12 @@ react-split-pane@^0.1.77:
     inline-style-prefixer "^3.0.6"
     prop-types "^15.5.10"
     react-style-proptype "^3.0.0"
+
+react-spring@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-4.1.3.tgz#c4e0bbefd9ec61f3d931c77b20cf8275393f001d"
+  dependencies:
+    normalize-css-color "^1.0.2"
 
 react-style-proptype@^3.0.0:
   version "3.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2404,13 +2404,6 @@ create-react-class@^15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-create-react-context@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.2.tgz#9836542f9aaa22868cd7d4a6f82667df38019dca"
-  dependencies:
-    fbjs "^0.8.0"
-    gud "^1.0.0"
-
 cross-env@^5.1.3:
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.1.4.tgz#f61c14291f7cc653bb86457002ea80a04699d022"
@@ -3499,7 +3492,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.0, fbjs@^0.8.12, fbjs@^0.8.16, fbjs@^0.8.5, fbjs@^0.8.9:
+fbjs@^0.8.12, fbjs@^0.8.16, fbjs@^0.8.5, fbjs@^0.8.9:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
@@ -3879,10 +3872,6 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4:
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
-
-gud@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
 
 gzip-size@3.0.0:
   version "3.0.0"
@@ -6782,12 +6771,11 @@ react-split-pane@^0.1.77:
     prop-types "^15.5.10"
     react-style-proptype "^3.0.0"
 
-react-spring@4.1.8-beta.2:
-  version "4.1.8-beta.2"
-  resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-4.1.8-beta.2.tgz#d84dc0cf08cc79998281f39db3e641d2c34e18bb"
+react-spring-numerical@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/react-spring-numerical/-/react-spring-numerical-1.0.3.tgz#62937a9c4ecab7327864889c2f79473a2aaf725a"
   dependencies:
     "@babel/runtime" "^7.0.0-beta.44"
-    create-react-context "^0.2.2"
 
 react-style-proptype@^3.0.0:
   version "3.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -58,6 +58,13 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@babel/runtime@^7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.44.tgz#ea5ad6c6fe9a2c1187b025bf42424d28050ee696"
+  dependencies:
+    core-js "^2.5.3"
+    regenerator-runtime "^0.11.1"
+
 "@babel/template@7.0.0-beta.42":
   version "7.0.0-beta.42"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.42.tgz#7186d4e70d44cdec975049ba0a73bdaf5cdee052"
@@ -2397,6 +2404,13 @@ create-react-class@^15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+create-react-context@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.2.tgz#9836542f9aaa22868cd7d4a6f82667df38019dca"
+  dependencies:
+    fbjs "^0.8.0"
+    gud "^1.0.0"
+
 cross-env@^5.1.3:
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.1.4.tgz#f61c14291f7cc653bb86457002ea80a04699d022"
@@ -3485,7 +3499,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.12, fbjs@^0.8.16, fbjs@^0.8.5, fbjs@^0.8.9:
+fbjs@^0.8.0, fbjs@^0.8.12, fbjs@^0.8.16, fbjs@^0.8.5, fbjs@^0.8.9:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
@@ -3865,6 +3879,10 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4:
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
+
+gud@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
 
 gzip-size@3.0.0:
   version "3.0.0"
@@ -6768,10 +6786,12 @@ react-split-pane@^0.1.77:
     prop-types "^15.5.10"
     react-style-proptype "^3.0.0"
 
-react-spring@^4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-4.1.3.tgz#c4e0bbefd9ec61f3d931c77b20cf8275393f001d"
+react-spring@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-4.1.5.tgz#4c93230a153388fb0eb7f90c582111f93f52e5d7"
   dependencies:
+    "@babel/runtime" "^7.0.0-beta.44"
+    create-react-context "^0.2.2"
     normalize-css-color "^1.0.2"
 
 react-style-proptype@^3.0.0:
@@ -6959,7 +6979,7 @@ regenerator-runtime@^0.10.5:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
-regenerator-runtime@^0.11.0:
+regenerator-runtime@^0.11.0, regenerator-runtime@^0.11.1:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5691,10 +5691,6 @@ nopt@^4.0.1:
     abbrev "1"
     osenv "^0.1.4"
 
-normalize-css-color@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/normalize-css-color/-/normalize-css-color-1.0.2.tgz#02991e97cccec6623fe573afbbf0de6a1f3e9f8d"
-
 normalize-package-data@^2.3.2:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
@@ -6786,13 +6782,12 @@ react-split-pane@^0.1.77:
     prop-types "^15.5.10"
     react-style-proptype "^3.0.0"
 
-react-spring@^4.1.5:
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-4.1.5.tgz#4c93230a153388fb0eb7f90c582111f93f52e5d7"
+react-spring@4.1.8-beta.2:
+  version "4.1.8-beta.2"
+  resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-4.1.8-beta.2.tgz#d84dc0cf08cc79998281f39db3e641d2c34e18bb"
   dependencies:
     "@babel/runtime" "^7.0.0-beta.44"
     create-react-context "^0.2.2"
-    normalize-css-color "^1.0.2"
 
 react-style-proptype@^3.0.0:
   version "3.2.1"


### PR DESCRIPTION
This PR removes react-motion and replaces it with react-spring (see: https://github.com/atlassian/react-beautiful-dnd/issues/437).

Since the api is almost the same it was pretty straight forward. I removed react-motion specific work arounds as well.

In a later stage we can think about how to enable native rendering. 