### PR TITLE
fix(types): compatible with csstype

### DIFF
--- a/README.md
+++ b/README.md
@@ -986,11 +986,11 @@ type DraggingStyle = {|
   left: number,
   margin: 0,
   transition: 'none',
-  transform: ?string,
+  transform?: string,
   zIndex: ZIndex,
 |}
 type NotDraggingStyle = {|
-  transition: ?string,
+  transition?: string,
   transition: null | 'none',
 |}
 ```
@@ -1342,12 +1342,12 @@ type DraggingStyle = {|
   left: number,
   margin: 0,
   transition: 'none',
-  transform: ?string,
+  transform?: string,
   zIndex: ZIndex,
 |}
 type NotDraggingStyle = {|
-  transition: ?string,
-  transition: null | 'none',
+  transition?: string,
+  transition?: 'none',
 |}
 
 type DragHandleProps = {|

--- a/src/view/draggable/draggable-types.js
+++ b/src/view/draggable/draggable-types.js
@@ -60,7 +60,7 @@ export type DraggingStyle = {|
   transition: 'none',
 
   // Move the element in response to a user dragging
-  transform: ?string,
+  transform?: string,
 
   // When dragging or dropping we control the z-index to ensure that
   // the layering is correct
@@ -75,10 +75,10 @@ export type DraggingStyle = {|
 |}
 
 export type NotDraggingStyle = {|
-  transform: ?string,
-  // null: use the global animation style
-  // none: skip animation (used in certain displacement situations)
-  transition: null | 'none',
+  transform?: string,
+  // missing: use the global animation style
+  // 'none': skip animation (used in certain displacement situations)
+  transition?: 'none',
 |}
 
 export type DraggableStyle = DraggingStyle | NotDraggingStyle;
@@ -91,7 +91,7 @@ export type ZIndexOptions = {|
 // Props that can be spread onto the element directly
 export type DraggableProps = {|
   // inline style
-  style: ?DraggableStyle,
+  style?: DraggableStyle,
   // used for shared global styles
   'data-react-beautiful-dnd-draggable': string,
 |}

--- a/src/view/draggable/draggable.jsx
+++ b/src/view/draggable/draggable.jsx
@@ -205,7 +205,7 @@ export default class Draggable extends Component<Props> {
         margin: 0,
         pointerEvents: 'none',
         transition: 'none',
-        transform: movementStyle.transform ? `${movementStyle.transform}` : null,
+        transform: movementStyle.transform ? `${movementStyle.transform}` : undefined,
       };
       return style;
     }
@@ -216,7 +216,7 @@ export default class Draggable extends Component<Props> {
       const style: NotDraggingStyle = {
         transform: movementStyle.transform,
         // use the global animation for animation - or opt out of it
-        transition: shouldAnimateDisplacement ? null : 'none',
+        transition: shouldAnimateDisplacement ? undefined : 'none',
         // transition: css.outOfTheWay,
       };
       return style;

--- a/src/view/moveable/moveable-types.js
+++ b/src/view/moveable/moveable-types.js
@@ -5,7 +5,7 @@ import { type Position } from 'css-box-model';
 export type Speed = 'INSTANT' | 'STANDARD' | 'FAST';
 
 export type Style = {|
-  transform: ?string,
+  transform?: string,
 |}
 
 export type Props = {|

--- a/src/view/moveable/moveable.jsx
+++ b/src/view/moveable/moveable.jsx
@@ -16,7 +16,7 @@ const origin: Position = {
 };
 
 const noMovement: Style = {
-  transform: null,
+  transform: undefined
 };
 
 const isAtOrigin = (point: PositionLike): boolean =>

--- a/test/unit/view/moveable.spec.js
+++ b/test/unit/view/moveable.spec.js
@@ -119,7 +119,7 @@ describe('Moveable', () => {
 
   it('should return no movement if the item is at the origin', () => {
     const expected: Style = {
-      transform: null,
+      transform: undefined,
     };
 
     moveTo({ x: 0, y: 0 });

--- a/test/unit/view/unconnected-draggable.spec.js
+++ b/test/unit/view/unconnected-draggable.spec.js
@@ -877,8 +877,8 @@ describe('Draggable - unconnected', () => {
       const notDraggingProvided: Provided = getLastCall(notDraggingMock)[0].provided;
       const notDraggingStyle: NotDraggingStyle = (notDraggingProvided.draggableProps.style : any);
       const notDraggingExpected: NotDraggingStyle = {
-        transform: null,
-        transition: null,
+        transform: undefined,
+        transition: undefined,
       };
 
       expect(draggingStyle.zIndex).toBe(zIndexOptions.dragging);
@@ -921,7 +921,7 @@ describe('Draggable - unconnected', () => {
         margin: 0,
         pointerEvents: 'none',
         transition: 'none',
-        transform: null,
+        transform: undefined,
         zIndex: zIndexOptions.dragging,
       };
 
@@ -1128,8 +1128,8 @@ describe('Draggable - unconnected', () => {
       const droppingProvided: Provided = getLastCall(dropAnimatingMock)[0].provided;
       const droppingStyle: DraggingStyle = (droppingProvided.draggableProps.style : any);
       const expectedNotDraggingStyle: NotDraggingStyle = {
-        transition: null,
-        transform: null,
+        transition: undefined,
+        transform: undefined,
       };
 
       expect(droppingStyle.zIndex).toBe(zIndexOptions.dropAnimating);
@@ -1192,8 +1192,8 @@ describe('Draggable - unconnected', () => {
 
     it('should not be moved from its original position', () => {
       const style: NotDraggingStyle = {
-        transform: null,
-        transition: null,
+        transform: undefined,
+        transition: undefined,
       };
 
       expect(provided.draggableProps.style).toEqual(style);
@@ -1226,8 +1226,8 @@ describe('Draggable - unconnected', () => {
 
       it('should have base inline styles', () => {
         const expected: NotDraggingStyle = {
-          transform: null,
-          transition: null,
+          transform: undefined,
+          transition: undefined,
         };
 
         expect(provided.draggableProps.style).toEqual(expected);
@@ -1261,8 +1261,8 @@ describe('Draggable - unconnected', () => {
         it('should return animate out of the way with css', () => {
           const expected: NotDraggingStyle = {
             // relying on the style marshal
-            transition: null,
-            transform: null,
+            transition: undefined,
+            transform: undefined,
           };
           expect(provided.draggableProps.style).toEqual(expected);
         });
@@ -1280,7 +1280,7 @@ describe('Draggable - unconnected', () => {
           };
           const expected: NotDraggingStyle = {
             transition: 'none',
-            transform: null,
+            transform: undefined,
           };
 
           const customWrapper = mountDraggable({
@@ -1332,7 +1332,7 @@ describe('Draggable - unconnected', () => {
         it('should animate out of the way with css', () => {
           const expected: NotDraggingStyle = {
             // use the style marshal global style
-            transition: null,
+            transition: undefined,
             transform: `translate(${offset.x}px, ${offset.y}px)`,
           };
 


### PR DESCRIPTION
Switch from Maybe types to optional properties. This makes the types compatible with `csstype`'s definition.

Currently the `style` object passed to consumers doesn't have a type compatible with React's intrinsic elements' `style` type. In general it's due to using `null` rather than `undefined`.