### PR TITLE
remove event.preventDefault in mousedown event

### DIFF
--- a/src/view/use-sensor-marshal/sensors/use-mouse-sensor.js
+++ b/src/view/use-sensor-marshal/sensors/use-mouse-sensor.js
@@ -246,9 +246,6 @@ export default function useMouseSensor(api: SensorAPI) {
           return;
         }
 
-        // consuming the event
-        event.preventDefault();
-
         const point: Position = {
           x: event.clientX,
           y: event.clientY,


### PR DESCRIPTION
1. when you click a normal element,then make it **contentEditable** and **focus** it.
Default behavior in most browsers it should be put cursor in right position and can edit the element's content.
2. If set **event.preventDefault()** in **mousedown** event.The default behavior will fly out.
3. I create a demo here:
https://codesandbox.io/s/click-then-contenteditable-react-xjkbx?fontsize=14&hidenavigation=1&theme=dark

