### PR TITLE
Removed PureComponent

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "memoize-one": "^3.1.1",
     "prop-types": "^15.6.0",
     "raf-schd": "^2.1.1",
+    "react-addons-shallow-compare": "^15.6.2",
     "react-motion": "^0.5.2",
     "react-redux": "^5.0.6",
     "redux": "^3.7.2",

--- a/src/view/placeholder/placeholder.jsx
+++ b/src/view/placeholder/placeholder.jsx
@@ -1,12 +1,15 @@
 // @flow
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import type { Placeholder as PlaceholderType } from '../../types';
+import shallowCompare from 'react-addons-shallow-compare';
 
 type Props = {|
   placeholder: PlaceholderType,
-|}
+|};
 
-export default class Placeholder extends PureComponent<Props> {
+export default class Placeholder extends Component<Props> {
+  shouldComponentUpdate = (nextProps, nextState) => !shallowCompare(this, nextProps, this.props);
+
   render() {
     const placeholder: PlaceholderType = this.props.placeholder;
     const { borderBox, margin, display, tagName } = placeholder;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3513,7 +3513,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.12, fbjs@^0.8.16, fbjs@^0.8.5, fbjs@^0.8.9:
+fbjs@^0.8.12, fbjs@^0.8.16, fbjs@^0.8.4, fbjs@^0.8.5, fbjs@^0.8.9:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
@@ -6681,6 +6681,13 @@ rc@^1.1.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-addons-shallow-compare@^15.6.2:
+  version "15.6.2"
+  resolved "https://registry.npmjs.org/react-addons-shallow-compare/-/react-addons-shallow-compare-15.6.2.tgz#198a00b91fc37623db64a28fd17b596ba362702f"
+  dependencies:
+    fbjs "^0.8.4"
+    object-assign "^4.1.0"
 
 react-dev-utils@^5.0.0:
   version "5.0.1"


### PR DESCRIPTION
Removed `PureComponent` and replaced with `react-addons-shallow-compare` so this library works in start+ legacy