### PR TITLE
Fix IE11 autoscroll behaviour

### DIFF
--- a/src/view/use-drag-handle/sensor/use-keyboard-sensor.js
+++ b/src/view/use-drag-handle/sensor/use-keyboard-sensor.js
@@ -127,7 +127,8 @@ export default function useKeyboardSensor(args: Args): OnKeyDown {
           // IE11 fix:
           // Scrollable events still bubble up and are caught by this handler in ie11.
           // We can ignore this event
-          if (event.currentTarget !== getWindow()) {
+          const window = getWindow();
+          if (event.currentTarget === window && event.target !== window) {
             return;
           }
 

--- a/src/view/use-drag-handle/sensor/use-mouse-sensor.js
+++ b/src/view/use-drag-handle/sensor/use-mouse-sensor.js
@@ -231,7 +231,8 @@ export default function useMouseSensor(args: Args): OnMouseDown {
           // IE11 fix:
           // Scrollable events still bubble up and are caught by this handler in ie11.
           // We can ignore this event
-          if (event.currentTarget !== getWindow()) {
+          const window = getWindow();
+          if (event.currentTarget === window && event.target !== window) {
             return;
           }
 

--- a/test/unit/view/drag-handle/keyboard-sensor.spec.js
+++ b/test/unit/view/drag-handle/keyboard-sensor.spec.js
@@ -2,6 +2,7 @@
 import { getRect, type Position } from 'css-box-model';
 import { type ReactWrapper } from 'enzyme';
 import * as keyCodes from '../../../../src/view/key-codes';
+import * as getWindowFromEl from '../../../../src/view/window/get-window-from-el';
 import { withKeyboard } from '../../../utils/user-input-util';
 import {
   callbacksCalled,
@@ -202,22 +203,32 @@ describe('progress', () => {
     expect(event.defaultPrevented).toBe(false);
   });
 
-  it('should not fire an onWindowScroll if it is not the window scrolling (ie11 bug)', () => {
+  it('should not fire an onWindowScroll if the scroll event was not dispatched from window (ie11 bug)', () => {
     // start the lift
     pressSpacebar(wrapper);
 
     // trigger scroll event
     const scrollable: HTMLElement = document.createElement('div');
     const fakeEvent: Event = new Event('scroll');
+    const fakeWindow: HTMLElement = document.createElement('div');
+    const getWindowSpy = jest
+      .spyOn(getWindowFromEl, 'default')
+      .mockImplementation(() => fakeWindow);
     Object.defineProperties(fakeEvent, {
-      currentTarget: {
+      target: {
         writable: true,
         value: scrollable,
+      },
+      currentTarget: {
+        writable: true,
+        value: fakeWindow,
       },
     });
     window.dispatchEvent(fakeEvent);
 
     expect(callbacks.onWindowScroll).not.toHaveBeenCalled();
+
+    getWindowSpy.mockRestore();
   });
 
   it('should prevent using keyboard keys that modify scroll', () => {


### PR DESCRIPTION
Repro:
- Add a `console.log(action.type)` [here](https://github.com/atlassian/react-beautiful-dnd/blob/master/src/state/reducer.js#L62)
- Run the storybook and go to `fixed list with fixed sidebar`
- (In Chrome) with dev-tools open, drag an item such that auto-scroll is triggered, note action types logged
- (In IE11) with dev-tools open, drag an item such that auto-scroll is triggered, note action types logged

Bug (IE11 only):
- Error in console - `Invariant failed: Window scrolling is currently not supported for fixed lists. Aborting drag`
- `MOVE_BY_WINDOW_SCROLL` action dispatched (whereas it is not in Chrome)

I am not sure I have the full context of how window scrolling is managed here, so this could be the wrong approach, but in any case I suspect that the fix in https://github.com/atlassian/react-beautiful-dnd/issues/1088 did not have the intended effect.

Happy to look for other solutions if this is not the way to go.

Fantastic library and API, many thanks for your efforts 👏 

