### PR TITLE
Duck type DOM objects, to fix usage with react-frame-component

### DIFF
--- a/src/view/drag-handle/util/get-drag-handle-ref.js
+++ b/src/view/drag-handle/util/get-drag-handle-ref.js
@@ -13,7 +13,7 @@ const isSVG = (el: mixed) => {
   }
 
   // $FlowFixMe - flow does not know about SVGElement
-  return el instanceof SVGElement;
+  return el.nodeName === 'svg' || el instanceof SVGElement;
 };
 
 const throwIfSVG = (el: mixed) => {
@@ -51,7 +51,7 @@ const getDragHandleRef = (draggableRef: HTMLElement): HTMLElement => {
     `,
   );
 
-  invariant(el instanceof HTMLElement, 'A drag handle must be a HTMLElement');
+  invariant(el && el.nodeType === 1, 'A drag handle must be a HTMLElement');
 
   return el;
 };

--- a/src/view/throw-if-invalid-inner-ref.js
+++ b/src/view/throw-if-invalid-inner-ref.js
@@ -3,7 +3,7 @@ import invariant from 'tiny-invariant';
 
 export default (ref: ?mixed) => {
   invariant(
-    ref && ref instanceof HTMLElement,
+    ref && ref.nodeType === 1,
     `
     provided.innerRef has not been provided with a HTMLElement.
 

--- a/test/unit/view/drag-handle/interactive-elements.spec.js
+++ b/test/unit/view/drag-handle/interactive-elements.spec.js
@@ -134,7 +134,7 @@ forEach((control: Control) => {
         'http://www.w3.org/2000/svg',
         'svg',
       );
-      expect(svg instanceof SVGElement).toBe(true);
+      expect(svg.nodeName === 'svg' || svg instanceof SVGElement).toBe(true);
 
       mixedCase(interactiveTagNames).forEach((tagName: string) => {
         const parent: HTMLElement = document.createElement(tagName);
@@ -164,10 +164,10 @@ forEach((control: Control) => {
         'http://www.w3.org/2000/svg',
         'svg',
       );
-      expect(svg instanceof SVGElement).toBe(true);
+      expect(svg.nodeName === 'svg' || svg instanceof SVGElement).toBe(true);
 
       const div: HTMLElement = document.createElement('div');
-      expect(div instanceof HTMLElement).toBe(true);
+      expect(div && dev.nodeType === 1).toBe(true);
 
       [div, svg].forEach((child: Element) => {
         mixedCase(interactiveTagNames).forEach((tagName: string) => {

--- a/website/src/components/landing/screen-reader-watcher.jsx
+++ b/website/src/components/landing/screen-reader-watcher.jsx
@@ -101,7 +101,7 @@ export default class ScreenReaderWatcher extends React.Component<*, State> {
   onWindowFocus = (event: FocusEvent) => {
     const target: EventTarget = event.target;
 
-    if (!(target instanceof HTMLElement)) {
+    if (target.nodeType !== 1) {
       this.setState({ message: null });
       return;
     }


### PR DESCRIPTION
#796 Probably not comprehensive, but demonstrates how duck typing could accomplish the same objective without breaking iframe portal binding.