### PR TITLE
Bcon/fixing codesandboxer

### DIFF
--- a/.storybook/.babelrc
+++ b/.storybook/.babelrc
@@ -6,8 +6,7 @@
   ],
   "plugins": [
     ["@babel/proposal-class-properties", { "loose": true }],
-    ["@babel/proposal-object-rest-spread", { "loose": true }],
-    "emotion"
+    ["@babel/proposal-object-rest-spread", { "loose": true }]
   ],
   "comments": false
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
   },
   "dependencies": {
     "@babel/runtime-corejs2": "7.0.0-beta.56",
-    "babel-plugin-emotion": "^9.2.6",
     "css-box-model": "^1.0.0",
     "emotion": "^9.2.6",
     "memoize-one": "^4.0.0",

--- a/stories/1-single-vertical-list-story.js
+++ b/stories/1-single-vertical-list-story.js
@@ -12,7 +12,7 @@ const data = {
   large: getQuotes(500),
 };
 
-const ScrollContainer = styled.div`
+const ScrollContainer = styled('div')`
   box-sizing: border-box;
   background: lightgrey;
   padding: ${grid * 2}px;
@@ -22,7 +22,7 @@ const ScrollContainer = styled.div`
   position: relative;
 `;
 
-const Title = styled.h4`
+const Title = styled('h4')`
   text-align: center;
   margin-bottom: ${grid}px;
 `;

--- a/stories/2-single-horizontal-story.js
+++ b/stories/2-single-horizontal-story.js
@@ -8,7 +8,7 @@ import type { Quote } from './src/types';
 
 const bigData: Quote[] = getQuotes(30);
 
-const WideWindow = styled.div`
+const WideWindow = styled('div')`
   width: 120vw;
 `;
 

--- a/stories/src/accessible/task-app.jsx
+++ b/stories/src/accessible/task-app.jsx
@@ -21,28 +21,28 @@ type State = {|
   blur: number,
 |};
 
-const Container = styled.div`
+const Container = styled('div')`
   padding-top: 20vh;
   display: flex;
   flex-direction: column;
   align-items: center;
 `;
-const Blur = styled.div`
+const Blur = styled('div')`
   filter: blur(${props => props.amount}px);
 `;
 
-const BlurControls = styled.div`
+const BlurControls = styled('div')`
   display: flex;
   align-items: center;
   font-size: 20px;
   margin-top: 20vh;
 `;
 
-const BlurTitle = styled.h4`
+const BlurTitle = styled('h4')`
   margin: 0;
 `;
 
-const Button = styled.button`
+const Button = styled('button')`
   height: ${grid * 5}px;
   width: ${grid * 5}px;
   font-size: 20px;

--- a/stories/src/accessible/task-list.jsx
+++ b/stories/src/accessible/task-list.jsx
@@ -12,18 +12,18 @@ type Props = {|
   title: string,
 |};
 
-const Container = styled.div`
+const Container = styled('div')`
   width: 300px;
   background-color: ${colors.grey.dark};
   border-radius: ${borderRadius}px;
 `;
 
-const Title = styled.h3`
+const Title = styled('h3')`
   font-weight: bold;
   padding: ${grid}px;
 `;
 
-const List = styled.div`
+const List = styled('div')`
   padding: ${grid}px;
   padding-bottom: 0;
   display: flex;

--- a/stories/src/accessible/task.jsx
+++ b/stories/src/accessible/task.jsx
@@ -11,7 +11,7 @@ type Props = {|
   index: number,
 |};
 
-const Container = styled.div`
+const Container = styled('div')`
   border-bottom: 1px solid #ccc;
   background: ${colors.white};
   padding: ${grid}px;

--- a/stories/src/board/board.jsx
+++ b/stories/src/board/board.jsx
@@ -18,13 +18,13 @@ import type { QuoteMap } from '../types';
 const publishOnDragStart = action('onDragStart');
 const publishOnDragEnd = action('onDragEnd');
 
-const ParentContainer = styled.div`
+const ParentContainer = styled('div')`
   height: ${({ height }) => height};
   overflow-x: hidden;
   overflow-y: auto;
 `;
 
-const Container = styled.div`
+const Container = styled('div')`
   min-height: 100vh;
 
   /* like display:flex but will allow bleeding over the window width */

--- a/stories/src/board/column.jsx
+++ b/stories/src/board/column.jsx
@@ -8,13 +8,13 @@ import QuoteList from '../primatives/quote-list';
 import Title from '../primatives/title';
 import type { Quote } from '../types';
 
-const Container = styled.div`
+const Container = styled('div')`
   margin: ${grid}px;
   display: flex;
   flex-direction: column;
 `;
 
-const Header = styled.div`
+const Header = styled('div')`
   display: flex;
   align-items: center;
   justify-content: center;

--- a/stories/src/dynamic/with-controls.jsx
+++ b/stories/src/dynamic/with-controls.jsx
@@ -11,7 +11,7 @@ import type { DropResult, DragUpdate } from '../../../src/types';
 
 const initial: QuoteMap = generateQuoteMap(0);
 
-const ControlSection = styled.div`
+const ControlSection = styled('div')`
   margin: ${grid * 4}px;
 `;
 
@@ -43,7 +43,7 @@ type State = {|
   quoteMap: QuoteMap,
 |};
 
-const Container = styled.div`
+const Container = styled('div')`
   display: flex;
   align-items: flex-start;
 `;

--- a/stories/src/horizontal/author-app.jsx
+++ b/stories/src/horizontal/author-app.jsx
@@ -21,7 +21,7 @@ type State = {|
   quotes: Quote[],
 |};
 
-const Root = styled.div`
+const Root = styled('div')`
   padding: ${grid}px;
   background: ${colors.blue.light};
 `;

--- a/stories/src/interactive-elements/interactive-elements-app.jsx
+++ b/stories/src/interactive-elements/interactive-elements-app.jsx
@@ -133,13 +133,13 @@ const initial: ItemType[] = [
   },
 ];
 
-const List = styled.div`
+const List = styled('div')`
   width: 250px;
   background-color: ${colors.blue.deep};
   padding: ${grid * 2}px;
 `;
 
-const Item = styled.div`
+const Item = styled('div')`
   min-height: 80px;
   background-color: ${colors.white};
   border: 1px solid ${colors.grey.dark};
@@ -147,16 +147,16 @@ const Item = styled.div`
   margin-bottom: ${grid}px;
 `;
 
-const Container = styled.div`
+const Container = styled('div')`
   display: flex;
 `;
 
-const Controls = styled.div`
+const Controls = styled('div')`
   padding: ${grid * 2}px;
   width: 250px;
 `;
 
-const Status = styled.strong`
+const Status = styled('strong')`
   color: ${({ isEnabled }) => (isEnabled ? colors.blue.deep : colors.purple)};
 `;
 

--- a/stories/src/multi-drag/column.jsx
+++ b/stories/src/multi-drag/column.jsx
@@ -20,7 +20,7 @@ type Props = {|
   multiSelectTo: (taskId: Id) => void,
 |};
 
-const Container = styled.div`
+const Container = styled('div')`
   width: 300px;
   margin: ${grid}px;
   border-radius: ${borderRadius}px;
@@ -32,12 +32,12 @@ const Container = styled.div`
   flex-direction: column;
 `;
 
-const Title = styled.h3`
+const Title = styled('h3')`
   font-weight: bold;
   padding: ${grid}px;
 `;
 
-const TaskList = styled.div`
+const TaskList = styled('div')`
   padding: ${grid}px;
   min-height: 200px;
   flex-grow: 1;

--- a/stories/src/multi-drag/task-app.jsx
+++ b/stories/src/multi-drag/task-app.jsx
@@ -10,7 +10,7 @@ import type { DragStart, DropResult, DraggableLocation } from '../../../src';
 import type { Task, Id } from '../types';
 import type { Entities } from './types';
 
-const Container = styled.div`
+const Container = styled('div')`
   display: flex;
   user-select: none;
 `;

--- a/stories/src/multi-drag/task.jsx
+++ b/stories/src/multi-drag/task.jsx
@@ -51,7 +51,7 @@ const getColor = ({ isSelected, isGhosting }): string => {
   return colors.black;
 };
 
-const Container = styled.div`
+const Container = styled('div')`
   background-color: ${props => getBackgroundColor(props)};
   color: ${props => getColor(props)};
   padding: ${grid}px;
@@ -77,11 +77,11 @@ const Container = styled.div`
   }
 `;
 /* stylelint-disable block-no-empty */
-const Content = styled.div``;
+const Content = styled('div')``;
 /* stylelint-enable */
 const size: number = 30;
 
-const SelectionCount = styled.div`
+const SelectionCount = styled('div')`
   right: -${grid}px;
   top: -${grid}px;
   color: ${colors.white};

--- a/stories/src/multiple-horizontal/quote-app.jsx
+++ b/stories/src/multiple-horizontal/quote-app.jsx
@@ -13,7 +13,7 @@ import type { DropResult, DragStart } from '../../../src/types';
 const publishOnDragStart = action('onDragStart');
 const publishOnDragEnd = action('onDragEnd');
 
-const Root = styled.div`
+const Root = styled('div')`
   background-color: ${colors.blue.deep};
   box-sizing: border-box;
   padding: ${grid * 2}px;

--- a/stories/src/multiple-vertical/quote-app.jsx
+++ b/stories/src/multiple-vertical/quote-app.jsx
@@ -17,7 +17,7 @@ import type {
 const publishOnDragStart = action('onDragStart');
 const publishOnDragEnd = action('onDragEnd');
 
-const Root = styled.div`
+const Root = styled('div')`
   background-color: ${colors.blue.deep};
   box-sizing: border-box;
   padding: ${grid * 2}px;
@@ -29,11 +29,11 @@ const Root = styled.div`
   align-items: flex-start;
 `;
 
-const Column = styled.div`
+const Column = styled('div')`
   margin: 0 ${grid * 2}px;
 `;
 
