### PR TITLE
Add isSortDisabled

### DIFF
--- a/src/state/action-creators.js
+++ b/src/state/action-creators.js
@@ -124,6 +124,23 @@ export const updateDroppableIsCombineEnabled = (
   payload: args,
 });
 
+export type UpdateDroppableIsSortDisabledArgs = {|
+  id: DroppableId,
+  isSortDisabled: boolean,
+|};
+
+export type UpdateDroppableIsSortDisabledAction = {|
+  type: 'UPDATE_DROPPABLE_IS_SORT_DISABLED',
+  payload: UpdateDroppableIsSortDisabledArgs,
+|};
+
+export const updateDroppableIsSortDisabled = (
+  args: UpdateDroppableIsSortDisabledArgs,
+): UpdateDroppableIsSortDisabledAction => ({
+  type: 'UPDATE_DROPPABLE_IS_SORT_DISABLED',
+  payload: args,
+});
+
 export type MoveArgs = {|
   client: Position,
 |};
@@ -304,6 +321,7 @@ export type Action =
   | UpdateDroppableScrollAction
   | UpdateDroppableIsEnabledAction
   | UpdateDroppableIsCombineEnabledAction
+  | UpdateDroppableIsSortDisabledAction
   | MoveByWindowScrollAction
   | UpdateViewportMaxScrollAction
   // | PostJumpScrollAction

