### PR TITLE
Change jest-axe dependency to dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
   "dependencies": {
     "@babel/runtime-corejs2": "^7.6.3",
     "css-box-model": "^1.2.0",
-    "jest-axe": "^3.2.0",
     "memoize-one": "^5.1.1",
     "raf-schd": "^4.0.2",
     "react-redux": "^7.1.1",
@@ -108,6 +107,7 @@
     "fs-extra": "^8.0.1",
     "globby": "^10.0.1",
     "jest": "^24.9.0",
+    "jest-axe": "^3.2.0",
     "jest-junit": "^9.0.0",
     "jest-watch-typeahead": "^0.4.0",
     "lighthouse": "^5.6.0",


### PR DESCRIPTION
`jest-axe` is only used during testing, therefore it belongs in `devDependencies`.

This is normally not a big deal, aside from increased install time, but still.