### PR TITLE
Correctly expose Droppable and Draggable component types

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -11,3 +11,4 @@
 # Example: // $ExpectError: This following line is correctly ignored by flow.
 suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe
 suppress_comment= \\(.\\|\n\\)*\\$ExpectError
+include_warnings=true

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "prettier:write": "yarn prettier --write $npm_package_config_prettier_target",
     "lint:eslint": "yarn eslint \"./**/*.{js,jsx}\"",
     "lint:css": "stylelint \"stories/**/*.{js,jsx}\" \"website/src/**/*.{js,jsx}\"",
-    "typecheck": "flow check",
+    "typecheck": "flow check --max-warnings=0",
     "bundle-size:check": "cross-env SNAPSHOT=match yarn bundle-size:update",
     "bundle-size:update": "yarn build:clean && yarn build:dist && yarn build:clean",
     "build": "yarn build:clean && yarn build:dist && yarn build:flow",

--- a/src/view/drag-handle/util/get-drag-handle-ref.js
+++ b/src/view/drag-handle/util/get-drag-handle-ref.js
@@ -12,7 +12,6 @@ const isSVG = (el: mixed) => {
     return false;
   }
 
-  // $FlowFixMe - flow does not know about SVGElement
   return el instanceof SVGElement;
 };
 

--- a/src/view/draggable/connected-draggable.js
+++ b/src/view/draggable/connected-draggable.js
@@ -1,5 +1,6 @@
 // @flow
 import { type Position } from 'css-box-model';
+// eslint-disable-next-line
 import * as React from 'react';
 import memoizeOne from 'memoize-one';
 import { connect } from 'react-redux';
@@ -264,6 +265,7 @@ const defaultProps = ({
   disableInteractiveElementBlocking: false,
 }: DefaultProps);
 
+// eslint-disable-next-line
 /*::
 class DraggableType extends React.Component<OwnProps> {
   static defaultProps = defaultProps;

--- a/src/view/draggable/connected-draggable.js
+++ b/src/view/draggable/connected-draggable.js
@@ -1,6 +1,6 @@
 // @flow
 import { type Position } from 'css-box-model';
-import { type Node } from 'react';
+import * as React from 'react';
 import memoizeOne from 'memoize-one';
 import { connect } from 'react-redux';
 import Draggable from './draggable';
@@ -258,10 +258,22 @@ const mapDispatchToProps: DispatchProps = {
   dropAnimationFinished: dropAnimationFinishedAction,
 };
 
+const defaultProps = ({
+  isDragDisabled: false,
+  // cannot drag interactive elements by default
+  disableInteractiveElementBlocking: false,
+}: DefaultProps);
+
+/*::
+class DraggableType extends React.Component<OwnProps> {
+  static defaultProps = defaultProps;
+}
+*/
+
 // Leaning heavily on the default shallow equality checking
 // that `connect` provides.
 // It avoids needing to do it own within `Draggable`
