### PR TITLE
Fix IE11 auto-scroll behaviour

### DIFF
--- a/src/view/scroll-listener.js
+++ b/src/view/scroll-listener.js
@@ -34,7 +34,10 @@ function getWindowScrollBinding(update: () => void): EventBinding {
       // IE11 fix:
       // Scrollable events still bubble up and are caught by this handler in ie11.
       // We can ignore this event
-      if (event.currentTarget !== window) {
+      if (
+        event.currentTarget === window &&
+        (event.target !== window && event.target !== window.document)
+      ) {
         return;
       }
 


### PR DESCRIPTION
This is another attempt at the fix previously tried with https://github.com/atlassian/react-beautiful-dnd/pull/1384.

I was able to see the auto-scrolling issues mentioned in the above PR by auto-scrolling with the various lists in the storybook, looks like it also needs a check for `window.document`, which this PR adds.

Repro steps for original bug:
- Run the storybook and go to `fixed list with fixed sidebar`
- (In IE11) with dev-tools open, drag an item such that auto-scroll is triggered

Bug:
- Error in console - `Invariant failed: Window scrolling is currently not supported for fixed lists. Aborting drag`

BTW - If you are testing Edge / IE11 locally on a Mac, I can highly recommend `Parallels`. I had previously been debugging using a Win10 VM on VirtualBox, and it was pretty painful/slow. Currently using the the demo of Parallels Desktop and it's super fast. One thing, in case it saves you some time, if you want to run storybook on the host and open it in your VM you will need to run the following from privileged command line on VM:

For VirtualBox:
```
netsh interface portproxy add v4tov4 listenport=9002 listenaddress=127.0.0.1 connectport=9002 connectaddress=10.0.2.2
```

For Parallels:
```
netsh interface portproxy add v4tov4 listenport=9002 listenaddress=127.0.0.1 connectport=9002 connectaddress=10.211.55.2
```