### PR TITLE
Update useIsomorphicLayoutEffect check

### DIFF
--- a/src/view/use-isomorphic-layout-effect.js
+++ b/src/view/use-isomorphic-layout-effect.js
@@ -9,6 +9,10 @@ import { useLayoutEffect, useEffect } from 'react';
 // `connect` to perform sync updates to a ref to save the latest props after
 // a render is actually committed to the DOM.
 const useIsomorphicLayoutEffect =
-  typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+  typeof window !== 'undefined' &&
+  typeof window.document !== 'undefined' &&
+  typeof window.document.createElement !== 'undefined'
+    ? useLayoutEffect
+    : useEffect;
 
 export default useIsomorphicLayoutEffect;


### PR DESCRIPTION
fixes #1623

Updated the the useIsomorphicLayoutEffect layout effect to check for window.document.createElement instead of just window.
That matches what both [React](https://github.com/facebook/react/blob/master/packages/shared/ExecutionEnvironment.js) and [Redux](https://github.com/reduxjs/react-redux/blob/master/src/utils/useIsomorphicLayoutEffect.js) are doing
