### PR TITLE
Use keyboard to move item between vertically stacked lists

### DIFF
--- a/src/state/axis.js
+++ b/src/state/axis.js
@@ -1,5 +1,5 @@
 // @flow
-import type { HorizontalAxis, VerticalAxis } from '../types';
+import type { Axis, HorizontalAxis, VerticalAxis } from '../types';
 
 export const vertical: VerticalAxis = {
   direction: 'vertical',
@@ -24,3 +24,10 @@ export const horizontal: HorizontalAxis = {
   crossAxisEnd: 'bottom',
   crossAxisSize: 'height',
 };
+
+export function oppositeAxis(axis: Axis) {
+  if (axis.direction === 'horizontal') {
+    return vertical;
+  }
+  return horizontal;
+}

--- a/src/state/move-cross-axis/get-best-cross-axis-droppable.js
+++ b/src/state/move-cross-axis/get-best-cross-axis-droppable.js
@@ -22,6 +22,7 @@ type GetBestDroppableArgs = {|
   // all the droppables in the system
   droppables: DroppableDimensionMap,
   viewport: Viewport,
+  axis: Axis,
 |}
 
 const getSafeClipped = (droppable: DroppableDimension): Rect => {
@@ -38,6 +39,7 @@ export default ({
   source,
   droppables,
   viewport,
+  axis = source.axis,
 }: GetBestDroppableArgs): ?DroppableDimension => {
   const sourceClipped: ?Rect = source.viewport.clippedPageMarginBox;
 
@@ -45,7 +47,6 @@ export default ({
     return null;
   }
 
-  const axis: Axis = source.axis;
   const isBetweenSourceClipped = isWithin(
     sourceClipped[axis.start],
     sourceClipped[axis.end]

--- a/src/state/move-cross-axis/get-best-cross-axis-droppable.js
+++ b/src/state/move-cross-axis/get-best-cross-axis-droppable.js
@@ -22,7 +22,7 @@ type GetBestDroppableArgs = {|
   // all the droppables in the system
   droppables: DroppableDimensionMap,
   viewport: Viewport,
-  axis: Axis,
+  customAxis?: Axis,
 |}
 
 const getSafeClipped = (droppable: DroppableDimension): Rect => {
@@ -39,7 +39,7 @@ export default ({
   source,
   droppables,
   viewport,
-  axis = source.axis,
+  customAxis,
 }: GetBestDroppableArgs): ?DroppableDimension => {
   const sourceClipped: ?Rect = source.viewport.clippedPageMarginBox;
 
@@ -47,6 +47,7 @@ export default ({
     return null;
   }
 
+  const axis: Axis = customAxis || source.axis;
   const isBetweenSourceClipped = isWithin(
     sourceClipped[axis.start],
     sourceClipped[axis.end]

--- a/src/state/move-cross-axis/index.js
+++ b/src/state/move-cross-axis/index.js
@@ -16,7 +16,9 @@ import type {
   DraggableLocation,
   DragImpact,
   Viewport,
+  Axis,
 } from '../../types';
+import { oppositeAxis as makeOppositeAxis } from '../axis';
 
 type Args = {|
   isMovingForward: boolean,
@@ -35,6 +37,7 @@ type Args = {|
   previousImpact: ?DragImpact,
   // the current viewport
   viewport: Viewport,
+  oppositeAxis: boolean,
 |}
 
 export default ({
@@ -47,18 +50,20 @@ export default ({
   droppables,
   previousImpact,
   viewport,
+  oppositeAxis = false,
 }: Args): ?Result => {
   const draggable: DraggableDimension = draggables[draggableId];
   const source: DroppableDimension = droppables[droppableId];
 
+  const axis: Axis = oppositeAxis ? makeOppositeAxis(source.axis) : source.axis;
   // not considering the container scroll changes as container scrolling cancels a keyboard drag
-
   const destination: ?DroppableDimension = getBestCrossAxisDroppable({
     isMovingForward,
     pageBorderBoxCenter,
     source,
     droppables,
     viewport,
+    axis,
   });
 
   // nothing available to move to
@@ -71,7 +76,7 @@ export default ({
   );
 
   const target: ?DraggableDimension = getClosestDraggable({
-    axis: destination.axis,
+    axis,
     pageBorderBoxCenter,
     destination,
     insideDestination,

--- a/src/state/move-cross-axis/index.js
+++ b/src/state/move-cross-axis/index.js
@@ -37,7 +37,7 @@ type Args = {|
   previousImpact: ?DragImpact,
   // the current viewport
   viewport: Viewport,
-  oppositeAxis: boolean,
+  oppositeAxis?: boolean,
 |}
 
 export default ({
@@ -50,7 +50,7 @@ export default ({
   droppables,
   previousImpact,
   viewport,
-  oppositeAxis = false,
+  oppositeAxis,
 }: Args): ?Result => {
   const draggable: DraggableDimension = draggables[draggableId];
   const source: DroppableDimension = droppables[droppableId];
@@ -63,7 +63,7 @@ export default ({
     source,
     droppables,
     viewport,
-    axis,
+    customAxis: axis,
   });
 
   // nothing available to move to

--- a/src/state/reducer.js
+++ b/src/state/reducer.js
@@ -566,14 +566,17 @@ export default (state: State = clean('IDLE'), action: Action): State => {
       droppable,
       previousPageBorderBoxCenter,
       ...params,
-    }) || moveCrossAxis({
-      pageBorderBoxCenter: previousPageBorderBoxCenter,
-      droppableId,
-      home,
-      droppables: state.dimension.droppable,
-      oppositeAxis: true,
-      ...params,
-    });
+    }) || {
+      scrollJumpRequest: null,
+      ...moveCrossAxis({
+        pageBorderBoxCenter: previousPageBorderBoxCenter,
+        droppableId,
+        home,
+        droppables: state.dimension.droppable,
+        oppositeAxis: true,
+        ...params,
+      }),
+    };
 
     if (!result) {
       return state;


### PR DESCRIPTION
This adds possibility to move item to the next list (vertically) with same UP/DOWN buttons that used to move through the list itself. Fixes: https://github.com/atlassian/react-beautiful-dnd/issues/219

Solution is based on existing movement between different lists but adds opposite axis parameter.

Testing: add `flex-direction: column` to multi-drag/task-app.jsx#Container