### PR TITLE
Fix heading styling

### DIFF
--- a/docs/api/drag-drop-context.md
+++ b/docs/api/drag-drop-context.md
@@ -96,7 +96,7 @@ function App() {
 }
 ```
 
-## `Responder`s
+## `Responders`
 
 > `Responders` were previously known as `Hooks`
 


### PR DESCRIPTION
Moved the 's' in Responders heading inside the back-ticks