-const HorizontalScrollContainer = styled.div`
+const HorizontalScrollContainer = styled('div')`
   display: flex;
   justify-content: flex-start;
   align-items: flex-start;
@@ -43,7 +43,7 @@ const HorizontalScrollContainer = styled.div`
   overflow: auto;
 `;
 
-const VerticalScrollContainer = styled.div`
+const VerticalScrollContainer = styled('div')`
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
@@ -54,7 +54,7 @@ const VerticalScrollContainer = styled.div`
   overflow: auto;
 `;
 
-const PushDown = styled.div`
+const PushDown = styled('div')`
   height: 200px;
 `;
 

--- a/stories/src/portal/portal-app.jsx
+++ b/stories/src/portal/portal-app.jsx
@@ -28,7 +28,7 @@ if (!document.body) {
 
 document.body.appendChild(portal);
 
-const SimpleQuote = styled.div`
+const SimpleQuote = styled('div')`
   padding: ${grid}px;
   margin-bottom: ${grid}px;
   background-color: ${colors.blue.light};
@@ -90,7 +90,7 @@ type AppState = {|
   quotes: Quote[],
 |};
 
-const Container = styled.div`
+const Container = styled('div')`
   margin: 0 auto;
   width: 300px;
 `;

--- a/stories/src/primatives/author-item.jsx
+++ b/stories/src/primatives/author-item.jsx
@@ -5,7 +5,7 @@ import { colors, grid } from '../constants';
 import type { DraggableProvided, DraggableStateSnapshot } from '../../../src';
 import type { Author } from '../types';
 
-const Avatar = styled.img`
+const Avatar = styled('img')`
   width: 60px;
   height: 60px;
   border-radius: 50%;

--- a/stories/src/primatives/author-list.jsx
+++ b/stories/src/primatives/author-list.jsx
@@ -12,7 +12,7 @@ import type {
   DraggableStateSnapshot,
 } from '../../../src';
 
-const Wrapper = styled.div`
+const Wrapper = styled('div')`
   background-color: ${({ isDraggingOver }) =>
     isDraggingOver ? colors.blue.lighter : colors.blue.light};
   display: flex;
@@ -23,7 +23,7 @@ const Wrapper = styled.div`
   margin: ${grid}px 0;
 `;
 
-const DropZone = styled.div`
+const DropZone = styled('div')`
   display: flex;
 
   /*
@@ -39,11 +39,11 @@ const DropZone = styled.div`
   min-height: 60px;
 `;
 
-const ScrollContainer = styled.div`
+const ScrollContainer = styled('div')`
   overflow: auto;
 `;
 
-const Container = styled.div`
+const Container = styled('div')`
   /* flex child */
   flex-grow: 1;
 

--- a/stories/src/primatives/quote-item.jsx
+++ b/stories/src/primatives/quote-item.jsx
@@ -11,7 +11,7 @@ type Props = {
   provided: DraggableProvided,
 };
 
