### PR TITLE
Update Hook types to return `mixed` vs `void` (addresses #695)

### DIFF
--- a/README.md
+++ b/README.md
@@ -758,7 +758,7 @@ Unfortunately we are [unable to apply this optimisation for you](https://medium.
 
 `Draggable` components can be dragged around and dropped onto `Droppable`s. A `Draggable` must always be contained within a `Droppable`. It is **possible** to reorder a `Draggable` within its home `Droppable` or move to another `Droppable`. It is **possible** because a `Droppable` is free to control what it allows to be dropped on it.
 
-Every `Draggable` has a _drag handle_. A _drag handle_ is the element that the user interacts with in order to drag a `Draggable`. A _drag handle_ can be a the `Draggable` element itself, or a child of the `Draggable`.
+Every `Draggable` has a _drag handle_. A _drag handle_ is the element that the user interacts with in order to drag a `Draggable`. A _drag handle_ can be a the `Draggable` element itself, or a child of the `Draggable`. A _drag handle should not be an interactive element_, since [event handlers are blocked on nested interactive elements](#interactive-child-elements-within-a-draggable). Proper semantics for accessibility are added to the _drag handle_ element.
 
 ```js
 import { Draggable } from 'react-beautiful-dnd';

--- a/README.md
+++ b/README.md
@@ -522,10 +522,10 @@ type Hooks = {|
   onDragEnd: OnDragEndHook,
 |};
 
-type OnBeforeDragStartHook = (start: DragStart) => void;
-type OnDragStartHook = (start: DragStart, provided: HookProvided) => void;
-type OnDragUpdateHook = (update: DragUpdate, provided: HookProvided) => void;
-type OnDragEndHook = (result: DropResult, provided: HookProvided) => void;
+type OnBeforeDragStartHook = (start: DragStart) => mixed;
+type OnDragStartHook = (start: DragStart, provided: HookProvided) => mixed;
+type OnDragUpdateHook = (update: DragUpdate, provided: HookProvided) => mixed;
+type OnDragEndHook = (result: DropResult, provided: HookProvided) => mixed;
 
 type Props = {|
   ...Hooks,

--- a/README.md
+++ b/README.md
@@ -758,7 +758,7 @@ Unfortunately we are [unable to apply this optimisation for you](https://medium.
 
 `Draggable` components can be dragged around and dropped onto `Droppable`s. A `Draggable` must always be contained within a `Droppable`. It is **possible** to reorder a `Draggable` within its home `Droppable` or move to another `Droppable`. It is **possible** because a `Droppable` is free to control what it allows to be dropped on it.
 
-Every `Draggable` has a _drag handle_. A _drag handle_ is the element that the user interacts with in order to drag a `Draggable`. A _drag handle_ can be a the `Draggable` element itself, or a child of the `Draggable`. A _drag handle should not be an interactive element_, since [event handlers are blocked on nested interactive elements](#interactive-child-elements-within-a-draggable). Proper semantics for accessibility are added to the _drag handle_ element.
+Every `Draggable` has a _drag handle_. A _drag handle_ is the element that the user interacts with in order to drag a `Draggable`. A _drag handle_ can be a the `Draggable` element itself, or a child of the `Draggable`. Note that by default a _drag handle_ cannot be an interactive element, since [event handlers are blocked on nested interactive elements](#interactive-child-elements-within-a-draggable). Proper semantics for accessibility are added to the _drag handle_ element. If you wish to use an interactive element, `disableInteractiveElementBlocking` must be set.
 
 ```js
 import { Draggable } from 'react-beautiful-dnd';

--- a/docs/guides/hooks.md
+++ b/docs/guides/hooks.md
@@ -35,7 +35,7 @@ All hooks (except for `onBeforeDragStart`) are provided with a second argument: 
 ## `onDragStart` (optional)
 
 ```js
-type OnDragStartHook = (start: DragStart, provided: HookProvided) => void;
+type OnDragStartHook = (start: DragStart, provided: HookProvided) => mixed;
 ```
 
 `onDragStart` will get notified when a drag starts. This hook is _optional_ and therefore does not need to be provided. It is **highly recommended** that you use this function to block updates to all `Draggable` and `Droppable` components during a drag. (See **Block updates during a drag** below)
@@ -58,8 +58,10 @@ type DragStart = {|
 
 ### `onDragStart` type information
 
+**Note:** while the return type is `mixed`, the return value is not used.
+
 ```js
-type OnDragStartHook = (start: DragStart, provided: HookProvided) => void;
+type OnDragStartHook = (start: DragStart, provided: HookProvided) => mixed;
 
 // supporting types
 type DragStart = {|
@@ -82,7 +84,7 @@ type TypeId = Id;
 ## `onDragUpdate` (optional)
 
 ```js
-type OnDragUpdateHook = (update: DragUpdate, provided: HookProvided) => void;
+type OnDragUpdateHook = (update: DragUpdate, provided: HookProvided) => mixed;
 ```
 
 This hook is called whenever something changes during a drag. The possible changes are:
@@ -91,7 +93,7 @@ This hook is called whenever something changes during a drag. The possible chang
 - The `Draggable` is now over a different `Droppable`
 - The `Draggable` is now over no `Droppable`
 
-It is important that you not do too much work as a result of this function as it will slow down the drag.
+It is important that you not do too much work as a result of this function as it will slow down the drag. While the return type is `mixed`, the return value is not used.
 
 ### `update: DragUpdate`
 
@@ -144,9 +146,11 @@ Once we have all of the information we need to start a drag we call the `onBefor
 
 ### `OnBeforeDragStartHook` type information
 
+**Note:** while the return type is `mixed`, the return value is not used.
+
 ```js
 // No second 'provided' argument
-type OnBeforeDragStartHook = (start: DragStart) => void;
+type OnBeforeDragStartHook = (start: DragStart) => mixed;
 
 // Otherwise the same type information as OnDragStartHook
 ```

--- a/src/types.js
+++ b/src/types.js
@@ -315,19 +315,19 @@ export type HookProvided = {|
   announce: Announce,
 |};
 
-export type OnBeforeDragStartHook = (start: DragStart) => void;
+export type OnBeforeDragStartHook = (start: DragStart) => mixed;
 export type OnDragStartHook = (
   start: DragStart,
   provided: HookProvided,
-) => void;
+) => mixed;
 export type OnDragUpdateHook = (
   update: DragUpdate,
   provided: HookProvided,
-) => void;
+) => mixed;
 export type OnDragEndHook = (
   result: DropResult,
   provided: HookProvided,
-) => void;
+) => mixed;
 
 export type Hooks = {|
   onBeforeDragStart?: OnBeforeDragStartHook,


### PR DESCRIPTION
Addresses #695.

edit: Also didn't realize subsequent commits to my fork would be added to the PR...but I was going to submit a new PR for the commit anyway. It's a small README change that clarifies that a drag handle should not be an interactive element. Something I discovered after 30 minutes of wondering why my `button` drag handle was not working.