--- a/src/state/dimension-marshal/dimension-marshal-types.js
+++ b/src/state/dimension-marshal/dimension-marshal-types.js
@@ -4,6 +4,7 @@ import type {
   UpdateDroppableScrollArgs,
   UpdateDroppableIsEnabledArgs,
   UpdateDroppableIsCombineEnabledArgs,
+  UpdateDroppableIsSortDisabledArgs,
 } from '../action-creators';
 import type {
   DraggableDescriptor,
@@ -98,6 +99,8 @@ export type DimensionMarshal = {|
     id: DroppableId,
     isEnabled: boolean,
   ) => void,
+  // it is also possible to update whether sorting is disabled
+  updateDroppableIsSortDisabled: (id: DroppableId, isDisabled: boolean) => void,
   updateDroppableScroll: (id: DroppableId, newScroll: Position) => void,
   scrollDroppable: (id: DroppableId, change: Position) => void,
   unregisterDroppable: (descriptor: DroppableDescriptor) => void,
@@ -113,5 +116,8 @@ export type Callbacks = {|
   updateDroppableIsEnabled: (args: UpdateDroppableIsEnabledArgs) => mixed,
   updateDroppableIsCombineEnabled: (
     args: UpdateDroppableIsCombineEnabledArgs,
+  ) => mixed,
+  updateDroppableIsSortDisabled: (
+    args: UpdateDroppableIsSortDisabledArgs,
   ) => mixed,
 |};

--- a/src/state/dimension-marshal/dimension-marshal.js
+++ b/src/state/dimension-marshal/dimension-marshal.js
@@ -241,6 +241,23 @@ export default (callbacks: Callbacks) => {
     callbacks.updateDroppableIsCombineEnabled({ id, isCombineEnabled });
   };
 
+  const updateDroppableIsSortDisabled = (
+    id: DroppableId,
+    isSortDisabled: boolean,
+  ) => {
+    invariant(
+      entries.droppables[id],
+      `Cannot update isSortDisabled flag of Droppable ${id} as it is not registered`,
+    );
+
+    // no need to update
+    if (!collection) {
+      return;
+    }
+
+    callbacks.updateDroppableIsSortDisabled({ id, isSortDisabled });
+  };
+
   const updateDroppableScroll = (id: DroppableId, newScroll: Position) => {
     invariant(
       entries.droppables[id],
@@ -327,6 +344,7 @@ export default (callbacks: Callbacks) => {
     // droppable changes
     updateDroppableIsEnabled,
     updateDroppableIsCombineEnabled,
+    updateDroppableIsSortDisabled,
     scrollDroppable,
     updateDroppableScroll,
 

--- a/src/state/droppable/get-droppable.js
+++ b/src/state/droppable/get-droppable.js
@@ -25,6 +25,7 @@ type Args = {|
   descriptor: DroppableDescriptor,
   isEnabled: boolean,
   isCombineEnabled: boolean,
+  isSortDisabled: boolean,
   isFixedOnPage: boolean,
   direction: 'vertical' | 'horizontal',
   client: BoxModel,
@@ -37,6 +38,7 @@ export default ({
   descriptor,
   isEnabled,
   isCombineEnabled,
+  isSortDisabled,
   isFixedOnPage,
   direction,
   client,
@@ -88,6 +90,7 @@ export default ({
   const dimension: DroppableDimension = {
     descriptor,
     isCombineEnabled,
+    isSortDisabled,
     isFixedOnPage,
     axis,
     isEnabled,

--- a/src/state/get-drag-impact/get-combine-impact.js
+++ b/src/state/get-drag-impact/get-combine-impact.js
@@ -40,6 +40,7 @@ type IsCombiningWithArgs = {|
 
 const isCombiningWith = ({
   id,
+  destination,
   currentCenter,
   axis,
   borderBox,
@@ -50,7 +51,7 @@ const isCombiningWith = ({
   const start: number = borderBox[axis.start] + displacedBy;
   const end: number = borderBox[axis.end] + displacedBy;
   const size: number = borderBox[axis.size];
-  const twoThirdsOfSize: number = size * 0.666;
+  const combineArea = destination.isSortDisabled ? size * 0.5 : size * 0.666;
 
   const whenEntered: UserDirection = getWhenEntered(
     id,
@@ -62,10 +63,10 @@ const isCombiningWith = ({
 
   if (isMovingForward) {
     // combine when moving in the front 2/3 of the item
-    return isWithin(start, start + twoThirdsOfSize)(targetCenter);
+    return isWithin(start, start + combineArea)(targetCenter);
   }
   // combine when moving in the back 2/3 of the item
-  return isWithin(end - twoThirdsOfSize, end)(targetCenter);
+  return isWithin(end - combineArea, end)(targetCenter);
 };
 
 type Args = {|
@@ -107,6 +108,7 @@ export default ({
 
       return isCombiningWith({
         id,
+        destination,
         currentCenter,
         axis,
         borderBox: child.page.borderBox,
@@ -130,7 +132,6 @@ export default ({
   };
 
   // no change of displacement
-  // clearing any destination
   const withMerge: DragImpact = {
     ...previousImpact,
     destination: null,

--- a/src/state/get-drag-impact/index.js
+++ b/src/state/get-drag-impact/index.js
@@ -76,7 +76,7 @@ export default ({
     return withMerge;
   }
 
-  return isWithinHomeDroppable
+  const test = isWithinHomeDroppable
     ? inHomeList({
         pageBorderBoxCenterWithDroppableScrollChange,
         draggable,
@@ -95,4 +95,8 @@ export default ({
         viewport,
         userDirection,
       });
+
+  console.log(test.destination);
+
+  return test;
 };

--- a/src/state/move-in-direction/move-to-next-place/index.js
+++ b/src/state/move-in-direction/move-to-next-place/index.js
@@ -49,24 +49,32 @@ export default ({
   );
   const isInHomeList: boolean = isHomeOf(draggable, destination);
 
-  const impact: ?DragImpact =
-    moveToNextCombine({
-      isInHomeList,
-      isMovingForward,
-      draggable,
-      destination,
-      insideDestination,
-      previousImpact,
-    }) ||
-    moveToNextIndex({
-      isMovingForward,
-      isInHomeList,
-      draggable,
-      draggables,
-      destination,
-      insideDestination,
-      previousImpact,
-    });
+  const impact: ?DragImpact = destination.isSortDisabled
+    ? moveToNextCombine({
+        isInHomeList,
+        isMovingForward,
+        draggable,
+        destination,
+        insideDestination,
+        previousImpact,
+      })
+    : moveToNextCombine({
+        isInHomeList,
+        isMovingForward,
+        draggable,
+        destination,
+        insideDestination,
+        previousImpact,
+      }) ||
+      moveToNextIndex({
+        isMovingForward,
+        isInHomeList,
+        draggable,
+        draggables,
+        destination,
+        insideDestination,
+        previousImpact,
+      });
 
   if (!impact) {
     return null;

--- a/src/state/move-in-direction/move-to-next-place/move-to-next-combine/index.js
+++ b/src/state/move-in-direction/move-to-next-place/move-to-next-combine/index.js
@@ -33,15 +33,17 @@ export default ({
     return null;
   }
 
-  // we move from a merge to a reorder
-  if (previousImpact.merge) {
+  // we move from a merge to a reorder, unless sort is disabled
+  if (previousImpact.merge && !destination.isSortDisabled) {
     return null;
   }
 
   // we are on a location, and we are trying to combine onto a sibling
   // that sibling might be displaced
 
-  const location: ?DraggableLocation = previousImpact.destination;
+  const location: ?DraggableLocation = destination.isSortDisabled
+    ? previousImpact.destination || previousImpact.merge
+    : previousImpact.destination;
   invariant(location, 'Need a previous location to move from into a combine');
 
   const currentIndex: number = location.index;
@@ -79,6 +81,7 @@ export default ({
 
   const merge: CombineImpact = {
     whenEntered: isMovingForward ? forward : backward,
+    index: targetIndex,
     combine: {
       draggableId: target.descriptor.id,
       droppableId: destination.descriptor.id,

--- a/src/state/publish-while-dragging/adjust-modified-droppables.js
+++ b/src/state/publish-while-dragging/adjust-modified-droppables.js
@@ -121,6 +121,7 @@ export default ({
         descriptor: provided.descriptor,
         isEnabled: provided.isEnabled,
         isCombineEnabled: provided.isCombineEnabled,
+        isSortDisabled: provided.isSortDisabled,
         isFixedOnPage: provided.isFixedOnPage,
         direction: provided.axis.direction,
         client,

--- a/src/state/reducer.js
+++ b/src/state/reducer.js
@@ -280,6 +280,39 @@ export default (state: State = idle, action: Action): State => {
     return postDroppableChange(state, updated, true);
   }
 
+  if (action.type === 'UPDATE_DROPPABLE_IS_SORT_DISABLED') {
+    // Things are locked at this point
+    if (state.phase === 'DROP_PENDING') {
+      return state;
+    }
+
+    invariant(
+      isMovementAllowed(state),
+      `Attempting to move in an unsupported phase ${state.phase}`,
+    );
+
+    const { id, isSortDisabled } = action.payload;
+    const target: ?DroppableDimension = state.dimensions.droppables[id];
+
+    invariant(
+      target,
+      `Cannot find Droppable[id: ${id}] to toggle its isSortDisabled state`,
+    );
+
+    invariant(
+      target.isSortDisabled !== isSortDisabled,
+      `Trying to set droppable isSortDisabled to ${String(isSortDisabled)}
+      but it is already ${String(target.isSortDisabled)}`,
+    );
+
+    const updated: DroppableDimension = {
+      ...target,
+      isSortDisabled,
+    };
+
+    return postDroppableChange(state, updated, true);
+  }
+
   if (action.type === 'MOVE_BY_WINDOW_SCROLL') {
     // No longer accepting changes
     if (state.phase === 'DROP_PENDING' || state.phase === 'DROP_ANIMATING') {

--- a/src/types.js
+++ b/src/types.js
@@ -128,6 +128,7 @@ export type DroppableDimension = {|
   axis: Axis,
   isEnabled: boolean,
   isCombineEnabled: boolean,
+  isSortDisabled: boolean,
   // relative to the current viewport
   client: BoxModel,
   // relative to the whole page
@@ -186,6 +187,7 @@ export type Combine = {|
 export type CombineImpact = {|
   // This has an impact on the hitbox for a grouping action
   whenEntered: UserDirection,
+  index: number,
   combine: Combine,
 |};
 

--- a/src/view/drag-drop-context/drag-drop-context.jsx
+++ b/src/view/drag-drop-context/drag-drop-context.jsx
@@ -34,6 +34,7 @@ import {
   updateDroppableScroll,
   updateDroppableIsEnabled,
   updateDroppableIsCombineEnabled,
+  updateDroppableIsSortDisabled,
   collectionStarting,
 } from '../../state/action-creators';
 import { getFormattedMessage } from '../../dev-warning';
@@ -121,6 +122,7 @@ export default class DragDropContext extends React.Component<Props> {
         updateDroppableScroll,
         updateDroppableIsEnabled,
         updateDroppableIsCombineEnabled,
+        updateDroppableIsSortDisabled,
         collectionStarting,
       },
       this.store.dispatch,

--- a/src/view/droppable-dimension-publisher/droppable-dimension-publisher.jsx
+++ b/src/view/droppable-dimension-publisher/droppable-dimension-publisher.jsx
@@ -31,6 +31,7 @@ type Props = {|
   direction: Direction,
   isDropDisabled: boolean,
   isCombineEnabled: boolean,
+  isSortDisabled: boolean,
   ignoreContainerClipping: boolean,
   getPlaceholderRef: () => ?HTMLElement,
   getDroppableRef: () => ?HTMLElement,
@@ -188,6 +189,8 @@ export default class DroppableDimensionPublisher extends React.Component<Props> 
       this.props.isDropDisabled !== prevProps.isDropDisabled;
     const isCombineChanged: boolean =
       this.props.isCombineEnabled !== prevProps.isCombineEnabled;
+    const isSortChanged: boolean =
+      this.props.isSortDiabled !== prevProps.isSortDisabled;
 
     if (!isDisabledChanged && !isCombineChanged) {
       return;
@@ -206,6 +209,13 @@ export default class DroppableDimensionPublisher extends React.Component<Props> 
       marshal.updateDroppableIsCombineEnabled(
         this.props.droppableId,
         this.props.isCombineEnabled,
+      );
+    }
+
+    if (isSortChanged) {
+      marshal.updateDroppableIsSortDisabled(
+        this.props.droppableId,
+        this.props.isSortDisabled,
       );
     }
   }
@@ -285,6 +295,7 @@ export default class DroppableDimensionPublisher extends React.Component<Props> 
         direction: this.props.direction,
         isDropDisabled: this.props.isDropDisabled,
         isCombineEnabled: this.props.isCombineEnabled,
+        isSortDisabled: this.props.isSortDisabled,
         shouldClipSubject: !this.props.ignoreContainerClipping,
       }),
     );
@@ -320,6 +331,7 @@ export default class DroppableDimensionPublisher extends React.Component<Props> 
       direction: this.props.direction,
       isDropDisabled: this.props.isDropDisabled,
       isCombineEnabled: this.props.isCombineEnabled,
+      isSortDisabled: this.props.isSortDisabled,
       shouldClipSubject: !this.props.ignoreContainerClipping,
     });
 

--- a/src/view/droppable-dimension-publisher/get-dimension.js
+++ b/src/view/droppable-dimension-publisher/get-dimension.js
@@ -87,6 +87,7 @@ type Args = {|
   direction: Direction,
   isDropDisabled: boolean,
   isCombineEnabled: boolean,
+  isSortDisabled: boolean,
   shouldClipSubject: boolean,
 |};
 
@@ -98,6 +99,7 @@ export default ({
   direction,
   isDropDisabled,
   isCombineEnabled,
+  isSortDisabled,
   shouldClipSubject,
 }: Args): DroppableDimension => {
   const closestScrollable: ?Element = env.closestScrollable;
@@ -128,6 +130,7 @@ export default ({
     descriptor,
     isEnabled: !isDropDisabled,
     isCombineEnabled,
+    isSortDisabled,
     isFixedOnPage: env.isFixedOnPage,
     direction,
     client,

--- a/src/view/droppable/check-own-props.js
+++ b/src/view/droppable/check-own-props.js
@@ -13,6 +13,10 @@ export default (props: Props) => {
     'isCombineEnabled must be a boolean',
   );
   invariant(
+    typeof props.isSortDisabled === 'boolean',
+    'isSortDisabled must be a boolean',
+  );
+  invariant(
     typeof props.ignoreContainerClipping === 'boolean',
     'ignoreContainerClipping must be a boolean',
   );

--- a/src/view/droppable/connected-droppable.js
+++ b/src/view/droppable/connected-droppable.js
@@ -95,6 +95,7 @@ const defaultProps = ({
   direction: 'vertical',
   isDropDisabled: false,
   isCombineEnabled: false,
+  isSortDisabled: false,
   ignoreContainerClipping: false,
 }: DefaultProps);
 

--- a/src/view/droppable/droppable-types.js
+++ b/src/view/droppable/droppable-types.js
@@ -39,6 +39,7 @@ export type DefaultProps = {|
   type: TypeId,
   isDropDisabled: boolean,
   isCombineEnabled: boolean,
+  isSortDisabled: boolean,
   direction: Direction,
   ignoreContainerClipping: boolean,
 |};

--- a/src/view/droppable/droppable.jsx
+++ b/src/view/droppable/droppable.jsx
@@ -138,6 +138,7 @@ export default class Droppable extends Component<Props> {
       droppableId,
       isDropDisabled,
       isCombineEnabled,
+      isSortDisabled,
       // mapProps
       ignoreContainerClipping,
       isDraggingOver,
@@ -163,6 +164,7 @@ export default class Droppable extends Component<Props> {
         ignoreContainerClipping={ignoreContainerClipping}
         isDropDisabled={isDropDisabled}
         isCombineEnabled={isCombineEnabled}
+        isSortDisabled={isSortDisabled}
         getDroppableRef={this.getDroppableRef}
         getPlaceholderRef={this.getPlaceholderRef}
       >

--- a/stories/1-single-vertical-list.stories.js
+++ b/stories/1-single-vertical-list.stories.js
@@ -58,4 +58,7 @@ storiesOf('single vertical list', module)
   ))
   .add('with combine enabled', () => (
     <QuoteApp initial={data.small} isCombineEnabled />
+  ))
+  .add('with combine enabled and with sort disabled', () => (
+    <QuoteApp initial={data.small} isCombineEnabled isSortDisabled />
   ));

--- a/stories/src/primatives/quote-list.jsx
+++ b/stories/src/primatives/quote-list.jsx
@@ -59,6 +59,7 @@ type Props = {|
   scrollContainerStyle?: Object,
   isDropDisabled?: boolean,
   isCombineEnabled?: boolean,
+  isSortDisabled?: boolean,
   style?: Object,
   // may not be provided - and might be null
   ignoreContainerClipping?: boolean,
@@ -131,6 +132,7 @@ export default class QuoteList extends React.Component<Props> {
       scrollContainerStyle,
       isDropDisabled,
       isCombineEnabled,
+      isSortDisabled,
       listId,
       listType,
       style,
@@ -145,6 +147,7 @@ export default class QuoteList extends React.Component<Props> {
         ignoreContainerClipping={ignoreContainerClipping}
         isDropDisabled={isDropDisabled}
         isCombineEnabled={isCombineEnabled}
+        isSortDisabled={isSortDisabled}
       >
         {(
           dropProvided: DroppableProvided,

--- a/stories/src/vertical/quote-app.jsx
+++ b/stories/src/vertical/quote-app.jsx
@@ -23,6 +23,7 @@ const Root = styled.div`
 type Props = {|
   initial: Quote[],
   isCombineEnabled?: boolean,
+  isSortDisabled?: boolean,
   listStyle?: Object,
 |};
 
@@ -34,6 +35,7 @@ export default class QuoteApp extends Component<Props, State> {
   /* eslint-disable react/sort-comp */
   static defaultProps = {
     isCombineEnabled: false,
+    isSortDisabled: false,
   };
 
   state: State = {
@@ -92,6 +94,7 @@ export default class QuoteApp extends Component<Props, State> {
             style={this.props.listStyle}
             quotes={quotes}
             isCombineEnabled={this.props.isCombineEnabled}
+            isSortDisabled={this.props.isSortDisabled}
           />
         </Root>
       </DragDropContext>


### PR DESCRIPTION
Closes #1116 

Hey Alex,

I wanted to take a shot at implementing this to help me understand how the library works under the hood and see for myself what the lift would be to add `isSortDisabled` (name pending ofc).

I've added it throughout the codebase, and partially implemented it when using keyboard commands.  There are some small bugs though.  (If you change directions with the key commands, it doesn't register the `moveToNextCombine` the first time)

I have some questions that I was hoping you would be able to shed some insight into.

**If you can only combine, how should a lifted draggable behave on `MOVE_*` actions?**
My first thought is that you would move to combine for each up and down, and could return to the elements original starting index.  You wouldn't be able to move to any other index.

**Where is the best place to start when trying to prevent the placeholder reordering?**
My first thought was I had to do something in the getDragImpact function, but now I'm not so sure.

If you have any thoughts please let me know, totally willing to just tear it all down and give it another shot 👍   