### PR TITLE
Fix parent to child drops

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "dist/react-beautiful-dnd.js": {
-    "bundled": 400269,
-    "minified": 151652,
-    "gzipped": 43139
+    "bundled": 400507,
+    "minified": 151621,
+    "gzipped": 43147
   },
   "dist/react-beautiful-dnd.min.js": {
-    "bundled": 358556,
-    "minified": 134751,
-    "gzipped": 38201
+    "bundled": 358937,
+    "minified": 134847,
+    "gzipped": 38228
   },
   "dist/react-beautiful-dnd.esm.js": {
-    "bundled": 177759,
-    "minified": 89807,
-    "gzipped": 22649,
+    "bundled": 177889,
+    "minified": 89747,
+    "gzipped": 22655,
     "treeshaked": {
-      "rollup": 78288,
-      "webpack": 80060
+      "rollup": 78234,
+      "webpack": 80006
     }
   }
 }

--- a/src/state/get-droppable-over.js
+++ b/src/state/get-droppable-over.js
@@ -136,7 +136,7 @@ export default ({
       .map((id: DroppableId): DroppableDimension => droppables[id])
       // only want enabled droppables
       .filter((droppable: DroppableDimension) => droppable.isEnabled)
-      .find((droppable: DroppableDimension): boolean => {
+      .filter((droppable: DroppableDimension): boolean => {
         // If previously dragging over a droppable we give it a
         // bit of room on the subsequent drags so that user and move
         // items in the space that the placeholder takes up
@@ -153,7 +153,19 @@ export default ({
         // Not adjusting target for droppable scroll as we are just checking
         // if it is over the droppable - not its internal impact
         return isPositionInFrame(withPlaceholder)(target);
-      });
+      })
+      .sort((a, b): number => {
+        if (a.client.contentBox[a.axis.size] < b.client.contentBox[b.axis.size]) {
+          return -1;
+        }
+
+        if (a.client.contentBox[a.axis.size] > b.client.contentBox[b.axis.size]) {
+          return 1;
+        }
+
+        return 0;
+      })
+      .find((droppable: DroppableDimension): boolean => !!droppable);
 
   return maybe ? maybe.descriptor.id : null;
 };

--- a/stories/src/vertical-nested/quote-app.jsx
+++ b/stories/src/vertical-nested/quote-app.jsx
@@ -74,11 +74,9 @@ export default class QuoteApp extends Component<*, State> {
 
     const setList = (newList) => {
       if (newList.id === 'first-level') {
-        debugger
         this.setState({ list: newList });
       } else {
         this.setState((prevState) => {
-          debugger
           const prevList: NestedQuoteList = prevState.list;
           const prevNestedList: NestedQuoteList = prevList.children.find(item => item.children);
           const children = prevList.children.slice();
@@ -100,7 +98,6 @@ export default class QuoteApp extends Component<*, State> {
       destList = { ...destList, children };
       setList(destList);
     } else {
-      debugger
       const srcChildren = srcList.children.slice();
       const [child] = srcChildren.splice(result.source.index, 1);
       srcList = { ...srcList, children: srcChildren };

--- a/stories/src/vertical-nested/quote-app.jsx
+++ b/stories/src/vertical-nested/quote-app.jsx
@@ -65,59 +65,57 @@ export default class QuoteApp extends Component<*, State> {
       return;
     }
 
-    if (result.type === 'first-level') {
+    const destId: String = result.destination.droppableId;
+    const srcId: String = result.source.droppableId;
+    const list: NestedQuoteList = this.state.list;
+    const nestedList: NestedQuoteList = list.children.find(item => item.children);
+    let destList: NestedQuoteList = destId === 'first-level' ? list : nestedList;
+    let srcList: NestedQuoteList = srcId === 'first-level' ? list : nestedList;
+
+    const setList = (newList) => {
+      if (newList.id === 'first-level') {
+        debugger
+        this.setState({ list: newList });
+      } else {
+        this.setState((prevState) => {
+          debugger
+          const prevList: NestedQuoteList = prevState.list;
+          const prevNestedList: NestedQuoteList = prevList.children.find(item => item.children);
+          const children = prevList.children.slice();
+          const index = children.indexOf(prevNestedList);
+          children[index] = newList;
+          return { list: { ...prevList, children } };
+        });
+      }
+    };
+
+    if (destId === srcId) {
       const children = reorder(
-        this.state.list.children,
+        destList.children,
         result.source.index,
         result.destination.index,
       );
 
       // $ExpectError - using spread
-      const list: NestedQuoteList = {
-        ...this.state.list,
-        children,
-      };
+      destList = { ...destList, children };
+      setList(destList);
+    } else {
+      debugger
+      const srcChildren = srcList.children.slice();
+      const [child] = srcChildren.splice(result.source.index, 1);
+      srcList = { ...srcList, children: srcChildren };
 
-      this.setState({
-        list,
-      });
-      return;
-    }
+      const destChildren = destList.children.slice();
+      destChildren.splice(result.destination.index, 0, child);
+      destList = { ...destList, children: destChildren };
 
-    if (result.type === 'second-level') {
-      const nested: ?NestedQuoteList = (this.state.list.children.filter(
-        (item: mixed): boolean => Object.prototype.hasOwnProperty.call(item, 'children')
-      )[0] : any);
-
-      if (!nested) {
-        console.error('could not find nested list');
-        return;
+      if (destId !== 'first-level') {
+        setList(srcList);
+        setList(destList);
+      } else {
+        setList(destList);
+        setList(srcList);
       }
-
-      // $ExpectError - using spread
-      const updated: NestedQuoteList = {
-        ...nested,
-        children: reorder(
-          nested.children,
-          result.source.index,
-          // $ExpectError - already checked for null
-          result.destination.index,
-        ),
-      };
-
-      const nestedIndex = this.state.list.children.indexOf(nested);
-      const children = Array.from(this.state.list.children);
-      children[nestedIndex] = updated;
-
-      // $ExpectError - using spread
-      const list: NestedQuoteList = {
-        ...this.state.list,
-        children,
-      };
-
-      this.setState({
-        list,
-      });
     }
   }
 

--- a/stories/src/vertical-nested/quote-list.jsx
+++ b/stories/src/vertical-nested/quote-list.jsx
@@ -59,7 +59,6 @@ export default class QuoteList extends Component<{ list: NestedQuoteList }> {
   renderList = (list: NestedQuoteList, level?: number = 0) => (
     <Droppable
       droppableId={list.id}
-      type={list.id}
       key={list.id}
     >
       {(dropProvided: DroppableProvided, dropSnapshot: DroppableStateSnapshot) => (
@@ -75,7 +74,6 @@ export default class QuoteList extends Component<{ list: NestedQuoteList }> {
               (
                 <Draggable
                   draggableId={item.id}
-                  type={list.id}
                   key={item.id}
                   index={index}
                 >

--- a/stories/src/vertical-nested/quote-list.jsx
+++ b/stories/src/vertical-nested/quote-list.jsx
@@ -90,6 +90,7 @@ export default class QuoteList extends Component<{ list: NestedQuoteList }> {
                 </Draggable>
               )
             ))}
+          {dropProvided.placeholder}
         </Container>
       )}
     </Droppable>


### PR DESCRIPTION
This lets draggable items be dragged from a parent and dropped into a nested child list, making this library suitable for not just boards but also trees.

This was previously impossible, since the parent list would only ever register itself, but by dropping into the smallest list instead, we can drop into children too.

![](http://g.recordit.co/JEwYttme9k.gif)

Right now this change works, in that you can now drag and drop either from a child into a parent, or from a parent into a child.

But there's one thing missing, which is that when dragging between nested lists, when a placeholder is rendered in the non-home list, for some reason it doesn't also increase the list's height to account for the placeholder. You can see this behavior here:

![](http://g.recordit.co/Q7YCIYAkmu.gif)

@alexreardon I couldn't for the life of me figure out where this logic was in the codebase. Is there any way this is something you could finish? or point me to where I need to make a change?

Thank you for this great library!

Fixes https://github.com/atlassian/react-beautiful-dnd/issues/456
Fixes https://github.com/atlassian/react-beautiful-dnd/issues/301
Fixes https://github.com/atlassian/react-beautiful-dnd/issues/134