### PR TITLE
Eliminate timings in production bundle

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,25 +1,25 @@
 {
   "dist/react-beautiful-dnd.js": {
-    "bundled": 357548,
-    "minified": 134356,
-    "gzipped": 37655
+    "bundled": 357677,
+    "minified": 134471,
+    "gzipped": 37693
   },
   "dist/react-beautiful-dnd.min.js": {
-    "bundled": 318599,
-    "minified": 117316,
-    "gzipped": 32164
+    "bundled": 317933,
+    "minified": 117115,
+    "gzipped": 32060
   },
   "dist/react-beautiful-dnd.esm.js": {
-    "bundled": 186358,
-    "minified": 95436,
-    "gzipped": 23626,
+    "bundled": 186523,
+    "minified": 95575,
+    "gzipped": 23674,
     "treeshaked": {
       "rollup": {
-        "code": 71360,
+        "code": 71159,
         "import_statements": 726
       },
       "webpack": {
-        "code": 73152
+        "code": 73238
       }
     }
   }

--- a/src/debug/timings.js
+++ b/src/debug/timings.js
@@ -9,25 +9,22 @@ const records: Records = {};
 
 const flag: string = '__react-beautiful-dnd-debug-timings-hook__';
 
-// we want to strip all the code out for production builds
-// draw back: can only do timings in dev env (which seems to be fine for now)
-const isProduction: boolean = process.env.NODE_ENV === 'production';
-
 const isTimingsEnabled = (): boolean => Boolean(window[flag]);
 
 // Debug: uncomment to enable
 // window[flag] = true;
 
 export const start = (key: string) => {
-  if (isProduction) {
-    return;
-  }
-  if (!isTimingsEnabled()) {
-    return;
-  }
-  const now: number = performance.now();
+  // we want to strip all the code out for production builds
+  // draw back: can only do timings in dev env (which seems to be fine for now)
+  if (process.env.NODE_ENV !== 'production') {
+    if (!isTimingsEnabled()) {
+      return;
+    }
+    const now: number = performance.now();
 
-  records[key] = now;
+    records[key] = now;
+  }
 };
 
 type Style = {|
@@ -36,50 +33,49 @@ type Style = {|
 |};
 
 export const finish = (key: string) => {
-  if (isProduction) {
-    return;
-  }
-  if (!isTimingsEnabled()) {
-    return;
-  }
-  const now: number = performance.now();
-
-  const previous: ?number = records[key];
-
-  invariant(previous, 'cannot finish timing as no previous time found');
-
-  const result: number = now - previous;
-  const rounded: string = result.toFixed(2);
-
-  const style: Style = (() => {
-    if (result < 16) {
-      return {
-        textColor: 'green',
-        symbol: '✅',
-      };
+  if (process.env.NODE_ENV !== 'production') {
+    if (!isTimingsEnabled()) {
+      return;
     }
-    if (result < 40) {
-      return {
-        textColor: 'orange',
-        symbol: '⚠️',
-      };
-    }
-    return {
-      textColor: 'red',
-      symbol: '❌',
-    };
-  })();
+    const now: number = performance.now();
 
-  // eslint-disable-next-line no-console
-  console.log(
-    `${style.symbol} %cTiming %c${rounded} %cms %c${key}`,
-    // title
-    'color: blue; font-weight: bold; ',
-    // result
-    `color: ${style.textColor}; font-size: 1.1em;`,
-    // ms
-    'color: grey;',
-    // key
-    'color: purple; font-weight: bold;',
-  );
+    const previous: ?number = records[key];
+
+    invariant(previous, 'cannot finish timing as no previous time found');
+
+    const result: number = now - previous;
+    const rounded: string = result.toFixed(2);
+
+    const style: Style = (() => {
+      if (result < 16) {
+        return {
+          textColor: 'green',
+          symbol: '✅',
+        };
+      }
+      if (result < 40) {
+        return {
+          textColor: 'orange',
+          symbol: '⚠️',
+        };
+      }
+      return {
+        textColor: 'red',
+        symbol: '❌',
+      };
+    })();
+
+    // eslint-disable-next-line no-console
+    console.log(
+      `${style.symbol} %cTiming %c${rounded} %cms %c${key}`,
+      // title
+      'color: blue; font-weight: bold; ',
+      // result
+      `color: ${style.textColor}; font-size: 1.1em;`,
+      // ms
+      'color: grey;',
+      // key
+      'color: purple; font-weight: bold;',
+    );
+  }
 };


### PR DESCRIPTION
Inlining `NODE_ENV` comparison allows uglify to eliminate
unused code in production.