### PR TITLE
add isCombineOnly alternative to isCombineEnabled

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,25 +1,25 @@
 {
   "dist/react-beautiful-dnd.js": {
-    "bundled": 392081,
-    "minified": 147079,
-    "gzipped": 41340
+    "bundled": 389996,
+    "minified": 146829,
+    "gzipped": 41283
   },
   "dist/react-beautiful-dnd.min.js": {
-    "bundled": 323864,
-    "minified": 116189,
-    "gzipped": 33372
+    "bundled": 321313,
+    "minified": 115555,
+    "gzipped": 33288
   },
   "dist/react-beautiful-dnd.esm.js": {
-    "bundled": 238384,
-    "minified": 123773,
-    "gzipped": 31477,
+    "bundled": 236703,
+    "minified": 123664,
+    "gzipped": 31394,
     "treeshaked": {
       "rollup": {
-        "code": 29975,
+        "code": 30400,
         "import_statements": 793
       },
       "webpack": {
-        "code": 33907
+        "code": 34326
       }
     }
   }

--- a/docs/api/droppable.md
+++ b/docs/api/droppable.md
@@ -31,6 +31,7 @@ type Props = {|
   type?: TypeId,
   isDropDisabled?: boolean,
   isCombineEnabled?: boolean,
+  isCombineOnly?: boolean,
   direction?: Direction,
   ignoreContainerClipping?: boolean,
   children: (Provided, StateSnapshot) => Node,

--- a/docs/guides/combining.md
+++ b/docs/guides/combining.md
@@ -11,6 +11,7 @@
 ## Setup
 
 In order to enable combining you need to set `isCombineEnabled` to `true` on a `<Droppable />` and you are good to go!
+If you _only_ want to combine, you can use `isCombineOnly` instead.
 
 ```js
 <Droppable droppableId="droppable" isCombineEnabled>

--- a/src/state/action-creators.js
+++ b/src/state/action-creators.js
@@ -111,15 +111,32 @@ export type UpdateDroppableIsCombineEnabledArgs = {|
   isCombineEnabled: boolean,
 |};
 
+export type UpdateDroppableIsCombineOnlyArgs = {|
+  id: DroppableId,
+  isCombineOnly: boolean,
+|};
+
 export type UpdateDroppableIsCombineEnabledAction = {|
   type: 'UPDATE_DROPPABLE_IS_COMBINE_ENABLED',
   payload: UpdateDroppableIsCombineEnabledArgs,
+|};
+
+export type UpdateDroppableIsCombineOnlyAction = {|
+  type: 'UPDATE_DROPPABLE_IS_COMBINE_ONLY',
+  payload: UpdateDroppableIsCombineOnlyArgs,
 |};
 
 export const updateDroppableIsCombineEnabled = (
   args: UpdateDroppableIsCombineEnabledArgs,
 ): UpdateDroppableIsCombineEnabledAction => ({
   type: 'UPDATE_DROPPABLE_IS_COMBINE_ENABLED',
+  payload: args,
+});
+
+export const updateDroppableIsCombineOnly = (
+  args: UpdateDroppableIsCombineOnlyArgs,
+): UpdateDroppableIsCombineOnlyAction => ({
+  type: 'UPDATE_DROPPABLE_IS_COMBINE_ONLY',
   payload: args,
 });
 
@@ -320,6 +337,7 @@ export type Action =
   | UpdateDroppableScrollAction
   | UpdateDroppableIsEnabledAction
   | UpdateDroppableIsCombineEnabledAction
+  | UpdateDroppableIsCombineOnlyAction
   | MoveByWindowScrollAction
   | UpdateViewportMaxScrollAction
   // | PostJumpScrollAction

--- a/src/state/dimension-marshal/dimension-marshal-types.js
+++ b/src/state/dimension-marshal/dimension-marshal-types.js
@@ -4,6 +4,7 @@ import type {
   UpdateDroppableScrollArgs,
   UpdateDroppableIsEnabledArgs,
   UpdateDroppableIsCombineEnabledArgs,
+  UpdateDroppableIsCombineOnlyArgs,
 } from '../action-creators';
 import type {
   DraggableDescriptor,
@@ -97,6 +98,10 @@ export type DimensionMarshal = {|
     id: DroppableId,
     isEnabled: boolean,
   ) => void,
+  updateDroppableIsCombineOnly: (
+    id: DroppableId,
+    isEnabled: boolean,
+  ) => void,
   updateDroppableScroll: (id: DroppableId, newScroll: Position) => void,
   scrollDroppable: (id: DroppableId, change: Position) => void,
   unregisterDroppable: (descriptor: DroppableDescriptor) => void,
@@ -112,5 +117,8 @@ export type Callbacks = {|
   updateDroppableIsEnabled: (args: UpdateDroppableIsEnabledArgs) => mixed,
   updateDroppableIsCombineEnabled: (
     args: UpdateDroppableIsCombineEnabledArgs,
+  ) => mixed,
+  updateDroppableIsCombineOnly: (
+    args: UpdateDroppableIsCombineOnlyArgs,
   ) => mixed,
 |};

--- a/src/state/dimension-marshal/dimension-marshal.js
+++ b/src/state/dimension-marshal/dimension-marshal.js
@@ -241,6 +241,23 @@ export default (callbacks: Callbacks) => {
     callbacks.updateDroppableIsCombineEnabled({ id, isCombineEnabled });
   };
 
+  const updateDroppableIsCombineOnly = (
+    id: DroppableId,
+    isCombineOnly: boolean,
+  ) => {
+    invariant(
+      entries.droppables[id],
+      `Cannot update isCombineOnly flag of Droppable ${id} as it is not registered`,
+    );
+
+    // no need to update
+    if (!collection) {
+      return;
+    }
+
+    callbacks.updateDroppableIsCombineOnly({ id, isCombineOnly });
+  };
+
   const updateDroppableScroll = (id: DroppableId, newScroll: Position) => {
     invariant(
       entries.droppables[id],
@@ -326,6 +343,7 @@ export default (callbacks: Callbacks) => {
     // droppable changes
     updateDroppableIsEnabled,
     updateDroppableIsCombineEnabled,
+    updateDroppableIsCombineOnly,
     scrollDroppable,
     updateDroppableScroll,
 

--- a/src/state/droppable/get-droppable.js
+++ b/src/state/droppable/get-droppable.js
@@ -25,6 +25,7 @@ type Args = {|
   descriptor: DroppableDescriptor,
   isEnabled: boolean,
   isCombineEnabled: boolean,
+  isCombineOnly: boolean,
   isFixedOnPage: boolean,
   direction: 'vertical' | 'horizontal',
   client: BoxModel,
@@ -37,6 +38,7 @@ export default ({
   descriptor,
   isEnabled,
   isCombineEnabled,
+  isCombineOnly,
   isFixedOnPage,
   direction,
   client,
@@ -88,6 +90,7 @@ export default ({
   const dimension: DroppableDimension = {
     descriptor,
     isCombineEnabled,
+    isCombineOnly,
     isFixedOnPage,
     axis,
     isEnabled,

--- a/src/state/get-drag-impact/get-combine-impact.js
+++ b/src/state/get-drag-impact/get-combine-impact.js
@@ -38,6 +38,7 @@ type IsCombiningWithArgs = {|
   borderBox: Rect,
   displaceBy: Position,
   currentUserDirection: UserDirection,
+  isCombineOnly: ?boolean,
   oldMerge: ?CombineImpact,
 |};
 
@@ -48,12 +49,13 @@ const isCombiningWith = ({
   borderBox,
   displaceBy,
   currentUserDirection,
+  isCombineOnly,
   oldMerge,
 }: IsCombiningWithArgs): boolean => {
   const start: number = borderBox[axis.start] + displaceBy[axis.line];
   const end: number = borderBox[axis.end] + displaceBy[axis.line];
   const size: number = borderBox[axis.size];
-  const twoThirdsOfSize: number = size * 0.666;
+  const twoThirdsOfSize: number = size * (isCombineOnly ? 1 : 0.666);
 
   const whenEntered: UserDirection = getWhenEntered(
     id,
@@ -76,6 +78,7 @@ type Args = {|
   previousImpact: DragImpact,
   destination: DroppableDimension,
   insideDestinationWithoutDraggable: DraggableDimension[],
+  isCombineOnly: ?boolean,
   userDirection: UserDirection,
   onLift: OnLift,
 |};
@@ -84,10 +87,11 @@ export default ({
   previousImpact,
   destination,
   insideDestinationWithoutDraggable,
+  isCombineOnly,
   userDirection,
   onLift,
 }: Args): ?DragImpact => {
-  if (!destination.isCombineEnabled) {
+  if (!destination.isCombineEnabled && !destination.isCombineOnly) {
     return null;
   }
 
@@ -115,6 +119,7 @@ export default ({
         borderBox: child.page.borderBox,
         displaceBy,
         currentUserDirection: userDirection,
+        isCombineOnly,
         oldMerge,
       });
     },

--- a/src/state/get-drag-impact/index.js
+++ b/src/state/get-drag-impact/index.js
@@ -84,6 +84,10 @@ export default ({
     return withMerge;
   }
 
+  if (destination.isCombineOnly) {
+    return noImpact;
+  }
+
   return getReorderImpact({
     pageBorderBoxCenterWithDroppableScrollChange,
     destination,

--- a/src/state/move-in-direction/move-to-next-place/index.js
+++ b/src/state/move-in-direction/move-to-next-place/index.js
@@ -60,17 +60,7 @@ export default ({
       destination,
       insideDestination,
       previousImpact,
-    }) ||
-    moveToNextIndex({
-      isMovingForward,
-      isInHomeList,
-      draggable,
-      draggables,
-      destination,
-      insideDestination,
-      previousImpact,
-      onLift,
-    });
+    })
 
   if (!impact) {
     return null;

--- a/src/state/move-in-direction/move-to-next-place/move-to-next-combine/index.js
+++ b/src/state/move-in-direction/move-to-next-place/move-to-next-combine/index.js
@@ -29,19 +29,19 @@ export default ({
   insideDestination: originalInsideDestination,
   previousImpact,
 }: Args): ?DragImpact => {
-  if (!destination.isCombineEnabled) {
+  if (!destination.isCombineEnabled && !destination.isCombineOnly) {
     return null;
   }
 
   // we move from a merge to a reorder
-  if (previousImpact.merge) {
+  if (previousImpact.merge && false) {
     return null;
   }
 
   // we are on a location, and we are trying to combine onto a sibling
   // that sibling might be displaced
 
-  const location: ?DraggableLocation = previousImpact.destination;
+  const location: ?DraggableLocation = previousImpact.destination || previousImpact.merge;
   invariant(location, 'Need a previous location to move from into a combine');
 
   const currentIndex: number = location.index;

--- a/src/state/move-in-direction/move-to-next-place/move-to-next-index/from-combine.js
+++ b/src/state/move-in-direction/move-to-next-place/move-to-next-index/from-combine.js
@@ -29,7 +29,7 @@ export default ({
   merge,
   onLift,
 }: Args): ?Instruction => {
-  if (!destination.isCombineEnabled) {
+  if (!destination.isCombineEnabled && !destination.isCombineOnly) {
     return null;
   }
 

--- a/src/state/publish-while-dragging/update-droppables/index.js
+++ b/src/state/publish-while-dragging/update-droppables/index.js
@@ -123,6 +123,7 @@ export default ({
         descriptor: provided.descriptor,
         isEnabled: provided.isEnabled,
         isCombineEnabled: provided.isCombineEnabled,
+        isCombineOnly: provided.isCombineOnly,
         isFixedOnPage: provided.isFixedOnPage,
         direction: provided.axis.direction,
         client,

--- a/src/state/reducer.js
+++ b/src/state/reducer.js
@@ -291,6 +291,39 @@ export default (state: State = idle, action: Action): State => {
     return postDroppableChange(state, updated, true);
   }
 
+  if (action.type === 'UPDATE_DROPPABLE_IS_COMBINE_ONLY') {
+    // Things are locked at this point
+    if (state.phase === 'DROP_PENDING') {
+      return state;
+    }
+
+    invariant(
+      isMovementAllowed(state),
+      `Attempting to move in an unsupported phase ${state.phase}`,
+    );
+
+    const { id, isCombineOnly } = action.payload;
+    const target: ?DroppableDimension = state.dimensions.droppables[id];
+
+    invariant(
+      target,
+      `Cannot find Droppable[id: ${id}] to toggle its isCombineOnly state`,
+    );
+
+    invariant(
+      target.isCombineOnly !== isCombineOnly,
+      `Trying to set droppable isCombineOnly to ${String(isCombineOnly)}
+      but it is already ${String(target.isCombineOnly)}`,
+    );
+
+    const updated: DroppableDimension = {
+      ...target,
+      isCombineOnly,
+    };
+
+    return postDroppableChange(state, updated, true);
+  }
+
   if (action.type === 'MOVE_BY_WINDOW_SCROLL') {
     // No longer accepting changes
     if (state.phase === 'DROP_PENDING' || state.phase === 'DROP_ANIMATING') {

--- a/src/types.js
+++ b/src/types.js
@@ -128,6 +128,7 @@ export type DroppableDimension = {|
   axis: Axis,
   isEnabled: boolean,
   isCombineEnabled: boolean,
+  isCombineOnly: boolean,
   // relative to the current viewport
   client: BoxModel,
   // relative to the whole page

--- a/src/view/drag-drop-context/app.jsx
+++ b/src/view/drag-drop-context/app.jsx
@@ -26,6 +26,7 @@ import {
   updateDroppableScroll,
   updateDroppableIsEnabled,
   updateDroppableIsCombineEnabled,
+  updateDroppableIsCombineOnly,
   collectionStarting,
 } from '../../state/action-creators';
 import isMovementAllowed from '../../state/is-movement-allowed';
@@ -87,6 +88,7 @@ export default function App(props: Props) {
           updateDroppableScroll,
           updateDroppableIsEnabled,
           updateDroppableIsCombineEnabled,
+          updateDroppableIsCombineOnly,
           collectionStarting,
         },
         // $FlowFixMe - not sure why this is wrong

--- a/src/view/droppable/connected-droppable.js
+++ b/src/view/droppable/connected-droppable.js
@@ -205,6 +205,7 @@ const defaultProps = ({
   direction: 'vertical',
   isDropDisabled: false,
   isCombineEnabled: false,
+  isCombineOnly: false,
   ignoreContainerClipping: false,
 }: DefaultProps);
 

--- a/src/view/droppable/droppable-types.js
+++ b/src/view/droppable/droppable-types.js
@@ -45,6 +45,7 @@ export type DefaultProps = {|
   type: TypeId,
   isDropDisabled: boolean,
   isCombineEnabled: boolean,
+  isCombineOnly: boolean,
   direction: Direction,
   ignoreContainerClipping: boolean,
 |};

--- a/src/view/droppable/droppable.jsx
+++ b/src/view/droppable/droppable.jsx
@@ -79,7 +79,9 @@ export default function Droppable(props: Props) {
   //   on: props.placeholder,
   //   shouldAnimate: props.shouldAnimatePlaceholder,
   // });
-
+  const isPlaceholderUsed = isCombineOnly
+    ? Boolean(snapshot.draggingFromThisWith)
+    : true;
   const placeholder: Node = (
     <AnimateInOut
       on={props.placeholder}
@@ -93,6 +95,7 @@ export default function Droppable(props: Props) {
           animate={animate}
           styleContext={styleContext}
           onTransitionEnd={onPlaceholderTransitionEnd}
+          isPlaceholderUsed={isPlaceholderUsed}
         />
       )}
     </AnimateInOut>

--- a/src/view/droppable/droppable.jsx
+++ b/src/view/droppable/droppable.jsx
@@ -34,6 +34,7 @@ export default function Droppable(props: Props) {
     ignoreContainerClipping,
     isDropDisabled,
     isCombineEnabled,
+    isCombineOnly,
     // map props
     snapshot,
     // dispatch props
@@ -68,6 +69,7 @@ export default function Droppable(props: Props) {
     direction,
     isDropDisabled,
     isCombineEnabled,
+    isCombineOnly,
     ignoreContainerClipping,
     getDroppableRef,
     getPlaceholderRef,

--- a/src/view/droppable/use-validation.js
+++ b/src/view/droppable/use-validation.js
@@ -16,6 +16,10 @@ function checkOwnProps(props: Props) {
     'isCombineEnabled must be a boolean',
   );
   invariant(
+    typeof props.isCombineOnly === 'boolean',
+    'isCombineOnly must be a boolean',
+  );
+  invariant(
     typeof props.ignoreContainerClipping === 'boolean',
     'ignoreContainerClipping must be a boolean',
   );

--- a/src/view/placeholder/placeholder.jsx
+++ b/src/view/placeholder/placeholder.jsx
@@ -30,6 +30,7 @@ export type Props = {|
   animate: InOutAnimationMode,
   onClose: () => void,
   innerRef?: () => ?HTMLElement,
+  isPlaceholderUsed: boolean,
   onTransitionEnd: () => void,
   styleContext: string,
 |};
@@ -57,12 +58,17 @@ const getSize = ({
   isAnimatingOpenOnMount,
   placeholder,
   animate,
+  isPlaceholderUsed,
 }: HelperArgs): Size => {
   if (isAnimatingOpenOnMount) {
     return empty;
   }
 
   if (animate === 'close') {
+    return empty;
+  }
+
+  if (!isPlaceholderUsed) {
     return empty;
   }
 
@@ -77,8 +83,9 @@ const getStyle = ({
   isAnimatingOpenOnMount,
   placeholder,
   animate,
+  isPlaceholderUsed,
 }: HelperArgs): PlaceholderStyle => {
-  const size: Size = getSize({ isAnimatingOpenOnMount, placeholder, animate });
+  const size: Size = getSize({ isAnimatingOpenOnMount, placeholder, animate, isPlaceholderUsed });
 
   return {
     display: placeholder.display,
@@ -182,6 +189,7 @@ function Placeholder(props: Props): Node {
     isAnimatingOpenOnMount,
     animate: props.animate,
     placeholder: props.placeholder,
+    isPlaceholderUsed: props.isPlaceholderUsed,
   });
 
   return React.createElement(props.placeholder.tagName, {

--- a/src/view/use-droppable-dimension-publisher/get-dimension.js
+++ b/src/view/use-droppable-dimension-publisher/get-dimension.js
@@ -87,6 +87,7 @@ type Args = {|
   direction: Direction,
   isDropDisabled: boolean,
   isCombineEnabled: boolean,
+  isCombineOnly: boolean,
   shouldClipSubject: boolean,
 |};
 
@@ -98,6 +99,7 @@ export default ({
   direction,
   isDropDisabled,
   isCombineEnabled,
+  isCombineOnly,
   shouldClipSubject,
 }: Args): DroppableDimension => {
   const closestScrollable: ?Element = env.closestScrollable;
@@ -128,6 +130,7 @@ export default ({
     descriptor,
     isEnabled: !isDropDisabled,
     isCombineEnabled,
+    isCombineOnly,
     isFixedOnPage: env.isFixedOnPage,
     direction,
     client,

--- a/src/view/use-droppable-dimension-publisher/use-droppable-dimension-publisher.js
+++ b/src/view/use-droppable-dimension-publisher/use-droppable-dimension-publisher.js
@@ -37,6 +37,7 @@ type Props = {|
   direction: Direction,
   isDropDisabled: boolean,
   isCombineEnabled: boolean,
+  isCombineOnly: boolean,
   ignoreContainerClipping: boolean,
   getPlaceholderRef: () => ?HTMLElement,
   getDroppableRef: () => ?HTMLElement,
@@ -140,6 +141,7 @@ export default function useDroppableDimensionPublisher(args: Props) {
         direction: previous.direction,
         isDropDisabled: previous.isDropDisabled,
         isCombineEnabled: previous.isCombineEnabled,
+        isCombineOnly: previous.isCombineOnly,
         shouldClipSubject: !previous.ignoreContainerClipping,
       });
 
@@ -181,6 +183,7 @@ export default function useDroppableDimensionPublisher(args: Props) {
           direction: previous.direction,
           isDropDisabled: previous.isDropDisabled,
           isCombineEnabled: previous.isCombineEnabled,
+          isCombineOnly: previous.isCombineOnly,
           shouldClipSubject: !previous.ignoreContainerClipping,
         });
 
@@ -275,5 +278,9 @@ export default function useDroppableDimensionPublisher(args: Props) {
       publishedDescriptorRef.current.id,
       args.isCombineEnabled,
     );
-  }, [args.isCombineEnabled, marshal]);
+    marshal.updateDroppableIsCombineOnly(
+      publishedDescriptorRef.current.id,
+      args.isCombineOnly,
+    );
+  }, [args.isCombineEnabled, args.isCombineOnly, marshal]);
 }

--- a/stories/3-board.stories.stories.js
+++ b/stories/3-board.stories.stories.js
@@ -1,8 +1,8 @@
 // @flow
 import React from 'react';
-import { storiesOf } from '@storybook/react';
+import {storiesOf} from '@storybook/react';
 import Board from './src/board/board';
-import { authorQuoteMap, generateQuoteMap } from './src/data';
+import {authorQuoteMap, generateQuoteMap} from './src/data';
 
 const data = {
   medium: generateQuoteMap(100),
@@ -21,4 +21,7 @@ storiesOf('board', module)
   ))
   .add('with combine enabled', () => (
     <Board initial={authorQuoteMap} isCombineEnabled />
+  ))
+  .add('with combine only', () => (
+    <Board initial={authorQuoteMap} isCombineOnly />
   ));

--- a/stories/src/board/board.jsx
+++ b/stories/src/board/board.jsx
@@ -31,6 +31,7 @@ type Props = {|
   initial: QuoteMap,
   withScrollableColumns?: boolean,
   isCombineEnabled?: boolean,
+  isCombineOnly?: boolean,
   containerHeight?: string,
 |};
 
@@ -43,6 +44,7 @@ export default class Board extends Component<Props, State> {
   /* eslint-disable react/sort-comp */
   static defaultProps = {
     isCombineEnabled: false,
+    isCombineOnly: false,
   };
 
   state: State = {
@@ -124,8 +126,10 @@ export default class Board extends Component<Props, State> {
         droppableId="board"
         type="COLUMN"
         direction="horizontal"
+        isDropDisabled
         ignoreContainerClipping={Boolean(containerHeight)}
         isCombineEnabled={this.props.isCombineEnabled}
+        isCombineOnly={this.props.isCombineOnly}
       >
         {(provided: DroppableProvided) => (
           <Container ref={provided.innerRef} {...provided.droppableProps}>
@@ -137,6 +141,7 @@ export default class Board extends Component<Props, State> {
                 quotes={columns[key]}
                 isScrollable={this.props.withScrollableColumns}
                 isCombineEnabled={this.props.isCombineEnabled}
+                isCombineOnly={this.props.isCombineOnly}
               />
             ))}
             {provided.placeholder}

--- a/stories/src/board/column.jsx
+++ b/stories/src/board/column.jsx
@@ -1,13 +1,11 @@
 // @flow
-import React, { Component } from 'react';
+import React, {Component} from 'react';
 import styled from '@emotion/styled';
-import { colors } from '@atlaskit/theme';
-import { grid, borderRadius } from '../constants';
-import { Draggable } from '../../../src';
-import type { DraggableProvided, DraggableStateSnapshot } from '../../../src';
+import {colors} from '@atlaskit/theme';
+import {borderRadius, grid} from '../constants';
 import QuoteList from '../primatives/quote-list';
 import Title from '../primatives/title';
-import type { Quote } from '../types';
+import type {Quote} from '../types';
 
 const Container = styled.div`
   margin: ${grid}px;
@@ -21,8 +19,8 @@ const Header = styled.div`
   justify-content: center;
   border-top-left-radius: ${borderRadius}px;
   border-top-right-radius: ${borderRadius}px;
-  background-color: ${({ isDragging }) =>
-    isDragging ? colors.G50 : colors.N30};
+  background-color: ${({isDragging}) =>
+  isDragging ? colors.G50 : colors.N30};
   transition: background-color 0.2s ease;
 
   &:hover {
@@ -36,6 +34,7 @@ type Props = {|
   index: number,
   isScrollable?: boolean,
   isCombineEnabled?: boolean,
+  isCombineOnly?: boolean,
 |};
 
 export default class Column extends Component<Props> {
@@ -44,30 +43,23 @@ export default class Column extends Component<Props> {
     const quotes: Quote[] = this.props.quotes;
     const index: number = this.props.index;
     return (
-      <Draggable draggableId={title} index={index}>
-        {(provided: DraggableProvided, snapshot: DraggableStateSnapshot) => (
-          <Container ref={provided.innerRef} {...provided.draggableProps}>
-            <Header isDragging={snapshot.isDragging}>
-              <Title
-                isDragging={snapshot.isDragging}
-                {...provided.dragHandleProps}
-              >
-                {title}
-              </Title>
-            </Header>
-            <QuoteList
-              listId={title}
-              listType="QUOTE"
-              style={{
-                backgroundColor: snapshot.isDragging ? colors.G50 : null,
-              }}
-              quotes={quotes}
-              internalScroll={this.props.isScrollable}
-              isCombineEnabled={Boolean(this.props.isCombineEnabled)}
-            />
-          </Container>
-        )}
-      </Draggable>
+      <Container>
+        <Header>
+          <Title>
+            {title}
+          </Title>
+        </Header>
+        <QuoteList
+          listId={title}
+          listType="QUOTE"
+          style={{
+          }}
+          quotes={quotes}
+          internalScroll={this.props.isScrollable}
+          isCombineEnabled={Boolean(this.props.isCombineEnabled)}
+          isCombineOnly={Boolean(this.props.isCombineOnly)}
+        />
+      </Container>
     );
   }
 }

--- a/stories/src/primatives/quote-list.jsx
+++ b/stories/src/primatives/quote-list.jsx
@@ -73,6 +73,7 @@ type Props = {|
   scrollContainerStyle?: Object,
   isDropDisabled?: boolean,
   isCombineEnabled?: boolean,
+  isCombineOnly?: boolean,
   style?: Object,
   // may not be provided - and might be null
   ignoreContainerClipping?: boolean,
@@ -131,6 +132,7 @@ export default function QuoteList(props: Props) {
     scrollContainerStyle,
     isDropDisabled,
     isCombineEnabled,
+    isCombineOnly,
     listId = 'LIST',
     listType,
     style,
@@ -145,6 +147,7 @@ export default function QuoteList(props: Props) {
       ignoreContainerClipping={ignoreContainerClipping}
       isDropDisabled={isDropDisabled}
       isCombineEnabled={isCombineEnabled}
+      isCombineOnly={isCombineOnly}
     >
       {(
         dropProvided: DroppableProvided,


### PR DESCRIPTION
Fixes #1390
simply pass `isCombineOnly` instead of `isCombineEnabled` to turn off reordering.