-const Container = styled.a`
+const Container = styled('a')`
   border-radius: ${borderRadius}px;
   border: 1px solid grey;
   background-color: ${({ isDragging }) =>
@@ -42,7 +42,7 @@ const Container = styled.a`
   align-items: center;
 `;
 
-const Avatar = styled.img`
+const Avatar = styled('img')`
   width: 40px;
   height: 40px;
   border-radius: 50%;
@@ -51,7 +51,7 @@ const Avatar = styled.img`
   flex-grow: 0;
 `;
 
-const Content = styled.div`
+const Content = styled('div')`
   /* flex child */
   flex-grow: 1;
 
@@ -66,7 +66,7 @@ const Content = styled.div`
   flex-direction: column;
 `;
 
-const BlockQuote = styled.div`
+const BlockQuote = styled('div')`
   &::before {
     content: open-quote;
   }
@@ -76,17 +76,17 @@ const BlockQuote = styled.div`
   }
 `;
 
-const Footer = styled.div`
+const Footer = styled('div')`
   display: flex;
   margin-top: ${grid}px;
 `;
 
-const QuoteId = styled.small`
+const QuoteId = styled('small')`
   flex-grow: 0;
   margin: 0;
 `;
 
-const Attribution = styled.small`
+const Attribution = styled('small')`
   margin: 0;
   margin-left: ${grid}px;
   text-align: right;

--- a/stories/src/primatives/quote-list.jsx
+++ b/stories/src/primatives/quote-list.jsx
@@ -13,7 +13,7 @@ import type {
   DraggableStateSnapshot,
 } from '../../../src';
 
-const Wrapper = styled.div`
+const Wrapper = styled('div')`
   background-color: ${({ isDraggingOver }) =>
     isDraggingOver ? colors.blue.lighter : colors.blue.light};
   display: flex;
@@ -27,7 +27,7 @@ const Wrapper = styled.div`
   width: 250px;
 `;
 
-const DropZone = styled.div`
+const DropZone = styled('div')`
   /* stop the list collapsing when empty */
   min-height: 250px;
 
@@ -38,14 +38,14 @@ const DropZone = styled.div`
   margin-bottom: ${grid}px;
 `;
 
-const ScrollContainer = styled.div`
+const ScrollContainer = styled('div')`
   overflow-x: hidden;
   overflow-y: auto;
   max-height: 300px;
 `;
 
 /* stylelint-disable block-no-empty */
-const Container = styled.div``;
+const Container = styled('div')``;
 /* stylelint-enable */
 
 type Props = {|

--- a/stories/src/primatives/title.jsx
+++ b/stories/src/primatives/title.jsx
@@ -2,7 +2,7 @@
 import styled from 'react-emotion';
 import { colors, grid } from '../constants';
 
-export default styled.h4`
+export default styled('h4')`
   padding: ${grid}px;
   transition: background-color ease 0.2s;
   flex-grow: 1;

--- a/stories/src/table/with-dimension-locking.jsx
+++ b/stories/src/table/with-dimension-locking.jsx
@@ -12,27 +12,27 @@ import type {
   DraggableStateSnapshot,
 } from '../../../src';
 
-const Table = styled.table`
+const Table = styled('table')`
   width: 500px;
   margin: 0 auto;
   table-layout: ${props => props.layout};
 `;
 
-const TBody = styled.tbody`
+const TBody = styled('tbody')`
   border: 0;
 `;
 
-const THead = styled.thead`
+const THead = styled('thead')`
   border: 0;
   border-bottom: none;
   background-color: ${colors.grey.light};
 `;
 
-const Row = styled.tr`
+const Row = styled('tr')`
   ${props => (props.isDragging ? `background: ${colors.green};` : '')};
 `;
 
-const Cell = styled.td`
+const Cell = styled('td')`
   box-sizing: border-box;
   padding: ${grid}px;
 `;
@@ -146,7 +146,7 @@ class TableRow extends Component<TableRowProps> {
 }
 
 // TODO: make this look nicer!
-const Header = styled.header`
+const Header = styled('header')`
   display: flex;
   flex-direction: column;
   width: 500px;
@@ -155,9 +155,9 @@ const Header = styled.header`
 `;
 
 /* stylelint-disable block-no-empty */
-const LayoutControl = styled.div``;
+const LayoutControl = styled('div')``;
 
-const CopyTableButton = styled.button``;
+const CopyTableButton = styled('button')``;
 /* stylelint-enable */
 
 type AppProps = {|

--- a/stories/src/table/with-fixed-columns.jsx
+++ b/stories/src/table/with-fixed-columns.jsx
@@ -12,23 +12,23 @@ import type {
   DraggableStateSnapshot,
 } from '../../../src';
 
-const Table = styled.table`
+const Table = styled('table')`
   width: 500px;
   margin: 0 auto;
   table-layout: ${props => props.layout};
 `;
 
-const TBody = styled.tbody`
+const TBody = styled('tbody')`
   border: 0;
 `;
 
-const THead = styled.thead`
+const THead = styled('thead')`
   border: 0;
   border-bottom: none;
   background-color: ${colors.grey.light};
 `;
 
-const Row = styled.tr`
+const Row = styled('tr')`
   /* stylelint-disable comment-empty-line-before */
   ${props =>
     props.isDragging
@@ -41,7 +41,7 @@ const Row = styled.tr`
       : ''} /* stylelint-enable */;
 `;
 
-const Cell = styled.td`
+const Cell = styled('td')`
   box-sizing: border-box;
   padding: ${grid}px;
 
@@ -72,7 +72,7 @@ class TableRow extends Component<TableRowProps> {
   }
 }
 
-const Header = styled.header`
+const Header = styled('header')`
   display: flex;
   flex-direction: column;
   width: 500px;
@@ -81,9 +81,9 @@ const Header = styled.header`
 `;
 
 /* stylelint-disable block-no-empty */
-const LayoutControl = styled.div``;
+const LayoutControl = styled('div')``;
 
-const CopyTableButton = styled.button``;
+const CopyTableButton = styled('button')``;
 /* stylelint-enable */
 
 type AppProps = {|

--- a/stories/src/table/with-portal.jsx
+++ b/stories/src/table/with-portal.jsx
@@ -13,27 +13,27 @@ import type {
   DraggableStateSnapshot,
 } from '../../../src';
 
-const Table = styled.table`
+const Table = styled('table')`
   width: 500px;
   margin: 0 auto;
   table-layout: ${props => props.layout};
 `;
 
-const TBody = styled.tbody`
+const TBody = styled('tbody')`
   border: 0;
 `;
 
-const THead = styled.thead`
+const THead = styled('thead')`
   border: 0;
   border-bottom: none;
   background-color: ${colors.grey.light};
 `;
 
-const Row = styled.tr`
+const Row = styled('tr')`
   ${props => (props.isDragging ? `background: ${colors.green};` : '')};
 `;
 
-const Cell = styled.td`
+const Cell = styled('td')`
   box-sizing: border-box;
   padding: ${grid}px;
 `;
@@ -232,7 +232,7 @@ class TableRow extends Component<TableRowProps> {
 }
 
 // TODO: make this look nicer!
-const Header = styled.header`
+const Header = styled('header')`
   display: flex;
   flex-direction: column;
   width: 500px;
@@ -241,9 +241,9 @@ const Header = styled.header`
 `;
 
 /* stylelint-disable block-no-empty */
-const LayoutControl = styled.div``;
+const LayoutControl = styled('div')``;
 
-const CopyTableButton = styled.button``;
+const CopyTableButton = styled('button')``;
 /* stylelint-enable */
 
 type AppProps = {|

--- a/stories/src/vertical-grouped/quote-app.jsx
+++ b/stories/src/vertical-grouped/quote-app.jsx
@@ -12,12 +12,12 @@ import type { DropResult, DragStart } from '../../../src/types';
 const publishOnDragStart = action('onDragStart');
 const publishOnDragEnd = action('onDragEnd');
 
-const Root = styled.div`
+const Root = styled('div')`
   background: ${colors.blue.deep};
   display: flex;
 `;
 
-const Column = styled.div`
+const Column = styled('div')`
   background-color: ${colors.blue.light};
 
   /* make the column a scroll container */
@@ -29,11 +29,11 @@ const Column = styled.div`
   flex-direction: column;
 `;
 
-const Group = styled.div`
+const Group = styled('div')`
   margin-top: ${grid * 2}px;
 `;
 
-const Title = styled.h4`
+const Title = styled('h4')`
   margin: ${grid}px;
 `;
 

--- a/stories/src/vertical-nested/quote-app.jsx
+++ b/stories/src/vertical-nested/quote-app.jsx
@@ -30,7 +30,7 @@ const initialList: NestedQuoteList = {
 const publishOnDragStart = action('onDragStart');
 const publishOnDragEnd = action('onDragEnd');
 
-const Root = styled.div`
+const Root = styled('div')`
   background-color: ${colors.blue.deep};
   box-sizing: border-box;
   padding: ${grid * 2}px;

--- a/stories/src/vertical-nested/quote-list.jsx
+++ b/stories/src/vertical-nested/quote-list.jsx
@@ -14,11 +14,11 @@ import type {
   DraggableStateSnapshot,
 } from '../../../src';
 
-const Root = styled.div`
+const Root = styled('div')`
   width: 250px;
 `;
 
-const Container = styled.div`
+const Container = styled('div')`
   background-color: ${({ isDraggingOver }) =>
     isDraggingOver ? colors.blue.lighter : colors.blue.light};
   display: flex;

--- a/stories/src/vertical/quote-app.jsx
+++ b/stories/src/vertical/quote-app.jsx
@@ -12,7 +12,7 @@ import type { DropResult, DragStart } from '../../../src/types';
 const publishOnDragStart = action('onDragStart');
 const publishOnDragEnd = action('onDragEnd');
 
-const Root = styled.div`
+const Root = styled('div')`
   background-color: ${colors.blue.deep};
   box-sizing: border-box;
   padding: ${grid * 2}px;

--- a/website/gatsby-node.js
+++ b/website/gatsby-node.js
@@ -194,21 +194,3 @@ exports.createPages = ({ graphql, actions } /* : NodeParams */) => {
     );
   });
 };
