### PR TITLE
Fix the distance calculation to support varied lists 

### DIFF
--- a/src/state/get-droppable-over.js
+++ b/src/state/get-droppable-over.js
@@ -45,10 +45,13 @@ function getFurthestAway({
   draggable,
   candidates,
 }: GetFurthestArgs): ?DroppableId {
+  // We are not comparing the center of the home list with the target list as it would
+  // give preference to giant lists
+
   // We are measuring the distance from where the draggable started
   // to where it is *hitting* the candidate
-  // The hit point might technically not be in the bounds of the candidate
-  // We are not comparing the centers
+  // Note: The hit point might technically not be in the bounds of the candidate
+
   const startCenter: Position = draggable.page.borderBox.center;
   const sorted: WithDistance[] = candidates
     .map((candidate: DroppableDimension): WithDistance => {

--- a/test/unit/state/get-droppable-over/preferencing.spec.js
+++ b/test/unit/state/get-droppable-over/preferencing.spec.js
@@ -14,7 +14,7 @@ import getDroppableOver from '../../../../src/state/get-droppable-over';
 import { toDroppableMap } from '../../../../src/state/dimension-structures';
 import { afterCrossAxisPoint } from '../../../util/after-point';
 
-const droppableLarge: DroppableDimension = getDroppableDimension({
+const droppableOrigin: DroppableDimension = getDroppableDimension({
   descriptor: {
     id: 'large',
     type: 'standard',
@@ -28,7 +28,7 @@ const droppableLarge: DroppableDimension = getDroppableDimension({
   },
 });
 
-const droppableSmall: DroppableDimension = getDroppableDimension({
+const droppableFirst: DroppableDimension = getDroppableDimension({
   descriptor: {
     id: 'small',
     type: 'standard',
@@ -42,7 +42,7 @@ const droppableSmall: DroppableDimension = getDroppableDimension({
   },
 });
 
-const droppableSecondary: DroppableDimension = getDroppableDimension({
+const droppableSecond: DroppableDimension = getDroppableDimension({
   descriptor: {
     id: 'secondary',
     type: 'standard',
@@ -57,7 +57,7 @@ const droppableSecondary: DroppableDimension = getDroppableDimension({
   },
 });
 
-const droppableTertiary: DroppableDimension = getDroppableDimension({
+const droppableThird: DroppableDimension = getDroppableDimension({
   descriptor: {
     id: 'tertiary',
     type: 'standard',
@@ -75,10 +75,10 @@ const draggable: DraggableDimension = getDraggableDimension({
   descriptor: {
     id: 'my draggable',
     index: 0,
-    type: droppableLarge.descriptor.type,
-    droppableId: droppableLarge.descriptor.id,
+    type: droppableOrigin.descriptor.type,
+    droppableId: droppableOrigin.descriptor.id,
   },
-  borderBox: droppableLarge.client.borderBox,
+  borderBox: droppableOrigin.client.borderBox,
 });
 
 /**
@@ -87,28 +87,28 @@ const draggable: DraggableDimension = getDraggableDimension({
  */
 it('should prefer the furthest away droppable when multiple lists are hit', () => {
   const offset = getOffsetForCrossAxisEndEdge({
-    crossAxisEndEdgeOn: droppableTertiary.page.borderBox.center,
+    crossAxisEndEdgeOn: droppableThird.page.borderBox.center,
     dragging: draggable.page.borderBox,
-    axis: droppableTertiary.axis,
+    axis: droppableThird.axis,
   });
 
   const pageBorderBox: Rect = offsetRectByPosition(
     draggable.page.borderBox,
-    afterCrossAxisPoint(droppableTertiary.axis, offset),
+    afterCrossAxisPoint(droppableThird.axis, offset),
   );
 
   const result = getDroppableOver({
     pageBorderBox,
     draggable,
     droppables: toDroppableMap([
-      droppableLarge,
-      droppableSmall,
-      droppableSecondary,
-      droppableTertiary,
+      droppableOrigin,
+      droppableFirst,
+      droppableSecond,
+      droppableThird,
     ]),
   });
 
-  expect(result).toEqual(droppableTertiary.descriptor.id);
+  expect(result).toEqual(droppableThird.descriptor.id);
 });
 
 /**
@@ -117,26 +117,26 @@ it('should prefer the furthest away droppable when multiple lists are hit', () =
  */
 it('should prefer the second furthest away droppable when multiple lists are hit', () => {
   const offset = getOffsetForCrossAxisEndEdge({
-    crossAxisEndEdgeOn: droppableSecondary.page.borderBox.center,
+    crossAxisEndEdgeOn: droppableSecond.page.borderBox.center,
     dragging: draggable.page.borderBox,
-    axis: droppableSecondary.axis,
+    axis: droppableSecond.axis,
   });
 
   const pageBorderBox: Rect = offsetRectByPosition(
     draggable.page.borderBox,
-    afterCrossAxisPoint(droppableSecondary.axis, offset),
+    afterCrossAxisPoint(droppableSecond.axis, offset),
   );
 
   const result = getDroppableOver({
     pageBorderBox,
     draggable,
     droppables: toDroppableMap([
-      droppableLarge,
-      droppableSmall,
-      droppableSecondary,
-      droppableTertiary,
+      droppableOrigin,
+      droppableFirst,
+      droppableSecond,
+      droppableThird,
     ]),
   });
 
-  expect(result).toEqual(droppableSecondary.descriptor.id);
+  expect(result).toEqual(droppableSecond.descriptor.id);
 });

--- a/test/unit/state/get-droppable-over/preferencing.spec.js
+++ b/test/unit/state/get-droppable-over/preferencing.spec.js
@@ -52,7 +52,8 @@ const droppableSecondary: DroppableDimension = getDroppableDimension({
     top: 1000,
     left: 1200,
     right: 1300,
-    bottom: 1100,
+    // This is really tall to test the distance calculation against varied lists
+    bottom: 8000,
   },
 });
 
@@ -64,8 +65,8 @@ const droppableTertiary: DroppableDimension = getDroppableDimension({
   },
   borderBox: {
     top: 1000,
-    left: 1100,
-    right: 1200,
+    left: 1400,
+    right: 1500,
     bottom: 1100,
   },
 });


### PR DESCRIPTION
In cases where lists are extremely tall (in relation to their siblings) we need to make sure preferencing based on distance between center points still holds up. 
