### PR TITLE
Remove duplicate code in dimension locking example

### DIFF
--- a/stories/src/table/with-dimension-locking.jsx
+++ b/stories/src/table/with-dimension-locking.jsx
@@ -191,10 +191,7 @@ export default class TableApp extends Component<AppProps, AppState> {
     });
 
     // dropped outside the list
-    if (
-      !result.destination ||
-      result.destination.index === result.source.index
-    ) {
+    if (!result.destination) {
       return;
     }
 


### PR DESCRIPTION
The same boolean check is performed twice, once after the other.

This cleans up the example for readability and to fix redundancy.