-
-exports.onCreatePage = async ({ page, actions } /* : PageParams  */) => {
-  const { createPage } = actions;
-
-  return new Promise(resolve => {
-    if (page.path === '/') {
-      // TODO: is this needed?
-      page.layout = 'landing';
-      // Update the page.
-      createPage(page);
-    } else if (page.path.match(/^\/(examples|internal)\/./)) {
-      // TODO: is this needed?
-      page.layout = 'example';
-      createPage(page);
-    }
-    resolve();
-  });
-};

--- a/website/src/components/example-wrapper.jsx
+++ b/website/src/components/example-wrapper.jsx
@@ -15,7 +15,7 @@ const gitInfo = {
   host: 'github',
   // this branch variable is the thing to change to repoint codesandboxer.
   // if it is pointing away from master, it should not be merged into master.
-  branch: 'bcon/fixing-codesandboxer',
+  branch: 'master',
 };
 
 const importReplacements = [

--- a/website/src/components/example-wrapper.jsx
+++ b/website/src/components/example-wrapper.jsx
@@ -9,11 +9,14 @@ const gitInfo = {
   account: 'atlassian',
   repository: 'react-beautiful-dnd',
   host: 'github',
+  branch: 'website',
 };
 
 // this needs to handle internal v external
-export const gatsbyUrlToCSBPath = (url: string) =>
-  `website/src/pages${url.replace(/\/$/, '.jsx')}`;
+export const gatsbyUrlToCSBPath = (url: string) => {
+  console.log(url);
+  return `${url.replace(/\/$/, '.jsx')}`;
+};
 
 const importReplacements = [
   ['src', 'react-beautiful-dnd'],

--- a/website/src/components/example-wrapper.jsx
+++ b/website/src/components/example-wrapper.jsx
@@ -9,13 +9,7 @@ const gitInfo = {
   account: 'atlassian',
   repository: 'react-beautiful-dnd',
   host: 'github',
-  branch: 'website',
-};
-
-// this needs to handle internal v external
-export const gatsbyUrlToCSBPath = (url: string) => {
-  console.log(url);
-  return `${url.replace(/\/$/, '.jsx')}`;
+  branch: 'bcon/fixing-codesandboxer',
 };
 
 const importReplacements = [
@@ -23,7 +17,7 @@ const importReplacements = [
   ['src/', 'react-beautiful-dnd'],
 ];
 
-const ActionLink = styled.button`
+const ActionLink = styled('button')`
   border: 2px solid grey;
   margin: 0 ${grid}px;
   padding: ${grid * 1}px ${grid * 2}px;
@@ -56,11 +50,11 @@ const ActionLink = styled.button`
   }
 `;
 
-const Title = styled.h2`
+const Title = styled('h2')`
   display: inline-block;
 `;
 
-const Wrapper = styled.div`
+const Wrapper = styled('div')`
   display: flex;
   margin-bottom: 20px;
 `;

--- a/website/src/components/example-wrapper.jsx
+++ b/website/src/components/example-wrapper.jsx
@@ -5,10 +5,16 @@ import styled from 'react-emotion';
 import pkg from '../../../package.json';
 import { grid } from '../constants';
 
+// USEFUL INFO: Codesandboxer pulls info in from github, which means that whatever
+// branch is specified on this file will be pulled from, and you will need to push
+// if you want to see changes you have made reflected on codesandbox.
+
 const gitInfo = {
   account: 'atlassian',
   repository: 'react-beautiful-dnd',
   host: 'github',
+  // this branch variable is the thing to change to repoint codesandboxer.
+  // if it is pointing away from master, it should not be merged into master.
   branch: 'bcon/fixing-codesandboxer',
 };
 

--- a/website/src/components/examples/primatives/author-item.jsx
+++ b/website/src/components/examples/primatives/author-item.jsx
@@ -8,7 +8,7 @@ import type {
 } from '../../../../../src';
 import type { Author } from '../types';
 
-const Avatar = styled.img`
+const Avatar = styled('img')`
   width: 60px;
   height: 60px;
   border-radius: 50%;

--- a/website/src/components/examples/primatives/author-list.jsx
+++ b/website/src/components/examples/primatives/author-list.jsx
@@ -12,7 +12,7 @@ import type {
   DraggableStateSnapshot,
 } from '../../../../../src';
 
-const Wrapper = styled.div`
+const Wrapper = styled('div')`
   background-color: ${({ isDraggingOver }) =>
     isDraggingOver ? 'skyblue' : 'lightblue'};
   display: flex;
@@ -23,7 +23,7 @@ const Wrapper = styled.div`
   margin: ${grid}px 0;
 `;
 
-const DropZone = styled.div`
+const DropZone = styled('div')`
   display: flex;
   /*
     Needed to avoid growth in list due to lifting the first item
@@ -35,11 +35,11 @@ const DropZone = styled.div`
   min-width: 600px;
 `;
 
-const ScrollContainer = styled.div`
+const ScrollContainer = styled('div')`
   overflow: auto;
 `;
 
-const Container = styled.div`
+const Container = styled('div')`
   /* flex child */
   flex-grow: 1;
 

--- a/website/src/components/examples/primatives/quote-item.jsx
+++ b/website/src/components/examples/primatives/quote-item.jsx
@@ -11,7 +11,7 @@ type Props = {
   provided: DraggableProvided,
 };
 
-const Container = styled.a`
+const Container = styled('a')`
   border-radius: ${borderRadius}px;
   border: 1px solid grey;
   background-color: ${({ isDragging }) => (isDragging ? 'green' : 'white')};
@@ -41,7 +41,7 @@ const Container = styled.a`
   align-items: center;
 `;
 
-const Avatar = styled.img`
+const Avatar = styled('img')`
   width: 40px;
   height: 40px;
   border-radius: 50%;
@@ -50,7 +50,7 @@ const Avatar = styled.img`
   flex-grow: 0;
 `;
 
-const Content = styled.div`
+const Content = styled('div')`
   /* flex child */
   flex-grow: 1;
 
@@ -63,7 +63,7 @@ const Content = styled.div`
   flex-direction: column;
 `;
 
-const BlockQuote = styled.div`
+const BlockQuote = styled('div')`
   &::before {
     content: open-quote;
   }
@@ -73,17 +73,17 @@ const BlockQuote = styled.div`
   }
 `;
 
-const Footer = styled.div`
+const Footer = styled('div')`
   display: flex;
   margin-top: ${grid}px;
 `;
 
-const QuoteId = styled.small`
+const QuoteId = styled('small')`
   flex-grow: 0;
   margin: 0;
 `;
 
-const Attribution = styled.small`
+const Attribution = styled('small')`
   margin: 0;
   margin-left: ${grid}px;
   text-align: right;

--- a/website/src/components/examples/primatives/quote-list.jsx
+++ b/website/src/components/examples/primatives/quote-list.jsx
@@ -13,7 +13,7 @@ import type {
   DraggableStateSnapshot,
 } from '../../../../../src';
 
-const Wrapper = styled.div`
+const Wrapper = styled('div')`
   display: flex;
   flex-direction: column;
   opacity: ${({ isDropDisabled }) => (isDropDisabled ? 0.5 : 'inherit')};
@@ -24,7 +24,7 @@ const Wrapper = styled.div`
   width: 250px;
 `;
 
-const DropZone = styled.div`
+const DropZone = styled('div')`
   /* stop the list collapsing when empty */
   min-height: 250px;
   /* not relying on the items for a margin-bottom
@@ -32,13 +32,13 @@ const DropZone = styled.div`
   margin-bottom: ${grid}px;
 `;
 
-const ScrollContainer = styled.div`
+const ScrollContainer = styled('div')`
   overflow-x: hidden;
   overflow-y: auto;
   max-height: 300px;
 `;
 
-const Container = styled.div``;
+const Container = styled('div')``;
 
 type Props = {|
   listId: string,

--- a/website/src/components/examples/primatives/title.jsx
+++ b/website/src/components/examples/primatives/title.jsx
@@ -2,7 +2,7 @@
 import styled from 'react-emotion';
 import { grid } from '../../../constants';
 
-export default styled.h4`
+export default styled('h4')`
   padding: ${grid}px;
   transition: background-color ease 0.2s;
   flex-grow: 1;

--- a/website/src/components/landing/index.jsx
+++ b/website/src/components/landing/index.jsx
@@ -7,7 +7,7 @@ import Welcome from './welcome';
 import Beautiful from './beautiful';
 import Accessible from './accessible';
 
-const FullPageSection = styled.section`
+const FullPageSection = styled('section')`
   min-height: 100vh;
   background-color: ${colors.dark500};
 `;

--- a/website/src/components/landing/screen-reader-watcher.jsx
+++ b/website/src/components/landing/screen-reader-watcher.jsx
@@ -8,7 +8,7 @@ const FeedbackIcon = () => 'TODO';
 const isMutationObserverSupported: boolean =
   typeof MutationObserver !== 'undefined';
 
-const Container = styled.div`
+const Container = styled('div')`
   background-color: red;
   border-radius: 3px;
   color: red;
@@ -31,18 +31,18 @@ const Container = styled.div`
   }
 `;
 
-const Title = styled.h4`
+const Title = styled('h4')`
   margin-bottom: ${grid}px;
   display: flex;
   justify-content: center;
   align-items: center;
 `;
 
-const TitleIcon = styled.span`
+const TitleIcon = styled('span')`
   margin-left: ${grid}px;
 `;
 
-const Speech = styled.div``;
+const Speech = styled('div')``;
 
 const defaultMessage: string = `
   (This is what the screen reader will announce)

--- a/website/src/components/landing/welcome/board/column.jsx
+++ b/website/src/components/landing/welcome/board/column.jsx
@@ -37,7 +37,7 @@ class InnerList extends React.Component<InnerListProps> {
 
 const interactive: string = 'yellow';
 
-const Container = styled.div`
+const Container = styled('div')`
   background-color: ${props => (props.isDragging ? interactive : 'purple')};
   margin: 0 ${grid}px;
   color: red;
@@ -47,7 +47,7 @@ const Container = styled.div`
   width: 270px;
 `;
 
-const Header = styled.div`
+const Header = styled('div')`
   font-size: 20px;
   padding: ${grid}px;
   border-top-left-radius: 2px;
@@ -62,7 +62,7 @@ const Header = styled.div`
   }
 `;
 
-const List = styled.div`
+const List = styled('div')`
   min-height: 100px;
   padding: ${grid}px;
   /* The list will already been pushed down by the cards */

--- a/website/src/components/landing/welcome/board/index.jsx
+++ b/website/src/components/landing/welcome/board/index.jsx
@@ -22,7 +22,7 @@ type Props = {|
   numberOfColumns: 1 | 2,
 |};
 
-const Container = styled.div`
+const Container = styled('div')`
   display: flex;
   justify-content: center;
   align-items: flex-start;

--- a/website/src/components/landing/welcome/board/love-column-header.jsx
+++ b/website/src/components/landing/welcome/board/love-column-header.jsx
@@ -4,7 +4,7 @@ import styled from 'react-emotion';
 import HeartIcon from 'react-icons/lib/go/heart';
 import { grid } from '../../../../constants';
 
-const LoveContainer = styled.div`
+const LoveContainer = styled('div')`
   display: flex;
   align-items: center;
 `;

--- a/website/src/components/landing/welcome/board/quote.jsx
+++ b/website/src/components/landing/welcome/board/quote.jsx
@@ -14,7 +14,7 @@ type Props = {|
   index: number,
 |};
 
-const Container = styled.div`
+const Container = styled('div')`
   background-color: ${props =>
     props.isDragging ? props.author.colors.soft : 'red'};
   box-shadow: ${props => (props.isDragging ? `1px 1px 1px red` : 'none')};
@@ -34,7 +34,7 @@ const Container = styled.div`
   }
 `;
 
-const Avatar = styled.img`
+const Avatar = styled('img')`
   border-radius: 50%;
   width: 40px;
   height: 40px;
@@ -43,13 +43,13 @@ const Avatar = styled.img`
   flex-grow: 0;
 `;
 
-const Content = styled.div`
+const Content = styled('div')`
   display: flex;
   flex-direction: column;
   align-items: flex-start;
 `;
 
-const BlockQuote = styled.div`
+const BlockQuote = styled('div')`
   &::before {
     content: open-quote;
   }
@@ -59,7 +59,7 @@ const BlockQuote = styled.div`
   }
 `;
 
-const Attribution = styled.small`
+const Attribution = styled('small')`
   margin: 0;
   margin-top: ${grid}px;
   text-align: right;

--- a/website/src/components/landing/welcome/call-to-action.jsx
+++ b/website/src/components/landing/welcome/call-to-action.jsx
@@ -12,7 +12,7 @@ import type {
   DropResult,
 } from '../../../../../src';
 
-const ActionBox = styled.div`
+const ActionBox = styled('div')`
   display: flex;
   align-items: center;
 

--- a/website/src/components/landing/welcome/draggable-logo.jsx
+++ b/website/src/components/landing/welcome/draggable-logo.jsx
@@ -36,7 +36,7 @@ const minorRotation = keyframes`
 // eslint-disable-next-line import/prefer-default-export
 const shake = `${minorRotation} 0.5s linear infinite`;
 
-const Shaker = styled.div`
+const Shaker = styled('div')`
   animation: ${props => (props.shake ? shake : 'none')};
 `;
 

--- a/website/src/components/landing/welcome/index.jsx
+++ b/website/src/components/landing/welcome/index.jsx
@@ -9,7 +9,7 @@ import DraggableLogo from './draggable-logo';
 import { grid, gutter } from '../../../constants';
 import { smallView } from '../../media';
 
-const Brand = styled.div`
+const Brand = styled('div')`
   display: flex;
   align-items: center;
 
@@ -19,7 +19,7 @@ const Brand = styled.div`
   `)};
 `;
 
-const Title = styled.h1`
+const Title = styled('h1')`
   font-weight: normal;
   font-size: 40px;
   margin: 0;
@@ -31,12 +31,12 @@ const Title = styled.h1`
   `)};
 `;
 
