### PR TITLE
allow dragging children to/from parent lists

### DIFF
--- a/src/state/get-droppable-over.js
+++ b/src/state/get-droppable-over.js
@@ -154,7 +154,7 @@ export default ({
   const maybe: ?DroppableDimension = toDroppableList(droppables)
     // only want enabled droppables
     .filter((droppable: DroppableDimension) => droppable.isEnabled)
-    .find(
+    .filter(
       (droppable: DroppableDimension): boolean => {
         // If previously dragging over a droppable we give it a
         // bit of room on the subsequent drags so that user and move
@@ -176,7 +176,25 @@ export default ({
         // if it is over the droppable - not its internal impact
         return isPositionInFrame(withPlaceholder)(target);
       },
-    );
+    )
+    .sort(
+      (a, b): number => {
+        if (
+          a.client.contentBox[a.axis.size] < b.client.contentBox[b.axis.size]
+        ) {
+          return -1;
+        }
+
+        if (
+          a.client.contentBox[a.axis.size] > b.client.contentBox[b.axis.size]
+        ) {
+          return 1;
+        }
+
+        return 0;
+      },
+    )
+    .find((droppable: DroppableDimension): boolean => !!droppable);
 
   return maybe ? maybe.descriptor.id : null;
 };

--- a/stories/src/vertical-nested/quote-app.jsx
+++ b/stories/src/vertical-nested/quote-app.jsx
@@ -61,64 +61,78 @@ export default class QuoteApp extends Component<*, State> {
     publishOnDragEnd(result);
 
     // dropped outside the list
-    if (!result.destination) {
-      return;
-    }
-
-    if (result.type === 'first-level') {
-      const children = reorder(
-        this.state.list.children,
-        result.source.index,
-        result.destination.index,
+    if (result.destination) {
+      const destId: string = result.destination.droppableId;
+      const srcId: string = result.source.droppableId;
+      const list: NestedQuoteList = this.state.list;
+      const nestedList: ?NestedQuoteList = list.children.find(
+        item => item.children,
       );
 
-      // $ExpectError - using spread
-      const list: NestedQuoteList = {
-        ...this.state.list,
-        children,
-      };
-
-      this.setState({
-        list,
-      });
-      return;
-    }
-
-    if (result.type === 'second-level') {
-      const nested: ?NestedQuoteList = (this.state.list.children.filter(
-        (item: mixed): boolean =>
-          Object.prototype.hasOwnProperty.call(item, 'children'),
-      )[0]: any);
-
-      if (!nested) {
-        console.error('could not find nested list');
-        return;
+      if (!nestedList) {
+        throw new Error('No nested list found!');
       }
 
-      // $ExpectError - using spread
-      const updated: NestedQuoteList = {
-        ...nested,
-        children: reorder(
-          nested.children,
+      let destList: NestedQuoteList =
+        destId === 'first-level' ? list : nestedList;
+      let srcList: NestedQuoteList =
+        srcId === 'first-level' ? list : nestedList;
+
+      const setList = newList => {
+        if (newList.id === 'first-level') {
+          this.setState({ list: newList });
+        } else {
+          this.setState(prevState => {
+            const prevList: NestedQuoteList = prevState.list;
+            const prevNestedList: ?NestedQuoteList = prevList.children.find(
+              item => item.children,
+            );
+
+            if (!prevNestedList) {
+              throw new Error('No nested list found!');
+            }
+
+            const children = prevList.children.slice();
+            const index = children.indexOf(prevNestedList);
+            children[index] = newList;
+            return { list: { ...prevList, children } };
+          });
+        }
+      };
+
+      if (destId === srcId) {
+        const children = reorder(
+          destList.children,
           result.source.index,
-          // $ExpectError - already checked for null
-          result.destination.index,
-        ),
-      };
+          // $FlowFixMe
+          result.destination && result.destination.index,
+        );
 
-      const nestedIndex = this.state.list.children.indexOf(nested);
-      const children = Array.from(this.state.list.children);
-      children[nestedIndex] = updated;
+        // $ExpectError - using spread
+        destList = { ...destList, children };
+        setList(destList);
+      } else {
+        const srcChildren = srcList.children.slice();
+        const [child] = srcChildren.splice(result.source.index, 1);
+        srcList = { ...srcList, children: srcChildren };
 
-      // $ExpectError - using spread
-      const list: NestedQuoteList = {
-        ...this.state.list,
-        children,
-      };
+        const destChildren = destList.children.slice();
+        // $FlowFixMe
+        destChildren.splice(
+          result.destination && result.destination.index,
+          0,
+          child,
+        );
+        destList = { ...destList, children: destChildren };
 
-      this.setState({
-        list,
-      });
+        if (destId !== 'first-level') {
+          setList(srcList);
+          setList(destList);
+        } else {
+          setList(destList);
+          setList(srcList);
+        }
+      }
     }
   };
 

--- a/stories/src/vertical-nested/quote-list.jsx
+++ b/stories/src/vertical-nested/quote-list.jsx
@@ -40,8 +40,8 @@ const NestedContainer = Container.extend`
 `;
 
 export default class QuoteList extends Component<{ list: NestedQuoteList }> {
-  renderQuote = (quote: Quote, type: string, index: number) => (
-    <Draggable key={quote.id} draggableId={quote.id} type={type} index={index}>
+  renderQuote = (quote: Quote, index: number) => (
+    <Draggable key={quote.id} draggableId={quote.id} index={index}>
       {(provided: DraggableProvided, snapshot: DraggableStateSnapshot) => (
         <QuoteItem
           quote={quote}
@@ -53,7 +53,7 @@ export default class QuoteList extends Component<{ list: NestedQuoteList }> {
   );
 
   renderList = (list: NestedQuoteList, level?: number = 0) => (
-    <Droppable droppableId={list.id} type={list.id} key={list.id}>
+    <Droppable droppableId={list.id} key={list.id}>
       {(
         dropProvided: DroppableProvided,
         dropSnapshot: DroppableStateSnapshot,
@@ -67,14 +67,9 @@ export default class QuoteList extends Component<{ list: NestedQuoteList }> {
           {list.children.map(
             (item: Quote | NestedQuoteList, index: number) =>
               !item.children ? (
-                this.renderQuote((item: any), list.id, index)
+                this.renderQuote((item: any), index)
               ) : (
-                <Draggable
-                  draggableId={item.id}
-                  type={list.id}
-                  key={item.id}
-                  index={index}
-                >
+                <Draggable draggableId={item.id} key={item.id} index={index}>
                   {(
                     dragProvided: DraggableProvided,
                     dragSnapshot: DraggableStateSnapshot,
@@ -91,6 +86,7 @@ export default class QuoteList extends Component<{ list: NestedQuoteList }> {
                 </Draggable>
               ),
           )}
+          {dropProvided.placeholder}
         </Container>
       )}
     </Droppable>


### PR DESCRIPTION
This lets draggable children be dragged from or into a parent, making this library suitable for not just boards but also trees.

![](https://camo.githubusercontent.com/7a3eb2f4ba6ce08016c7b7df37659aad0aee71e4/687474703a2f2f672e7265636f726469742e636f2f486d45624262787073782e676966)

@alexreardon one of the reasons that #563 was closed so quickly was because of the big refactor, so I've rebased this pull request against the latest master. It's still just a ~10 line change that only impacts the nested lists use case.

Would you consider merging so we can unblock people using nested lists?