### PR TITLE
Adding interactive elements tagging functionality

### DIFF
--- a/docs/api/draggable.md
+++ b/docs/api/draggable.md
@@ -453,6 +453,7 @@ It is possible for your `<Draggable />` to contain interactive elements. By defa
 - `video`
 - `audio`
 - [`contenteditable`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contenteditable) (any elements that are `contenteditable` or are within a `contenteditable` container)
+- Any elements that have a `data-interactive-element` property set to true, or any element that is contained in such element.
 
 You can opt out of this behavior by adding the `disableInteractiveElementBlocking` prop to a `<Draggable />`. However, it is questionable as to whether you should be doing so because it will render the interactive element unusable. If you need to _conditionally_ block dragging from interactive elements you can add the `disableInteractiveElementBlocking` prop to opt out of the default blocking and monkey patch the `dragHandleProps (DragHandleProps)` event handlers to disable dragging as required.
 

--- a/src/view/use-sensor-marshal/is-event-in-interactive-element.js
+++ b/src/view/use-sensor-marshal/is-event-in-interactive-element.js
@@ -43,6 +43,11 @@ function isAnInteractiveElement(parent: Element, current: ?Element) {
     return true;
   }
 
+  const dataAttribute: ?string = current.getAttribute('data-interactive-element');
+  if (dataAttribute === 'true' || dataAttribute === '') {
+    return true;
+  }
+
   // nothing more can be done and no results found
   if (current === parent) {
     return false;

--- a/test/unit/integration/drag-handle/shared-behaviours/interactive-element-tag.spec.js
+++ b/test/unit/integration/drag-handle/shared-behaviours/interactive-element-tag.spec.js
@@ -1,0 +1,146 @@
+// @flow
+import React from 'react';
+import { render } from '@testing-library/react';
+import { forEachSensor, type Control, simpleLift } from '../../util/controls';
+import { isDragging } from '../../util/helpers';
+import {
+  type DraggableProvided,
+  type DraggableStateSnapshot,
+} from '../../../../../src';
+import App, { type Item } from '../../util/app';
+
+forEachSensor((control: Control) => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    // $ExpectError - mock
+    console.error.mockRestore();
+  });
+
+  it('should block the drag if the drag handle is itself data-interactive-element', () => {
+    const renderItem = (item: Item) => (
+      provided: DraggableProvided,
+      snapshot: DraggableStateSnapshot,
+    ) => (
+      <div
+        {...provided.draggableProps}
+        {...provided.dragHandleProps}
+        ref={provided.innerRef}
+        data-is-dragging={snapshot.isDragging}
+        data-testid={item.id}
+        data-interactive-element
+      />
+    );
+
+    const { getByTestId } = render(<App renderItem={renderItem} />);
+    const handle: HTMLElement = getByTestId('0');
+
+    simpleLift(control, handle);
+
+    expect(isDragging(handle)).toBe(false);
+  });
+
+  it('should block the drag if originated from a child data-interactive-element', () => {
+    const renderItem = (item: Item) => (
+      provided: DraggableProvided,
+      snapshot: DraggableStateSnapshot,
+    ) => (
+      <div
+        {...provided.draggableProps}
+        {...provided.dragHandleProps}
+        ref={provided.innerRef}
+        data-is-dragging={snapshot.isDragging}
+        data-testid={`handle-${item.id}`}
+      >
+        <div data-testid={`inner-${item.id}`} data-interactive-element />
+      </div>
+    );
+
+    const { getByTestId } = render(<App renderItem={renderItem} />);
+    const inner: HTMLElement = getByTestId('inner-0');
+    const handle: HTMLElement = getByTestId('handle-0');
+
+    simpleLift(control, inner);
+
+    expect(isDragging(handle)).toBe(false);
+  });
+
+  it('should block the drag if originated from a child of a child data-interactive-element', () => {
+    const renderItem = (item: Item) => (
+      provided: DraggableProvided,
+      snapshot: DraggableStateSnapshot,
+    ) => (
+      <div
+        {...provided.draggableProps}
+        {...provided.dragHandleProps}
+        ref={provided.innerRef}
+        data-is-dragging={snapshot.isDragging}
+        data-testid={`handle-${item.id}`}
+      >
+        <div data-interactive-element>
+          <p>hello there</p>
+          <span data-testid={`inner-${item.id}`}>Edit me!</span>
+        </div>
+      </div>
+    );
+
+    const { getByTestId } = render(<App renderItem={renderItem} />);
+    const inner: HTMLElement = getByTestId('inner-0');
+    const handle: HTMLElement = getByTestId('handle-0');
+
+    simpleLift(control, inner);
+
+    expect(isDragging(handle)).toBe(false);
+  });
+
+  it('should not block if data-interactive-element is set to false', () => {
+    const renderItem = (item: Item) => (
+      provided: DraggableProvided,
+      snapshot: DraggableStateSnapshot,
+    ) => (
+      <div
+        {...provided.draggableProps}
+        {...provided.dragHandleProps}
+        ref={provided.innerRef}
+        data-is-dragging={snapshot.isDragging}
+        data-testid={item.id}
+        data-interactive-element={false}
+      />
+    );
+
+    const { getByTestId } = render(<App renderItem={renderItem} />);
+    const handle: HTMLElement = getByTestId('0');
+
+    simpleLift(control, handle);
+
+    expect(isDragging(handle)).toBe(true);
+  });
+
+  it('should not block a drag if dragging interactive elements is allowed', () => {
+    const items: Item[] = [{ id: '0', canDragInteractiveElements: true }];
+
+    const renderItem = (item: Item) => (
+      provided: DraggableProvided,
+      snapshot: DraggableStateSnapshot,
+    ) => (
+      <div
+        {...provided.draggableProps}
+        {...provided.dragHandleProps}
+        ref={provided.innerRef}
+        data-is-dragging={snapshot.isDragging}
+        data-testid={item.id}
+        data-interactive-element
+      />
+    );
+
+    const { getByTestId } = render(
+      <App items={items} renderItem={renderItem} />,
+    );
+    const handle: HTMLElement = getByTestId('0');
+
+    simpleLift(control, handle);
+
+    expect(isDragging(handle)).toBe(true);
+  });
+});


### PR DESCRIPTION
Added support for a data-interactive-element property, to mark elements inside Draggables as interactive elements, even if they are not truly HTML-editable.