### PR TITLE
Fix IE11 autoscroll behaviour (v12)

### DIFF
--- a/src/view/scroll-listener.js
+++ b/src/view/scroll-listener.js
@@ -34,7 +34,7 @@ function getWindowScrollBinding(update: () => void): EventBinding {
       // IE11 fix:
       // Scrollable events still bubble up and are caught by this handler in ie11.
       // We can ignore this event
-      if (event.currentTarget !== window) {
+      if (event.currentTarget === window && event.target !== window) {
         return;
       }
 


### PR DESCRIPTION
Logic from https://github.com/atlassian/react-beautiful-dnd/pull/1308 targeting `virtual` branch.

Not clear to me how to test this, as `getWindow` doesn't seem to be being used in this branch.