### PR TITLE
fix: droppable-get-dimension withScroll

### DIFF
--- a/src/view/droppable-dimension-publisher/get-dimension.js
+++ b/src/view/droppable-dimension-publisher/get-dimension.js
@@ -117,7 +117,7 @@ export default ({
 
     return {
       client: frameClient,
-      page: withScroll(frameClient),
+      page: withScroll(frameClient, windowScroll),
       scroll: getScroll(closestScrollable),
       scrollSize,
       shouldClipSubject,


### PR DESCRIPTION
We're forking your amazing repo and need to add some features based on our product logic, and then I found a potential bug, which I spent a lot of time debuging.

The default container supporting horizontal scroll is the window, which would not trigger any bugs currently. But I think it would be stricter to code it this way. Pls take a look and see if I'm doing this correctly. 