### PR TITLE
Upgrade eslint-plugin-es5

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -215,7 +215,10 @@ module.exports = {
       files: 'src/**/*.js',
       rules: {
         'es5/no-es6-methods': 'error',
-        'es5/no-es6-static-methods': 'error',
+        'es5/no-es6-static-methods': [
+          'error',
+          { exceptMethods: ['Object.assign'] },
+        ],
       },
     },
   ],

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "eslint-config-prettier": "^6.4.0",
     "eslint-plugin-cypress": "^2.7.0",
     "eslint-plugin-emotion": "^10.0.14",
-    "eslint-plugin-es5": "^1.4.1",
+    "eslint-plugin-es5": "^1.5.0",
     "eslint-plugin-flowtype": "^4.3.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jest": "^22.20.0",

--- a/src/native-with-fallback.js
+++ b/src/native-with-fallback.js
@@ -1,13 +1,12 @@
 // @flow
 /* eslint-disable es5/no-es6-methods */
+/* eslint-disable es5/no-es6-static-methods */
 /* eslint-disable no-restricted-globals */
 
 type Map<T> = {
   [key: string]: T,
 };
 
-// Number.isInteger is not forbidden yet
-// https://github.com/nkt/eslint-plugin-es5/pull/37
 export function isInteger(value: mixed): boolean {
   if (Number.isInteger) {
     return Number.isInteger(value);

--- a/src/view/use-announcer/use-announcer.js
+++ b/src/view/use-announcer/use-announcer.js
@@ -31,7 +31,6 @@ export default function useAnnouncer(contextId: ContextId): Announce {
       el.setAttribute('aria-atomic', 'true');
 
       // hide the element visually
-      // eslint-disable-next-line es5/no-es6-static-methods
       Object.assign(el.style, visuallyHidden);
 
       // Add to body

--- a/yarn.lock
+++ b/yarn.lock
@@ -5769,10 +5769,10 @@ eslint-plugin-emotion@^10.0.14:
   resolved "https://registry.yarnpkg.com/eslint-plugin-emotion/-/eslint-plugin-emotion-10.0.14.tgz#c643ff2f34f85ae77a65b2056915e939cf7e8129"
   integrity sha512-kI0hTPA5oo7MAc2YcdF1JcT36TZ1Ci0S5sbA9aojZ3leEPyCH34YBB76/8NQ3/9gybqrekIEuEhr8MP6JZf95Q==
 
-eslint-plugin-es5@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-es5/-/eslint-plugin-es5-1.4.1.tgz#258fe89bc5f72fbd9f5f7936c840151766821f1e"
-  integrity sha512-kktkmkF2O7pnSZYgrMiYMbt3wCKRIiXePwILv8USDG95YgP0PzhIxSIROLLKmiQQ/Z6LuhDGWTHK04gnbXBvkg==
+eslint-plugin-es5@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-es5/-/eslint-plugin-es5-1.5.0.tgz#aab19af3d4798f7924bba309bc4f87087280fbba"
+  integrity sha512-Qxmfo7v2B7SGAEURJo0dpBweFf+JU15kSyALfiB2rXWcBuJ96r6X9kFHXFnhdopPHCaHjoQs1xQPUJVbGMb1AA==
 
 eslint-plugin-flowtype@^4.3.0:
   version "4.3.0"


### PR DESCRIPTION
Number.isInteger is forbidden now. Object.assign is added to exceptions
globally.