-const ConnectedDraggable: OwnProps => Node = (connect(
+const ConnectedDraggable: typeof DraggableType = (connect(
   // returning a function so each component can do its own memoization
   makeMapStateToProps,
   (mapDispatchToProps: any),
@@ -282,10 +294,6 @@ const ConnectedDraggable: OwnProps => Node = (connect(
   },
 ): any)(Draggable);
 
-ConnectedDraggable.defaultProps = ({
-  isDragDisabled: false,
-  // cannot drag interactive elements by default
-  disableInteractiveElementBlocking: false,
-}: DefaultProps);
+ConnectedDraggable.defaultProps = defaultProps;
 
 export default ConnectedDraggable;

--- a/src/view/draggable/connected-draggable.js
+++ b/src/view/draggable/connected-draggable.js
@@ -265,9 +265,11 @@ const defaultProps = ({
   disableInteractiveElementBlocking: false,
 }: DefaultProps);
 
+// Abstract class allows to specify props and defaults to component.
+// All other ways give any or do not let add default props.
 // eslint-disable-next-line
 /*::
-class DraggableType extends React.Component<OwnProps> {
+class DraggableType extends Component<OwnProps> {
   static defaultProps = defaultProps;
 }
 */

--- a/src/view/draggable/connected-draggable.js
+++ b/src/view/draggable/connected-draggable.js
@@ -1,7 +1,7 @@
 // @flow
 import { type Position } from 'css-box-model';
 // eslint-disable-next-line
-import * as React from 'react';
+import { Component } from 'react';
 import memoizeOne from 'memoize-one';
 import { connect } from 'react-redux';
 import Draggable from './draggable';

--- a/src/view/draggable/draggable-types.js
+++ b/src/view/draggable/draggable-types.js
@@ -131,17 +131,16 @@ export type MapProps = {|
 
 export type ChildrenFn = (Provided, StateSnapshot) => Node;
 
-export type OwnProps = {|
-  draggableId: DraggableId,
-  index: number,
-  children: ChildrenFn,
+export type DefaultProps = {|
   isDragDisabled: boolean,
   disableInteractiveElementBlocking: boolean,
 |};
 
-export type DefaultProps = {|
-  isDragDisabled: boolean,
-  disableInteractiveElementBlocking: boolean,
+export type OwnProps = {|
+  ...DefaultProps,
+  draggableId: DraggableId,
+  index: number,
+  children: ChildrenFn,
 |};
 
 export type Props = {|

--- a/src/view/droppable/connected-droppable.js
+++ b/src/view/droppable/connected-droppable.js
@@ -98,9 +98,11 @@ const defaultProps = ({
   ignoreContainerClipping: false,
 }: DefaultProps);
 
+// Abstract class allows to specify props and defaults to component.
+// All other ways give any or do not let add default props.
 // eslint-disable-next-line
 /*::
-class DroppableType extends React.Component<OwnProps> {
+class DroppableType extends Component<OwnProps> {
   static defaultProps = defaultProps;
 }
 */

--- a/src/view/droppable/connected-droppable.js
+++ b/src/view/droppable/connected-droppable.js
@@ -1,4 +1,5 @@
 // @flow
+// eslint-disable-next-line
 import * as React from 'react';
 import { connect } from 'react-redux';
 import memoizeOne from 'memoize-one';
@@ -97,6 +98,7 @@ const defaultProps = ({
   ignoreContainerClipping: false,
 }: DefaultProps);
 
+// eslint-disable-next-line
 /*::
 class DroppableType extends React.Component<OwnProps> {
   static defaultProps = defaultProps;

--- a/src/view/droppable/connected-droppable.js
+++ b/src/view/droppable/connected-droppable.js
@@ -1,6 +1,6 @@
 // @flow
 // eslint-disable-next-line
-import * as React from 'react';
+import { Component } from 'react';
 import { connect } from 'react-redux';
 import memoizeOne from 'memoize-one';
 import { storeKey } from '../context-keys';

--- a/src/view/droppable/connected-droppable.js
+++ b/src/view/droppable/connected-droppable.js
@@ -1,5 +1,5 @@
 // @flow
-import { type Node } from 'react';
+import * as React from 'react';
 import { connect } from 'react-redux';
 import memoizeOne from 'memoize-one';
 import { storeKey } from '../context-keys';
@@ -89,10 +89,24 @@ export const makeMapStateToProps = (): Selector => {
   return selector;
 };
 
+const defaultProps = ({
+  type: 'DEFAULT',
+  direction: 'vertical',
+  isDropDisabled: false,
+  isCombineEnabled: false,
+  ignoreContainerClipping: false,
+}: DefaultProps);
+
+/*::
+class DroppableType extends React.Component<OwnProps> {
+  static defaultProps = defaultProps;
+}
+*/
+
 // Leaning heavily on the default shallow equality checking
 // that `connect` provides.
 // It avoids needing to do it own within `Droppable`
-const ConnectedDroppable: OwnProps => Node = (connect(
+const ConnectedDroppable: typeof DroppableType = (connect(
   // returning a function so each component can do its own memoization
   makeMapStateToProps,
   // no dispatch props for droppable
@@ -113,12 +127,6 @@ const ConnectedDroppable: OwnProps => Node = (connect(
   },
 ): any)(Droppable);
 
-ConnectedDroppable.defaultProps = ({
-  type: 'DEFAULT',
-  direction: 'vertical',
-  isDropDisabled: false,
-  isCombineEnabled: false,
-  ignoreContainerClipping: false,
-}: DefaultProps);
+ConnectedDroppable.defaultProps = defaultProps;
 
 export default ConnectedDroppable;

--- a/src/view/droppable/droppable-types.js
+++ b/src/view/droppable/droppable-types.js
@@ -35,9 +35,7 @@ export type MapProps = {|
   placeholder: ?Placeholder,
 |};
 
-export type OwnProps = {|
-  children: (Provided, StateSnapshot) => Node,
-  droppableId: DroppableId,
+export type DefaultProps = {|
   type: TypeId,
   isDropDisabled: boolean,
   isCombineEnabled: boolean,
@@ -45,12 +43,10 @@ export type OwnProps = {|
   ignoreContainerClipping: boolean,
 |};
 
-export type DefaultProps = {|
-  type: string,
-  isDropDisabled: boolean,
-  isCombineEnabled: false,
-  direction: Direction,
-  ignoreContainerClipping: boolean,
+export type OwnProps = {|
+  ...DefaultProps,
+  children: (Provided, StateSnapshot) => Node,
+  droppableId: DroppableId,
 |};
 
 export type Props = {|

--- a/stories/src/primatives/author-list.jsx
+++ b/stories/src/primatives/author-list.jsx
@@ -67,18 +67,13 @@ export default class AuthorList extends Component<Props> {
     isCombineEnabled: false,
   };
   renderBoard = (dropProvided: DroppableProvided) => {
-    const { listType, quotes } = this.props;
+    const { quotes } = this.props;
 
     return (
       <Container>
         <DropZone innerRef={dropProvided.innerRef}>
           {quotes.map((quote: Quote, index: number) => (
-            <Draggable
-              key={quote.id}
-              draggableId={quote.id}
-              type={listType}
-              index={index}
-            >
+            <Draggable key={quote.id} draggableId={quote.id} index={index}>
               {(
                 dragProvided: DraggableProvided,
                 dragSnapshot: DraggableStateSnapshot,

--- a/stories/src/vertical-nested/quote-app.jsx
+++ b/stories/src/vertical-nested/quote-app.jsx
@@ -73,7 +73,6 @@ export default class QuoteApp extends Component<*, State> {
         result.destination.index,
       );
 
-      // $ExpectError - using spread
       const list: NestedQuoteList = {
         ...this.state.list,
         children,
@@ -93,7 +92,6 @@ export default class QuoteApp extends Component<*, State> {
 
       invariant(nested, 'could not find nested list');
 
-      // $ExpectError - using spread
       const updated: NestedQuoteList = {
         ...nested,
         children: reorder(
@@ -108,7 +106,6 @@ export default class QuoteApp extends Component<*, State> {
       const children = Array.from(this.state.list.children);
       children[nestedIndex] = updated;
 
-      // $ExpectError - using spread
       const list: NestedQuoteList = {
         ...this.state.list,
         children,

--- a/stories/src/vertical-nested/quote-list.jsx
+++ b/stories/src/vertical-nested/quote-list.jsx
@@ -40,8 +40,8 @@ const NestedContainer = styled(Container)`
 `;
 
 export default class QuoteList extends Component<{ list: NestedQuoteList }> {
-  renderQuote = (quote: Quote, type: string, index: number) => (
-    <Draggable key={quote.id} draggableId={quote.id} type={type} index={index}>
+  renderQuote = (quote: Quote, index: number) => (
+    <Draggable key={quote.id} draggableId={quote.id} index={index}>
       {(provided: DraggableProvided, snapshot: DraggableStateSnapshot) => (
         <QuoteItem
           quote={quote}
@@ -66,14 +66,9 @@ export default class QuoteList extends Component<{ list: NestedQuoteList }> {
           <Title>{list.title}</Title>
           {list.children.map((item: Quote | NestedQuoteList, index: number) =>
             !item.children ? (
-              this.renderQuote((item: any), list.id, index)
+              this.renderQuote((item: any), index)
             ) : (
-              <Draggable
-                draggableId={item.id}
-                type={list.id}
-                key={item.id}
-                index={index}
-              >
+              <Draggable draggableId={item.id} key={item.id} index={index}>
                 {(
                   dragProvided: DraggableProvided,
                   dragSnapshot: DraggableStateSnapshot,

--- a/test/test_flow.js
+++ b/test/test_flow.js
@@ -1,0 +1,38 @@
+// @flow
+
+import * as React from 'react';
+import { DragDropContext, Droppable, Draggable } from '../src';
+
+{
+  <>
+    <DragDropContext onDragEnd={() => {}}>{null}</DragDropContext>
+    {/* $ExpectError onDragEnd is required */}
+    <DragDropContext>{null}</DragDropContext>
+    {/* $ExpectError children is required */}
+    <DragDropContext onDragEnd={() => {}} />
+  </>;
+}
+
+{
+  <>
+    <Droppable droppableId="">{() => null}</Droppable>
+    {/* $ExpectError doppableId is required */}
+    <Droppable>{() => null}</Droppable>
+    {/* $ExpectError children as function is required*/}
+    <Droppable droppableId="" />
+  </>;
+}
+
+{
+  <>
+    <Draggable draggableId="" index={0}>
+      {() => null}
+    </Draggable>
+    {/* $ExpectError draggableId is required */}
+    <Draggable index={0}>{() => null}</Draggable>
+    {/* $ExpectError index is required */}
+    <Draggable draggableId="">{() => null}</Draggable>
+    {/* $ExpectError children as function is required*/}
+    <Draggable draggableId="" index={0} />
+  </>;
+}

--- a/test/test_flow.js
+++ b/test/test_flow.js
@@ -5,27 +5,27 @@ import * as React from 'react';
 import { DragDropContext, Droppable, Draggable } from '../src';
 
 {
-  <>
+  <React.Fragment>
     <DragDropContext onDragEnd={() => {}}>{null}</DragDropContext>
     {/* $ExpectError onDragEnd is required */}
     <DragDropContext>{null}</DragDropContext>
     {/* $ExpectError children is required */}
     <DragDropContext onDragEnd={() => {}} />
-  </>;
+  </React.Fragment>;
 }
 
 {
-  <>
+  <React.Fragment>
     <Droppable droppableId="">{() => null}</Droppable>
     {/* $ExpectError doppableId is required */}
     <Droppable>{() => null}</Droppable>
     {/* $ExpectError children as function is required*/}
     <Droppable droppableId="" />
-  </>;
+  </React.Fragment>;
 }
 
 {
-  <>
+  <React.Fragment>
     <Draggable draggableId="" index={0}>
       {() => null}
     </Draggable>
@@ -35,5 +35,5 @@ import { DragDropContext, Droppable, Draggable } from '../src';
     <Draggable draggableId="">{() => null}</Draggable>
     {/* $ExpectError children as function is required*/}
     <Draggable draggableId="" index={0} />
-  </>;
+  </React.Fragment>;
 }

--- a/test/test_flow.js
+++ b/test/test_flow.js
@@ -1,4 +1,5 @@
 // @flow
+/* eslint-disable */
 
 import * as React from 'react';
 import { DragDropContext, Droppable, Draggable } from '../src';

--- a/test/unit/state/middleware/responders/abort.spec.js
+++ b/test/unit/state/middleware/responders/abort.spec.js
@@ -95,7 +95,6 @@ it('should not publish an onDragEnd if aborted after a drop', () => {
   };
   store.dispatch(completeDrop(result));
   expect(responders.onDragEnd).toHaveBeenCalledTimes(1);
-  // $ExpectError - unknown mock reset property
   responders.onDragEnd.mockReset();
 
   // abort

--- a/test/unit/state/middleware/responders/announcements.spec.js
+++ b/test/unit/state/middleware/responders/announcements.spec.js
@@ -151,7 +151,6 @@ cases.forEach((current: Case) => {
     });
 
     it('should not announce twice if the responder makes an announcement', () => {
-      // $ExpectError - property does not exist on responder property
       responders[current.responder] = jest.fn(
         (data: any, provided: ResponderProvided) => {
           announce.mockReset();
@@ -169,7 +168,6 @@ cases.forEach((current: Case) => {
       jest.spyOn(console, 'warn').mockImplementation(() => {});
 
       let provided: ResponderProvided;
-      // $ExpectError - property does not exist on responder property
       responders[current.responder] = jest.fn(
         (data: any, supplied: ResponderProvided) => {
           announce.mockReset();
@@ -200,7 +198,6 @@ cases.forEach((current: Case) => {
       jest.spyOn(console, 'warn').mockImplementation(() => {});
 
       let provided: ResponderProvided;
-      // $ExpectError - property does not exist on responder property
       responders[current.responder] = jest.fn(
         (data: any, supplied: ResponderProvided) => {
           announce.mockReset();

--- a/test/unit/state/middleware/responders/flushing.spec.js
+++ b/test/unit/state/middleware/responders/flushing.spec.js
@@ -101,7 +101,6 @@ it('should work across multiple drags', () => {
     responders.onDragStart.mockReset();
     // $FlowFixMe - responder does not have mockReset property
     responders.onDragUpdate.mockReset();
-    // $FlowFixMe - responder does not have mockReset property
     responders.onDragEnd.mockReset();
   });
 });

--- a/test/unit/state/middleware/responders/repeated-use.spec.js
+++ b/test/unit/state/middleware/responders/repeated-use.spec.js
@@ -70,7 +70,6 @@ it('should behave correctly across multiple drags', () => {
     responders.onDragStart.mockReset();
     // $ExpectError - unknown mock reset property
     responders.onDragUpdate.mockReset();
-    // $ExpectError - unknown mock reset property
     responders.onDragEnd.mockReset();
   });
 });

--- a/test/unit/view/draggable/drag-handle-connection.spec.js
+++ b/test/unit/view/draggable/drag-handle-connection.spec.js
@@ -151,7 +151,6 @@ describe('handling drag handle events', () => {
           movementMode: 'SNAP',
         });
 
-      // $ExpectError - mock property on lift function
       expect(dispatchProps.lift).toHaveBeenCalledWith({
         id: draggable.id,
         clientSelection: origin,

--- a/website/src/components/examples/primatives/author-list.jsx
+++ b/website/src/components/examples/primatives/author-list.jsx
@@ -57,18 +57,13 @@ type Props = {|
 
 export default class AuthorList extends Component<Props> {
   renderBoard = (dropProvided: DroppableProvided) => {
-    const { listType, quotes } = this.props;
+    const { quotes } = this.props;
 
     return (
       <Container>
         <DropZone innerRef={dropProvided.innerRef}>
           {quotes.map((quote: Quote, index: number) => (
-            <Draggable
-              key={quote.id}
-              draggableId={quote.id}
-              type={listType}
-              index={index}
-            >
+            <Draggable key={quote.id} draggableId={quote.id} index={index}>
               {(
                 dragProvided: DraggableProvided,
                 dragSnapshot: DraggableStateSnapshot,

--- a/website/src/pages/private.jsx
+++ b/website/src/pages/private.jsx
@@ -33,7 +33,6 @@ const PrivateExamplesList = ({ data }: { data: ExampleData }) => (
 export default PrivateExamplesList;
 
 /* eslint-disable no-undef */
-// $FlowFixMe
 export const query = graphql`
   query privateExampleList {
     allSitePage(filter: { path: { regex: "/^/private/.+/" } }) {

--- a/website/src/templates/markdown.jsx
+++ b/website/src/templates/markdown.jsx
@@ -50,7 +50,6 @@ export default ({ data, location }: Props) => (
 );
 
 /* eslint-disable no-undef */
-// $FlowFixMe
 export const query = graphql`
   query markdownQuery($slug: String!) {
     markdownRemark(fields: { slug: { eq: $slug } }) {


### PR DESCRIPTION
Currently `Droppable` and `Draggable` components are treated as `any`
which a makes development less safer.

In this diff I with @istarkov help found a way to cover connected
components with default props without loosing type information.
A few basic flow tests will let to not remove this info accidentally.

As a result unused type property was result from some stories.

Some error suppressions are not necessary so I removed them.