### PR TITLE
Update responders.md

### DIFF
--- a/docs/guides/responders.md
+++ b/docs/guides/responders.md
@@ -76,6 +76,7 @@ type DragStart = {|
   draggableId: DraggableId,
   type: TypeId,
   source: DraggableLocation,
+  mode: MovementMode,
 |};
 
 type DraggableLocation = {|


### PR DESCRIPTION
Missing `mode` in the type description of DragStart.