### PR TITLE
Remove custom ExpectError from source code

### DIFF
--- a/src/view/use-droppable-dimension-publisher/use-droppable-dimension-publisher.js
+++ b/src/view/use-droppable-dimension-publisher/use-droppable-dimension-publisher.js
@@ -56,8 +56,8 @@ export default function useDroppableDimensionPublisher(args: Props) {
   const whileDraggingRef = useRef<?WhileDragging>(null);
   const appContext: AppContextValue = useRequiredContext(AppContext);
   const marshal: DimensionMarshal = appContext.marshal;
-  const previousRef: { current: Props } = usePreviousRef(args);
-  const descriptor: DroppableDescriptor = useMemo((): DroppableDescriptor => {
+  const previousRef = usePreviousRef(args);
+  const descriptor = useMemo<DroppableDescriptor>(() => {
     return {
       id: args.droppableId,
       type: args.type,

--- a/src/view/use-previous-ref.js
+++ b/src/view/use-previous-ref.js
@@ -1,9 +1,7 @@
 // @flow
 import { useRef, useEffect } from 'react';
 
-// Should return MutableRefObject<T> but I cannot import this type from 'react';
-// $ExpectError - MutableRefObject I want you
-export default function usePrevious<T>(current: T): MutableRefObject<T> {
+export default function usePrevious<T>(current: T): {| current: T |} {
   const ref = useRef<T>(current);
 
   // will be updated on the next render


### PR DESCRIPTION
ExpectError is not always defined in user config and flow fails there.

MutatableRefObject is just exact object with current field. I don't
think it will be exported.

```js
type MutatableRefObject<T> = {| current: T |};
```