### PR TITLE
Multi-drag example: fix incorrect selection count

### DIFF
--- a/stories/src/multi-drag/task-app.jsx
+++ b/stories/src/multi-drag/task-app.jsx
@@ -26,6 +26,10 @@ const getTasks = (entities: Entities, columnId: Id): Task[] =>
   entities.columns[columnId].taskIds.map(
     (taskId: Id): Task => entities.tasks[taskId],
   );
+const getSelected = (selected: Id[], entities: Entities, columnId: Id): Id[] => {
+  const available: Id[] = entities.columns[columnId].taskIds;
+  return selected.filter((selectedId: Id): boolean => available.includes(selectedId));
+};
 export default class TaskApp extends Component<*, State> {
   state: State = {
     entities: initial,
@@ -196,7 +200,7 @@ export default class TaskApp extends Component<*, State> {
             <Column
               column={entities.columns[columnId]}
               tasks={getTasks(entities, columnId)}
-              selectedTaskIds={selected}
+              selectedTaskIds={getSelected(selected, entities, columnId)}
               key={columnId}
               draggingTaskId={this.state.draggingTaskId}
               toggleSelection={this.toggleSelection}

--- a/stories/src/multi-drag/task-app.jsx
+++ b/stories/src/multi-drag/task-app.jsx
@@ -26,9 +26,15 @@ const getTasks = (entities: Entities, columnId: Id): Task[] =>
   entities.columns[columnId].taskIds.map(
     (taskId: Id): Task => entities.tasks[taskId],
   );
-const getSelected = (selected: Id[], entities: Entities, columnId: Id): Id[] => {
+const getSelected = (
+  selected: Id[],
+  entities: Entities,
+  columnId: Id,
+): Id[] => {
   const available: Id[] = entities.columns[columnId].taskIds;
-  return selected.filter((selectedId: Id): boolean => available.includes(selectedId));
+  return selected.filter(
+    (selectedId: Id): boolean => available.includes(selectedId),
+  );
 };
 export default class TaskApp extends Component<*, State> {
   state: State = {


### PR DESCRIPTION
When dragging multiple items the selection count is also shown to display how many of these items in drag, but now this count includes even items selected in another column.

PS Another and IMO better way to fix this is to forcibly clear selection on 2nd list when drag is started/initial drop is finished, but I don't have a time right now to create such fix :(