-const Tagline = styled.p`
+const Tagline = styled('p')`
   font-size: 20px;
   ${smallView.fn(`text-align: center`)};
 `;
 
-const SideBySide = styled.div`
+const SideBySide = styled('div')`
   padding-top: ${grid * 10}px;
   padding-left: ${grid * 6}px;
   padding-right: ${grid * 6}px;
@@ -56,11 +56,11 @@ const SideBySide = styled.div`
 
 const verticalSpacing = `margin-top: ${gutter.large}px;`;
 
-const VerticalRhythm = styled.div`
+const VerticalRhythm = styled('div')`
   ${verticalSpacing};
 `;
 
-const Content = styled.div`
+const Content = styled('div')`
   margin-top: ${grid * 8}px;
   flex-grow: 1;
 
@@ -72,7 +72,7 @@ const Content = styled.div`
   `)};
 `;
 
-const Example = styled.div`
+const Example = styled('div')`
   flex-grow: 0;
 
   ${smallView.fn(`${verticalSpacing}`)};

--- a/website/src/components/landing/welcome/social-icons.jsx
+++ b/website/src/components/landing/welcome/social-icons.jsx
@@ -14,11 +14,11 @@ import {
   type DropResult,
 } from '../../../../../src';
 
-const Container = styled.div`
+const Container = styled('div')`
   display: flex;
 `;
 
-const ExternalLink = styled.a`
+const ExternalLink = styled('a')`
   color: ${colors.dark100};
   transition: color 0.2s ease;
   margin-right: ${grid}px;

--- a/website/src/components/layouts/example.jsx
+++ b/website/src/components/layouts/example.jsx
@@ -1,7 +1,7 @@
 // @flow
 import React, { type Node } from 'react';
 import { StaticQuery, graphql } from 'gatsby';
-import ExampleWrapper, { gatsbyUrlToCSBPath } from '../example-wrapper';
+import ExampleWrapper from '../example-wrapper';
 import CommonPage from '../common-page';
 import PageWrapper from '../page-wrapper';
 import { getTitleFromExamplePath } from '../../utils';
@@ -12,9 +12,10 @@ type Props = {
   location: {
     pathname: string,
   },
+  examplePath: string,
 };
 
-const ExamplePage = ({ children, location }: Props) => (
+const ExamplePage = ({ children, location, examplePath }: Props) => (
   <StaticQuery
     query={graphql`
       query examplesSidebarInfo {
@@ -52,7 +53,7 @@ const ExamplePage = ({ children, location }: Props) => (
         >
           <ExampleWrapper
             title={getTitleFromExamplePath(location.pathname, '/examples/')}
-            path={gatsbyUrlToCSBPath(location.pathname)}
+            path={examplePath}
           >
             {children}
           </ExampleWrapper>

--- a/website/src/components/page-wrapper.jsx
+++ b/website/src/components/page-wrapper.jsx
@@ -12,7 +12,7 @@ require('prism-themes/themes/prism-a11y-dark.css');
 
 const sectionGap: number = gutter.large;
 
-const Content = styled.div`
+const Content = styled('div')`
   background: ${colors.dark400};
   margin-left: ${sidebarWidth + gutter.normal}px;
   margin-right: ${gutter.normal}px;
@@ -25,7 +25,7 @@ const Content = styled.div`
   `)};
 `;
 
-const ContentSpacing = styled.div`
+const ContentSpacing = styled('div')`
   max-width: ${contentWidth}px;
   padding: ${sectionGap}px;
   padding-top: ${sectionGap}px;

--- a/website/src/components/sidebar/heading.jsx
+++ b/website/src/components/sidebar/heading.jsx
@@ -9,11 +9,11 @@ import Logo from '../logo';
 
 const iconSize: number = grid * 4;
 
-const Container = styled.div`
+const Container = styled('div')`
   display: flex;
 `;
 
