### PR TITLE
Resolve #1108 - error handling improvements

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,25 +1,25 @@
 {
   "dist/react-beautiful-dnd.js": {
-    "bundled": 393181,
-    "minified": 147695,
-    "gzipped": 41532
+    "bundled": 394170,
+    "minified": 147884,
+    "gzipped": 41623
   },
   "dist/react-beautiful-dnd.min.js": {
-    "bundled": 324803,
-    "minified": 116622,
-    "gzipped": 33468
+    "bundled": 325920,
+    "minified": 116961,
+    "gzipped": 33612
   },
   "dist/react-beautiful-dnd.esm.js": {
-    "bundled": 239412,
-    "minified": 124303,
-    "gzipped": 31620,
+    "bundled": 240342,
+    "minified": 124725,
+    "gzipped": 31771,
     "treeshaked": {
       "rollup": {
-        "code": 30396,
-        "import_statements": 793
+        "code": 30700,
+        "import_statements": 800
       },
       "webpack": {
-        "code": 34327
+        "code": 34654
       }
     }
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -40,6 +40,13 @@ const commonjsArgs = {
       'isValidElementType',
       'isContextConsumer',
     ],
+    'node_modules/react-is/index.js': [
+      'isValidElementType',
+      'isContextConsumer',
+    ],
+    'node_modules/react-redux/es/components/connectAdvanced.js': [
+      'isContextConsumer',
+    ],
   },
 };
 

--- a/src/utilities/handle-errors.js
+++ b/src/utilities/handle-errors.js
@@ -1,0 +1,19 @@
+// @flow
+/*
+ * Utility file for keeping track of errors we have already logged
+ * to eliminate duplication of logging due to the window listener on the error event.
+ */
+const errorMap = {};
+
+export const hasLoggedError = (key: string): number => errorMap[key];
+
+export const setError = (key: string): void => {
+  errorMap[key] = 1;
+};
+
+export const clearErrorMap = (): void => {
+  const props = Object.keys(errorMap);
+  for (let i = 0; i < props.length; i++) {
+    delete errorMap[props[i]];
+  }
+};

--- a/test/unit/view/drag-drop-context/error-handling.spec.js
+++ b/test/unit/view/drag-drop-context/error-handling.spec.js
@@ -12,6 +12,7 @@ import type {
   StateSnapshot as DraggableStateSnapshot,
 } from '../../../../src/view/draggable/draggable-types';
 import { getComputedSpacing } from '../../../utils/dimension';
+import * as errorUtils from '../../../../src/utilities/handle-errors';
 
 type Props = {|
   provided: DraggableProvided,
@@ -141,6 +142,9 @@ it('should recover from an error on mount', () => {
     }
     return null;
   }
+  // verify we are internally keeping track of errors so we don't double log
+  const hasLoggedErrorSpy = jest.spyOn(errorUtils, 'hasLoggedError');
+  const setErrorSpy = jest.spyOn(errorUtils, 'setError');
   // This is lame. enzyme is bubbling up errors that where caught in componentDidCatch to the window
   expect(() =>
     mount(
@@ -149,4 +153,6 @@ it('should recover from an error on mount', () => {
       </DragDropContext>,
     ),
   ).toThrow();
+  expect(hasLoggedErrorSpy).toHaveBeenCalled();
+  expect(setErrorSpy).toHaveBeenCalled();
 });


### PR DESCRIPTION
Keep track of errors with an internal store and add a type property to the errors we catch with the error boundary so we only keep track of internal errors.