### PR TITLE
unwinding event blocking if cannot drag. Fixes #615

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,25 +1,25 @@
 {
   "dist/react-beautiful-dnd.js": {
-    "bundled": 350983,
-    "minified": 131579,
-    "gzipped": 36875
+    "bundled": 350931,
+    "minified": 131530,
+    "gzipped": 36859
   },
   "dist/react-beautiful-dnd.min.js": {
-    "bundled": 311656,
-    "minified": 114427,
-    "gzipped": 31353
+    "bundled": 311604,
+    "minified": 114378,
+    "gzipped": 31334
   },
   "dist/react-beautiful-dnd.esm.js": {
-    "bundled": 180447,
-    "minified": 92592,
-    "gzipped": 22949,
+    "bundled": 180396,
+    "minified": 92565,
+    "gzipped": 22942,
     "treeshaked": {
       "rollup": {
-        "code": 68627,
+        "code": 68578,
         "import_statements": 668
       },
       "webpack": {
-        "code": 70911
+        "code": 70862
       }
     }
   }

--- a/src/view/drag-handle/sensor/create-keyboard-sensor.js
+++ b/src/view/drag-handle/sensor/create-keyboard-sensor.js
@@ -70,10 +70,8 @@ export default ({
         return;
       }
 
-      // cannot lift at this time
+      // Cannot lift at this time
       if (!canStartCapturing(event)) {
-        // need to block to prevent default browser behaviour
-        event.preventDefault();
         return;
       }
 

--- a/src/view/drag-handle/sensor/create-mouse-sensor.js
+++ b/src/view/drag-handle/sensor/create-mouse-sensor.js
@@ -269,6 +269,9 @@ export default ({
       'Should not be able to perform a mouse down while a drag or pending drag is occurring',
     );
 
+    // We do not need to prevent the event on a dropping draggable as
+    // the mouse down event will not fire due to pointer-events: none
+    // https://codesandbox.io/s/oxo0o775rz
     if (!canStartCapturing(event)) {
       return;
     }

--- a/src/view/drag-handle/sensor/create-mouse-sensor.js
+++ b/src/view/drag-handle/sensor/create-mouse-sensor.js
@@ -270,10 +270,6 @@ export default ({
     );
 
     if (!canStartCapturing(event)) {
-      // blocking the event as we want to opt out of the standard browser behaviour
-      // this *could* occur during a drop - although it should not thanks to pointer-events: none
-      // this is just being really safe
-      event.preventDefault();
       return;
     }
 

--- a/src/view/drag-handle/sensor/create-touch-sensor.js
+++ b/src/view/drag-handle/sensor/create-touch-sensor.js
@@ -386,6 +386,9 @@ export default ({
       'Should not be able to perform a touch start while a drag or pending drag is occurring',
     );
 
+    // We do not need to prevent the event on a dropping draggable as
+    // the touchstart event will not fire due to pointer-events: none
+    // https://codesandbox.io/s/oxo0o775rz
     if (!canStartCapturing(event)) {
       return;
     }

--- a/src/view/draggable/draggable-types.js
+++ b/src/view/draggable/draggable-types.js
@@ -33,9 +33,9 @@ export type DraggingStyle = {|
   zIndex: ZIndex,
 
   // Avoiding any processing of mouse events.
-  // This is already applied by the shared styles. However, doing it here also prevents
-  // the pointer-events during a drop. The actual drag start blocking is taken care of
-  // by canStartDrag() on the context. But this a little safeguard.
+  // This is already applied by the shared styles during a drag.
+  // During a drop it prevents a draggable from being dragged.
+  // canStartDrag() will prevent drags in some cases for non primary draggable.
   // It is also a minor performance optimisation
   pointerEvents: 'none',
 |};

--- a/test/unit/view/drag-handle/drag-handle.spec.js
+++ b/test/unit/view/drag-handle/drag-handle.spec.js
@@ -432,9 +432,9 @@ describe('drag handle', () => {
         const customWrapper = getWrapper(customCallbacks, customContext);
         const mock: MockEvent = createMockEvent();
 
-        // prevent default called on mousedown
+        // prevent default not called on mousedown
         mouseDown(customWrapper, origin, primaryButton, mock);
-        expect(mock.preventDefault).toHaveBeenCalled();
+        expect(mock.preventDefault).not.toHaveBeenCalled();
 
         // a normal lift will not occur
         windowMouseMove({ x: 0, y: sloppyClickThreshold });
@@ -1591,7 +1591,7 @@ describe('drag handle', () => {
         expect(mock.preventDefault).not.toHaveBeenCalled();
       });
 
-      it('should not lift and prevent the default action if the state does not currently allow lifting', () => {
+      it('should not lift if the state does not currently allow lifting', () => {
         const customCallbacks: Callbacks = getStubCallbacks();
         const customContext = {
           [styleContextKey]: 'hello',
@@ -1607,8 +1607,8 @@ describe('drag handle', () => {
             onLift: 0,
           }),
         ).toBe(true);
-        // preventing the event to stop the default browser action
-        expect(mock.preventDefault).toHaveBeenCalled();
+        // not preventing the event to stop the default browser action
+        expect(mock.preventDefault).not.toHaveBeenCalled();
       });
     });
 

--- a/test/unit/view/drag-handle/drag-handle.spec.js
+++ b/test/unit/view/drag-handle/drag-handle.spec.js
@@ -1607,7 +1607,7 @@ describe('drag handle', () => {
             onLift: 0,
           }),
         ).toBe(true);
-        // not preventing the event to stop the default browser action
+        // not preventing browser event
         expect(mock.preventDefault).not.toHaveBeenCalled();
       });
     });


### PR DESCRIPTION
Fixes #615 /cc @eduludi

We added some unnecessary, overly defensive event blocking which broke some nested interactive element experiences. These unnecessary checks have been removed