### PR TITLE
Fix broken example source link

### DIFF
--- a/docs/patterns/using-a-portal.md
+++ b/docs/patterns/using-a-portal.md
@@ -24,8 +24,8 @@ If your `Draggable` does not have many children nodes then you are welcome to us
 
 <!-- TODO: embed example here on new website -->
 
-We have created a [working example](https://react-beautiful-dnd.netlify.com/?selectedKind=Portals&selectedStory=Using%20your%20own%20portal&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel) that uses `React.Portal` to guide you. You can view the [source here](https://github.com/atlassian/react-beautiful-dnd/blob/master/stories/11-portal-story.js)
+We have created a [working example](https://react-beautiful-dnd.netlify.com/?selectedKind=Portals&selectedStory=Using%20your%20own%20portal&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel) that uses `React.Portal` to guide you. You can view the [source here](https://github.com/atlassian/react-beautiful-dnd/blob/master/stories/11-portal.stories.js).
 
 ## Tables
 
-If are doing drag and drop reordering within a `<table>` we have created a portal section inside our [table guide](/docs/patterns/tables)
+If you are doing drag and drop reordering within a `<table>` we have created a portal section inside our [table guide](/docs/patterns/tables).


### PR DESCRIPTION
The link to the portal usage source was broken, This PR fixes that and another typo in the portal documentation.