### PR TITLE
Update Droppable's StateSnapshot to include isDropAnimating

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,25 +1,25 @@
 {
   "dist/react-beautiful-dnd.js": {
-    "bundled": 347275,
-    "minified": 134225,
-    "gzipped": 39798
+    "bundled": 347594,
+    "minified": 134362,
+    "gzipped": 39810
   },
   "dist/react-beautiful-dnd.min.js": {
-    "bundled": 295057,
-    "minified": 109593,
-    "gzipped": 31944
+    "bundled": 295178,
+    "minified": 109541,
+    "gzipped": 31910
   },
   "dist/react-beautiful-dnd.esm.js": {
-    "bundled": 228983,
-    "minified": 120746,
-    "gzipped": 30051,
+    "bundled": 229335,
+    "minified": 120969,
+    "gzipped": 30082,
     "treeshaked": {
       "rollup": {
-        "code": 81922,
+        "code": 81870,
         "import_statements": 846
       },
       "webpack": {
-        "code": 84599
+        "code": 84547
       }
     }
   }

--- a/src/view/droppable/connected-droppable.js
+++ b/src/view/droppable/connected-droppable.js
@@ -27,6 +27,7 @@ const defaultMapProps: MapProps = {
   isDraggingOver: false,
   draggingOverWith: null,
   placeholder: null,
+  isDropAnimating: false,
 };
 
 // Returning a function to ensure each
@@ -37,10 +38,12 @@ export const makeMapStateToProps = (): Selector => {
       isDraggingOver: boolean,
       draggingOverWith: ?DraggableId,
       placeholder: ?Placeholder,
+      isDropAnimating: boolean,
     ): MapProps => ({
       isDraggingOver,
       draggingOverWith,
       placeholder,
+      isDropAnimating,
     }),
   );
 
@@ -48,6 +51,7 @@ export const makeMapStateToProps = (): Selector => {
     id: DroppableId,
     draggable: DraggableDimension,
     impact: DragImpact,
+    result: ?DropResult,
   ) => {
     const isOver: boolean = whatIsDraggedOver(impact) === id;
     if (!isOver) {
@@ -62,7 +66,14 @@ export const makeMapStateToProps = (): Selector => {
       ? draggable.placeholder
       : null;
 
-    return getMapProps(true, draggable.descriptor.id, placeholder);
+    const isDropAnimating: boolean = result ? result.reason === 'DROP' : false;
+
+    return getMapProps(
+      true,
+      draggable.descriptor.id,
+      placeholder,
+      isDropAnimating,
+    );
   };
 
   const selector = (state: State, ownProps: OwnProps): MapProps => {
@@ -81,7 +92,12 @@ export const makeMapStateToProps = (): Selector => {
     if (state.phase === 'DROP_ANIMATING') {
       const draggable: DraggableDimension =
         state.dimensions.draggables[state.pending.result.draggableId];
-      return getDraggingOverProps(id, draggable, state.pending.impact);
+      return getDraggingOverProps(
+        id,
+        draggable,
+        state.pending.impact,
+        state.pending.result,
+      );
     }
 
     return defaultMapProps;

--- a/src/view/droppable/droppable-types.js
+++ b/src/view/droppable/droppable-types.js
@@ -22,6 +22,7 @@ export type Provided = {|
 
 export type StateSnapshot = {|
   isDraggingOver: boolean,
+  isDropAnimating: boolean,
   draggingOverWith: ?DraggableId,
 |};
 

--- a/src/view/droppable/droppable.jsx
+++ b/src/view/droppable/droppable.jsx
@@ -141,6 +141,7 @@ export default class Droppable extends Component<Props> {
       // mapProps
       ignoreContainerClipping,
       isDraggingOver,
+      isDropAnimating,
       draggingOverWith,
     } = this.props;
     const provided: Provided = {
@@ -152,6 +153,7 @@ export default class Droppable extends Component<Props> {
     };
     const snapshot: StateSnapshot = {
       isDraggingOver,
+      isDropAnimating,
       draggingOverWith,
     };
 


### PR DESCRIPTION
# What
- Add `isDropAnimating` to the type for Droppable's `StateSnapshot`
- Make sure `Droppable` passes that value from props to snapshot
- In `connected-droppable`, when `state.phase === 'DROP_ANIMATING'` pass along `state.pending.result` to `getDraggingProps`
  - value for the new `isDropAnimating` prop is essentially computed with: `whatIsDraggedOver(impact) === id && result && result.reason === 'DROP'`

# Why
> use case: I have a component that I want to respond to changes in `isDropAnimating` that isn't a `Draggable`, but is contained by a `Droppable`

## Links
- #1074 