### PR TITLE
Extend Jest timeout

### DIFF
--- a/test/browser/simple-vertical-list-with-keyboard.spec.js
+++ b/test/browser/simple-vertical-list-with-keyboard.spec.js
@@ -10,6 +10,9 @@ const urlSingleList: string = 'http://localhost:9002/iframe.html?selectedKind=si
 
 const timeout: number = 60000;
 
+/* To avoid async callback from jest.setTimeout */
+jest.setTimeout(timeout);
+
 type Selector = string;
 
 const returnPositionAndText = async (page: Object, selector: Selector) =>

--- a/test/browser/simple-vertical-list-with-keyboard.spec.js
+++ b/test/browser/simple-vertical-list-with-keyboard.spec.js
@@ -11,6 +11,7 @@ const urlSingleList: string = 'http://localhost:9002/iframe.html?selectedKind=si
 const timeout: number = 60000;
 
 /* To avoid async callback from jest.setTimeout */
+/* Background: https://stackoverflow.com/questions/49603939/jest-async-callback-was-not-invoked-within-the-5000ms-timeout-specified-by-jest */
 jest.setTimeout(timeout);
 
 type Selector = string;


### PR DESCRIPTION
Hey @alexreardon ,

looking at stackoverflow and I found this:
https://stackoverflow.com/questions/49603939/jest-async-callback-was-not-invoked-within-the-5000ms-timeout-specified-by-jest

I needed to extend the timeout in the jest runner itself. Hope it will fix this.

Feel free to create an issue about adding cypress tests and assign it to me.