-const Title = styled.h2`
+const Title = styled('h2')`
   margin: 0;
 `;
 
@@ -46,7 +46,7 @@ const SmallLogo = styled(Logo)`
   flex-grow: 0;
 `;
 
-const GithubLink = styled.a`
+const GithubLink = styled('a')`
   display: block;
   color: ${colors.dark100};
   padding: ${gutter.normal}px;

--- a/website/src/components/sidebar/index.jsx
+++ b/website/src/components/sidebar/index.jsx
@@ -11,7 +11,7 @@ import LinkList from './link-list';
 import spacing from './spacing';
 import { linkClassName, isActiveClassName } from './link-class-name';
 
-const Sidebar = styled.div`
+const Sidebar = styled('div')`
   height: 100vh;
   width: ${sidebarWidth}px;
   box-sizing: border-box;
@@ -35,13 +35,13 @@ const Sidebar = styled.div`
   }
 `;
 
-const Section = styled.div`
+const Section = styled('div')`
   margin-top: ${spacing.top}px;
   display: flex;
   flex-direction: column;
 `;
 
-const Title = styled.h3`
+const Title = styled('h3')`
   color: ${colors.dark100};
   font-size: 20px;
   padding: ${grid}px ${spacing.side}px;

--- a/website/src/examples/basic.jsx
+++ b/website/src/examples/basic.jsx
@@ -28,9 +28,6 @@ const Root = styled('div')`
 
 type Props = {|
   listStyle?: Object,
-  location: {
-    pathname: string,
-  },
 |};
 
 type State = {|

--- a/website/src/examples/basic.jsx
+++ b/website/src/examples/basic.jsx
@@ -14,7 +14,7 @@ const publishOnDragStart = (v?: any) => console.log('onDragStart', v);
 const publishOnDragEnd = (v?: any) => console.log('onDragEnd', v);
 /* eslint-enable no-console */
 
-const Root = styled.div`
+const Root = styled('div')`
   background-color: ${colors.dark300};
   box-sizing: border-box;
   padding: ${grid * 2}px;

--- a/website/src/examples/basic.jsx
+++ b/website/src/examples/basic.jsx
@@ -1,0 +1,97 @@
+// // @flow
+import React, { Component } from 'react';
+import styled from 'react-emotion';
+import { DragDropContext } from '../../../src';
+import QuoteList from '../components/examples/primatives/quote-list';
+import { grid, colors } from '../constants';
+import reorder from '../components/examples/reorder';
+import type { Quote } from '../components/examples/types';
+import { quotes as initialQuotes } from '../components/examples/data';
+import type { DropResult, DragStart } from '../../../src/types';
+
+/* eslint-disable no-console */
+const publishOnDragStart = (v?: any) => console.log('onDragStart', v);
+const publishOnDragEnd = (v?: any) => console.log('onDragEnd', v);
+/* eslint-enable no-console */
+
+const Root = styled.div`
+  background-color: ${colors.dark300};
+  box-sizing: border-box;
+  padding: ${grid * 2}px;
+  min-height: 100vh;
+
+  /* flexbox */
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+`;
+
+type Props = {|
+  listStyle?: Object,
+  location: {
+    pathname: string,
+  },
+|};
+
+type State = {|
+  quotes: Quote[],
+|};
+
+export default class QuoteApp extends Component<Props, State> {
+  /* eslint-disable react/sort-comp */
+
+  state: State = {
+    quotes: initialQuotes,
+  };
+
+  onDragStart = (initial: DragStart) => {
+    publishOnDragStart(initial);
+    // Add a little vibration if the browser supports it.
+    // Add's a nice little physical feedback
+    if (window.navigator.vibrate) {
+      window.navigator.vibrate(100);
+    }
+  };
+
+  onDragEnd = (result: DropResult) => {
+    publishOnDragEnd(result);
+
+    // dropped outside the list
+    if (!result.destination) {
+      return;
+    }
+
+    if (result.destination.index === result.source.index) {
+      return;
+    }
+
+    const quotes = reorder(
+      this.state.quotes,
+      result.source.index,
+      result.destination.index,
+    );
+
+    this.setState({
+      quotes,
+    });
+  };
+
+  render() {
+    const { quotes } = this.state;
+
+    return (
+      <DragDropContext
+        onDragStart={this.onDragStart}
+        onDragEnd={this.onDragEnd}
+      >
+        <Root>
+          <QuoteList
+            listId="list"
+            style={this.props.listStyle}
+            quotes={quotes}
+          />
+        </Root>
+      </DragDropContext>
+    );
+  }
+}

--- a/website/src/pages/examples/basic.jsx
+++ b/website/src/pages/examples/basic.jsx
@@ -3,7 +3,13 @@ import React from 'react';
 import Example from '../../examples/basic';
 import Layout from '../../components/layouts/example';
 
-export default ({ location }) => (
+export default ({
+  location,
+}: {
+  location: {
+    pathname: string,
+  },
+}) => (
   <Layout location={location} examplePath="website/src/examples/basic.jsx">
     <Example />
   </Layout>

--- a/website/src/pages/examples/basic.jsx
+++ b/website/src/pages/examples/basic.jsx
@@ -4,7 +4,7 @@ import Example from '../../examples/basic';
 import Layout from '../../components/layouts/example';
 
 export default ({ location }) => (
-  <Layout location={location} examplePath="src/examples/basic.jsx">
+  <Layout location={location} examplePath="website/src/examples/basic.jsx">
     <Example />
   </Layout>
 );

--- a/website/src/pages/examples/basic.jsx
+++ b/website/src/pages/examples/basic.jsx
@@ -1,100 +1,10 @@
 // @flow
-import React, { Component } from 'react';
-import styled from 'react-emotion';
-import { DragDropContext } from '../../../../src';
-import QuoteList from '../../components/examples/primatives/quote-list';
-import { grid, colors } from '../../constants';
-import reorder from '../../components/examples/reorder';
-import type { Quote } from '../../components/examples/types';
-import { quotes as initialQuotes } from '../../components/examples/data';
-import type { DropResult, DragStart } from '../../../../src/types';
+import React from 'react';
+import Example from '../../examples/basic';
 import Layout from '../../components/layouts/example';
 
-/* eslint-disable no-console */
-const publishOnDragStart = (v?: any) => console.log('onDragStart', v);
-const publishOnDragEnd = (v?: any) => console.log('onDragEnd', v);
-/* eslint-enable no-console */
-
-const Root = styled.div`
-  background-color: ${colors.dark300};
-  box-sizing: border-box;
-  padding: ${grid * 2}px;
-  min-height: 100vh;
-
-  /* flexbox */
-  display: flex;
-  justify-content: center;
-  align-items: flex-start;
-`;
-
-type Props = {|
-  listStyle?: Object,
-  location: {
-    pathname: string,
-  },
-|};
-
-type State = {|
-  quotes: Quote[],
-|};
-
-export default class QuoteApp extends Component<Props, State> {
-  /* eslint-disable react/sort-comp */
-
-  state: State = {
-    quotes: initialQuotes,
-  };
-
-  onDragStart = (initial: DragStart) => {
-    publishOnDragStart(initial);
-    // Add a little vibration if the browser supports it.
-    // Add's a nice little physical feedback
-    if (window.navigator.vibrate) {
-      window.navigator.vibrate(100);
-    }
-  };
-
-  onDragEnd = (result: DropResult) => {
-    publishOnDragEnd(result);
-
-    // dropped outside the list
-    if (!result.destination) {
-      return;
-    }
-
-    if (result.destination.index === result.source.index) {
-      return;
-    }
-
-    const quotes = reorder(
-      this.state.quotes,
-      result.source.index,
-      result.destination.index,
-    );
-
-    this.setState({
-      quotes,
-    });
-  };
-
-  render() {
-    const { quotes } = this.state;
-
-    return (
-      <Layout location={this.props.location}>
-        <DragDropContext
-          onDragStart={this.onDragStart}
-          onDragEnd={this.onDragEnd}
-        >
-          <Root>
-            <QuoteList
-              listId="list"
-              style={this.props.listStyle}
-              quotes={quotes}
-            />
-          </Root>
-        </DragDropContext>
-      </Layout>
-    );
-  }
-}
+export default ({ location }) => (
+  <Layout location={location} examplePath="src/examples/basic.jsx">
+    <Example />
+  </Layout>
+);

--- a/website/src/pages/get-started-old.jsx
+++ b/website/src/pages/get-started-old.jsx
@@ -8,7 +8,7 @@ import Logo from '../components/egghead-logo';
 const courseUrl =
   'https://egghead.io/courses/beautiful-and-accessible-drag-and-drop-with-react-beautiful-dnd';
 
-const Aye = styled.a`
+const Aye = styled('a')`
   margin: auto;
   display: block;
   width: 424px;

--- a/website/src/templates/markdown.jsx
+++ b/website/src/templates/markdown.jsx
@@ -23,7 +23,7 @@ type Props = {
   },
 };
 
-const EditLink = styled.a`
+const EditLink = styled('a')`
   float: right;
   display: flex;
   align-items: center;
@@ -34,7 +34,7 @@ const EditLink = styled.a`
   `)};
 `;
 
-const EditText = styled.span`
+const EditText = styled('span')`
   padding-left: ${grid}px;
 `;
 


### PR DESCRIPTION
Had some fun with this one. Some of the set-up for codesandbox was kind of hostile to understanding what it was doing, which I'm trying to make a bit nicer. I think ultimately I probably want a `gatsby-codesandboxer` plugin, as we could actually cut out referencing github using gatsby's runtime buuut we probably want a working website in the meantime.

Major changes:
- moved emotion to use emotion syntax (instead of fussing over adding a babelrc to our sandboxes)
- isolated example in its own file so it can be opened in codesandbox (previously it was trying to add the whole page
- provided the `branch` option to codesandboxer's git info so that it is easier to figure discover where codesandboxer is getting the files from

The isolated example pattern is a bit gross, but works for now, and the basic example demonstrates how it works okay.