### PR TITLE
Added codesandbox to examples in docs

### DIFF
--- a/docs/about/examples.md
+++ b/docs/about/examples.md
@@ -21,5 +21,6 @@ We have created some basic examples on `codesandbox` for you to play with direct
 - [Simple horizontal list](https://codesandbox.io/s/mmrp44okvj)
 - [Using with function components](https://codesandbox.io/s/zqwz5n5p9x)
 - [Simple DnD between two lists](https://codesandbox.io/s/ql08j35j3q) - _Community made_
+- [Simple DnD between a dynamic number of lists (with function components) and ability to delete items](https://codesandbox.io/s/-w5szl) - _Community made_
 
 [← Back to documentation](/README.md#documentation-)


### PR DESCRIPTION
Hi! I'm a novice at contributing to open source, so I apologize if I'm not doing this the right way, but I wanted to share this example with the community. I basically combined the "Simple DnD between two lists" example with the "Using with function components" example, and then added the ability to add a droppable area and add/delete an item into a new droppable area. It's not much, but I think it shows some of the awesome modularity and power of react-beautiful-dnd.

Happy to remove this PR and add the suggestion elsewhere if you let me know the best way to proceed. Or just ignore this and I'll continue on my merry way!

Thanks for the amazing library!! It's exactly what I was looking for.