### PR TITLE
Migrate to import * as React from 'react';

### DIFF
--- a/csp-server/app.jsx
+++ b/csp-server/app.jsx
@@ -2,7 +2,8 @@
 // It matches
 /* eslint-disable flowtype/require-valid-file-annotation */
 
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { DragDropContext, Droppable, Draggable } from '../src';
 

--- a/csp-server/client.js
+++ b/csp-server/client.js
@@ -1,7 +1,7 @@
 // @flow
 /* eslint-env browser */
 
-import React from 'react';
+import * as React from 'react';
 import { hydrate } from 'react-dom';
 import Sample from './app';
 

--- a/csp-server/server.js
+++ b/csp-server/server.js
@@ -1,6 +1,6 @@
 // @flow
 import express from 'express';
-import React from 'react';
+import * as React from 'react';
 import { renderToString } from 'react-dom/server';
 import { resolve } from 'path';
 import App from './app';

--- a/docs/api/drag-drop-context.md
+++ b/docs/api/drag-drop-context.md
@@ -43,7 +43,7 @@ type Props = {|
 ### Using a `class` component
 
 ```js
-import React from 'react';
+import * as React from 'react';
 import { DragDropContext } from 'react-beautiful-dnd';
 
 class App extends React.Component {
@@ -84,7 +84,7 @@ class App extends React.Component {
 ### Using a `function` component
 
 ```js
-import React from 'react';
+import * as React from 'react';
 import { DragDropContext } from 'react-beautiful-dnd';
 
 function App() {

--- a/docs/api/droppable.md
+++ b/docs/api/droppable.md
@@ -220,15 +220,15 @@ When a user drags over, or stops dragging over, a `<Droppable />` we re-render t
 Here is an example of how you could do this using `class` components:
 
 ```js
-import React, { Component } from 'react';
+import * as React from 'react';
 
-class Student extends Component<{ student: Person }> {
+class Student extends React.Component<{ student: Person }> {
   render() {
     // Renders out a draggable student
   }
 }
 
-class InnerList extends Component<{ students: Person[] }> {
+class InnerList extends React.Component<{ students: Person[] }> {
   // do not re-render if the students list has not changed
   shouldComponentUpdate(nextProps: Props) {
     if (this.props.students === nextProps.students) {
@@ -246,7 +246,7 @@ class InnerList extends Component<{ students: Person[] }> {
   }
 }
 
-class Students extends Component<{ students: Person[] }> {
+class Students extends React.Component<{ students: Person[] }> {
   render() {
     return (
       <Droppable droppableId="list">
@@ -271,7 +271,7 @@ class Students extends Component<{ students: Person[] }> {
 Here is an example of how you could do this using `function` components:
 
 ```js
-import React from 'react';
+import * as React from 'react';
 
 function Student (props: { student: Person }) {
   // Renders out a draggable student

--- a/src/view/animate-in-out/animate-in-out.jsx
+++ b/src/view/animate-in-out/animate-in-out.jsx
@@ -1,5 +1,5 @@
 // @flow
-import React, { type Node } from 'react';
+import * as React from 'react';
 import type { InOutAnimationMode } from '../../types';
 
 export type AnimateProvided = {|
@@ -11,7 +11,7 @@ export type AnimateProvided = {|
 type Props = {|
   on: mixed,
   shouldAnimate: boolean,
-  children: (provided: AnimateProvided) => Node,
+  children: (provided: AnimateProvided) => React.Node,
 |};
 
 type State = {|

--- a/src/view/context/app-context.js
+++ b/src/view/context/app-context.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import type { DraggableId, ContextId, ElementId } from '../../types';
 import type { DimensionMarshal } from '../../state/dimension-marshal/dimension-marshal-types';
 import type { FocusMarshal } from '../use-focus-marshal/focus-marshal-types';

--- a/src/view/context/droppable-context.js
+++ b/src/view/context/droppable-context.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import type { DraggableId, DroppableId, TypeId } from '../../types';
 
 export type DroppableContextValue = {|

--- a/src/view/context/store-context.js
+++ b/src/view/context/store-context.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import type { Store } from '../../state/store-types';
 
 export default React.createContext<?Store>(null);

--- a/src/view/drag-drop-context/app.jsx
+++ b/src/view/drag-drop-context/app.jsx
@@ -1,5 +1,6 @@
 // @flow
-import React, { useEffect, useRef, type Node } from 'react';
+import * as React from 'react';
+import { useEffect, useRef } from 'react';
 import { bindActionCreators } from 'redux';
 import { Provider } from 'react-redux';
 import { useMemo, useCallback } from 'use-memo-one';
@@ -55,7 +56,7 @@ export type Props = {|
   setCallbacks: SetAppCallbacks,
   nonce?: string,
   // we do not technically need any children for this component
-  children: Node | null,
+  children: React.Node | null,
 
   // sensors
   sensors?: Sensor[],

--- a/src/view/drag-drop-context/drag-drop-context.jsx
+++ b/src/view/drag-drop-context/drag-drop-context.jsx
@@ -1,5 +1,5 @@
 // @flow
-import React, { type Node } from 'react';
+import * as React from 'react';
 import type { Responders, ContextId, Sensor } from '../../types';
 import ErrorBoundary from './error-boundary';
 import preset from '../../screen-reader-message-preset';
@@ -12,7 +12,7 @@ import { reset as resetUniqueIds } from '../use-unique-id';
 type Props = {|
   ...Responders,
   // We do not technically need any children for this component
-  children: Node | null,
+  children: React.Node | null,
   // Read out by screen readers when focusing on a drag handle
   dragHandleUsageInstructions?: string,
   // Used for strict content security policies

--- a/src/view/drag-drop-context/error-boundary.jsx
+++ b/src/view/drag-drop-context/error-boundary.jsx
@@ -1,5 +1,5 @@
 // @flow
-import React, { type Node } from 'react';
+import * as React from 'react';
 import { warning, error } from '../../dev-warning';
 import { noop } from '../../empty';
 import bindEvents from '../event-bindings/bind-events';
@@ -7,7 +7,7 @@ import { RbdInvariant } from '../../invariant';
 import type { AppCallbacks } from './drag-drop-context-types';
 
 type Props = {|
-  children: (setCallbacks: (callbacks: AppCallbacks) => void) => Node,
+  children: (setCallbacks: (callbacks: AppCallbacks) => void) => React.Node,
 |};
 
 // Lame that this is not in flow

--- a/src/view/drag-drop-context/use-startup-validation.js
+++ b/src/view/drag-drop-context/use-startup-validation.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { peerDependencies } from '../../../package.json';
 import checkReactVersion from './check-react-version';
 import checkDoctype from './check-doctype';

--- a/src/view/draggable/draggable-api.jsx
+++ b/src/view/draggable/draggable-api.jsx
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import type { DraggableId } from '../../types';
 import type { PublicOwnProps, PrivateOwnProps } from './draggable-types';
 import ConnectedDraggable from './connected-draggable';

--- a/src/view/droppable/droppable.jsx
+++ b/src/view/droppable/droppable.jsx
@@ -1,7 +1,8 @@
 // @flow
 import ReactDOM from 'react-dom';
 import { useMemo, useCallback } from 'use-memo-one';
-import React, { useRef, useContext, type Node } from 'react';
+import * as React from 'react';
+import { useRef, useContext } from 'react';
 import { invariant } from '../../invariant';
 import type { DraggableId } from '../../types';
 import type { Props, Provided } from './droppable-types';
@@ -89,7 +90,7 @@ export default function Droppable(props: Props) {
     getDroppableRef,
   });
 
-  const placeholder: Node = (
+  const placeholder: React.Node = (
     <AnimateInOut
       on={props.placeholder}
       shouldAnimate={props.shouldAnimatePlaceholder}
@@ -132,13 +133,13 @@ export default function Droppable(props: Props) {
     [droppableId, isUsingCloneFor, type],
   );
 
-  function getClone(): ?Node {
+  function getClone(): ?React.Node {
     if (!useClone) {
       return null;
     }
     const { dragging, render } = useClone;
 
-    const node: Node = (
+    const node: React.Node = (
       <PrivateDraggable
         draggableId={dragging.draggableId}
         index={dragging.source.index}

--- a/src/view/placeholder/placeholder.jsx
+++ b/src/view/placeholder/placeholder.jsx
@@ -1,5 +1,6 @@
 // @flow
-import React, { useState, useRef, useEffect, type Node } from 'react';
+import * as React from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { useCallback } from 'use-memo-one';
 import type { Spacing } from 'css-box-model';
 import type {
@@ -114,7 +115,7 @@ const getStyle = ({
   };
 };
 
-function Placeholder(props: Props): Node {
+function Placeholder(props: Props): React.Node {
   const animateOpenTimerRef = useRef<?TimeoutID>(null);
 
   const tryClearAnimateOpenTimer = useCallback(() => {

--- a/stories/1-single-vertical-list.stories.js
+++ b/stories/1-single-vertical-list.stories.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 import styled from '@emotion/styled';
 import QuoteApp from './src/vertical/quote-app';

--- a/stories/10-table.stories.js
+++ b/stories/10-table.stories.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 import WithDimensionLocking from './src/table/with-dimension-locking';
 import WithFixedColumns from './src/table/with-fixed-columns';

--- a/stories/11-portal.stories.js
+++ b/stories/11-portal.stories.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 import PortalApp from './src/portal/portal-app';
 import { quotes } from './src/data';

--- a/stories/12-dynamic.stories.js
+++ b/stories/12-dynamic.stories.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 import WithControls from './src/dynamic/with-controls';
 import LazyLoading from './src/dynamic/lazy-loading';

--- a/stories/15-on-before-capture.stories.js
+++ b/stories/15-on-before-capture.stories.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 import AddingThings from './src/on-before-capture/adding-things';
 

--- a/stories/2-single-horizontal.stories.js
+++ b/stories/2-single-horizontal.stories.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 import styled from '@emotion/styled';
 import AuthorApp from './src/horizontal/author-app';

--- a/stories/20-super-simple.stories.js
+++ b/stories/20-super-simple.stories.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 import Simple from './src/simple/simple';
 import SimpleWithScroll from './src/simple/simple-scrollable';

--- a/stories/21-change-on-drag-start.stories.js
+++ b/stories/21-change-on-drag-start.stories.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 import {
   DragDropContext,

--- a/stories/25-fixed-list.stories.js
+++ b/stories/25-fixed-list.stories.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 import WithFixedSidebar from './src/fixed-list/fixed-sidebar';
 

--- a/stories/3-board.stories.stories.js
+++ b/stories/3-board.stories.stories.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 import Board from './src/board/board';
 import { authorQuoteMap, generateQuoteMap } from './src/data';

--- a/stories/30-custom-drop.stories.js
+++ b/stories/30-custom-drop.stories.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 import FunnyDrop from './src/custom-drop/funny-drop';
 import NoDrop from './src/custom-drop/no-drop';

--- a/stories/35-function-component.stories.js
+++ b/stories/35-function-component.stories.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 import QuoteApp from './src/function-component/quote-app';
 

--- a/stories/4-complex-vertical-list.stories.js
+++ b/stories/4-complex-vertical-list.stories.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 import NestedQuoteApp from './src/vertical-nested/quote-app';
 import GroupedQuoteApp from './src/vertical-grouped/quote-app';

--- a/stories/40-programmatic.stories.js
+++ b/stories/40-programmatic.stories.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 import WithControls from './src/programmatic/with-controls';
 import Runsheet from './src/programmatic/runsheet';

--- a/stories/45-virtual.stories.js
+++ b/stories/45-virtual.stories.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 import ReactWindowList from './src/virtual/react-window/list';
 import ReactVirtualizedList from './src/virtual/react-virtualized/list';

--- a/stories/5-multiple-vertical-lists.stories.js
+++ b/stories/5-multiple-vertical-lists.stories.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 import QuoteApp from './src/multiple-vertical/quote-app';
 import { getQuotes } from './src/data';

--- a/stories/50-multiple-contexts.stories.js
+++ b/stories/50-multiple-contexts.stories.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 import MultipleContexts from './src/programmatic/multiple-contexts';
 

--- a/stories/55-mixed-sizes.stories.js
+++ b/stories/55-mixed-sizes.stories.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 import MixedSizedItems from './src/mixed-sizes/mixed-size-items';
 import MixedSizedLists from './src/mixed-sizes/mixed-size-lists';

--- a/stories/6-multiple-horizontal-lists.stories.js
+++ b/stories/6-multiple-horizontal-lists.stories.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 import QuoteApp from './src/multiple-horizontal/quote-app';
 import { getQuotes } from './src/data';

--- a/stories/7-interactive-elements.stories.js
+++ b/stories/7-interactive-elements.stories.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 import InteractiveElementsApp from './src/interactive-elements/interactive-elements-app';
 

--- a/stories/8-accessibility.stories.js
+++ b/stories/8-accessibility.stories.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 import TaskApp from './src/accessible/task-app';
 

--- a/stories/9-multi-drag.stories.js
+++ b/stories/9-multi-drag.stories.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 import TaskApp from './src/multi-drag/task-app';
 

--- a/stories/99-debug.stories.js
+++ b/stories/99-debug.stories.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 // import { Draggable, Droppable, DragDropContext } from '../src';
 

--- a/stories/src/accessible/blur-context.js
+++ b/stories/src/accessible/blur-context.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 
 const BlurContext = React.createContext<number>(0);
 

--- a/stories/src/accessible/task-app.jsx
+++ b/stories/src/accessible/task-app.jsx
@@ -1,5 +1,6 @@
 // @flow
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import styled from '@emotion/styled';
 import TaskList from './task-list';
 import initial from './data';

--- a/stories/src/accessible/task-list.jsx
+++ b/stories/src/accessible/task-list.jsx
@@ -1,5 +1,6 @@
 // @flow
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import styled from '@emotion/styled';
 import { colors } from '@atlaskit/theme';
 import { Droppable } from '../../../src';

--- a/stories/src/accessible/task.jsx
+++ b/stories/src/accessible/task.jsx
@@ -1,5 +1,6 @@
 // @flow
-import React, { Component, type Node } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import ReactDOM from 'react-dom';
 import memoizeOne from 'memoize-one';
 import styled from '@emotion/styled';
@@ -51,7 +52,7 @@ export default class Task extends Component<Props> {
               provided: DraggableProvided,
               snapshot: DraggableStateSnapshot,
             ) => {
-              const child: Node = (
+              const child: React.Node = (
                 <Container
                   ref={provided.innerRef}
                   isDragging={snapshot.isDragging}

--- a/stories/src/board/board.jsx
+++ b/stories/src/board/board.jsx
@@ -1,5 +1,6 @@
 // @flow
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import styled from '@emotion/styled';
 import { Global, css } from '@emotion/core';
 import { colors } from '@atlaskit/theme';

--- a/stories/src/board/column.jsx
+++ b/stories/src/board/column.jsx
@@ -1,5 +1,6 @@
 // @flow
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import styled from '@emotion/styled';
 import { colors } from '@atlaskit/theme';
 import { grid, borderRadius } from '../constants';

--- a/stories/src/custom-drop/funny-drop.jsx
+++ b/stories/src/custom-drop/funny-drop.jsx
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import styled from '@emotion/styled';
 import { colors } from '@atlaskit/theme';
 import { grid } from '../constants';

--- a/stories/src/custom-drop/no-drop.jsx
+++ b/stories/src/custom-drop/no-drop.jsx
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import styled from '@emotion/styled';
 import { grid } from '../constants';
 import reorder from '../reorder';

--- a/stories/src/dynamic/lazy-loading.jsx
+++ b/stories/src/dynamic/lazy-loading.jsx
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import QuoteList from '../primatives/quote-list';
 import { DragDropContext } from '../../../src';
 import type {

--- a/stories/src/dynamic/with-controls.jsx
+++ b/stories/src/dynamic/with-controls.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-restricted-syntax */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import styled from '@emotion/styled';
 import QuoteList from '../primatives/quote-list';
 import { DragDropContext } from '../../../src';

--- a/stories/src/fixed-list/fixed-sidebar.jsx
+++ b/stories/src/fixed-list/fixed-sidebar.jsx
@@ -1,5 +1,5 @@
 // @flow
-import React, { type Node } from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import styled from '@emotion/styled';
 import { colors } from '@atlaskit/theme';
@@ -65,7 +65,7 @@ class Sidebar extends React.Component<ListProps> {
                   ) => {
                     const usePortal: boolean = draggableSnapshot.isDragging;
 
-                    const child: Node = (
+                    const child: React.Node = (
                       <QuoteItem
                         quote={quote}
                         isDragging={draggableSnapshot.isDragging}

--- a/stories/src/function-component/quote-app.jsx
+++ b/stories/src/function-component/quote-app.jsx
@@ -1,5 +1,6 @@
 // @flow
-import React, { useState } from 'react';
+import * as React from 'react';
+import { useState } from 'react';
 import styled from '@emotion/styled';
 import { DragDropContext, Droppable, Draggable } from '../../../src';
 import type {

--- a/stories/src/horizontal/author-app.jsx
+++ b/stories/src/horizontal/author-app.jsx
@@ -1,5 +1,6 @@
 // @flow
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import styled from '@emotion/styled';
 import { colors } from '@atlaskit/theme';
 import { DragDropContext } from '../../../src';

--- a/stories/src/interactive-elements/interactive-elements-app.jsx
+++ b/stories/src/interactive-elements/interactive-elements-app.jsx
@@ -1,5 +1,5 @@
 // @flow
-import React, { type Node } from 'react';
+import * as React from 'react';
 import styled from '@emotion/styled';
 import { colors } from '@atlaskit/theme';
 import { DragDropContext, Droppable, Draggable } from '../../../src';
@@ -13,7 +13,7 @@ import type {
 
 type ItemType = {|
   id: string,
-  component: Node,
+  component: React.Node,
 |};
 
 const initial: ItemType[] = [

--- a/stories/src/mixed-sizes/mixed-size-items.jsx
+++ b/stories/src/mixed-sizes/mixed-size-items.jsx
@@ -1,5 +1,6 @@
 // @flow
-import React, { useState } from 'react';
+import * as React from 'react';
+import { useState } from 'react';
 import { quotes as initial } from '../data';
 import type { Quote } from '../types';
 import QuoteList from '../primatives/quote-list';

--- a/stories/src/mixed-sizes/mixed-size-lists-experiment.jsx
+++ b/stories/src/mixed-sizes/mixed-size-lists-experiment.jsx
@@ -1,5 +1,6 @@
 // @flow
-import React, { useState, useEffect, useRef, useContext } from 'react';
+import * as React from 'react';
+import { useState, useEffect, useRef, useContext } from 'react';
 import { getBox, type Position, type BoxModel } from 'css-box-model';
 import styled from '@emotion/styled';
 import { colors } from '@atlaskit/theme';

--- a/stories/src/mixed-sizes/mixed-size-lists.jsx
+++ b/stories/src/mixed-sizes/mixed-size-lists.jsx
@@ -1,7 +1,8 @@
 // @flow
 import { colors } from '@atlaskit/theme';
 import styled from '@emotion/styled';
-import React, { useState } from 'react';
+import * as React from 'react';
+import { useState } from 'react';
 import { useMemo } from 'use-memo-one';
 import {
   DragDropContext,

--- a/stories/src/multi-drag/column.jsx
+++ b/stories/src/multi-drag/column.jsx
@@ -1,5 +1,6 @@
 // @flow
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import styled from '@emotion/styled';
 import memoizeOne from 'memoize-one';
 import { colors } from '@atlaskit/theme';

--- a/stories/src/multi-drag/task-app.jsx
+++ b/stories/src/multi-drag/task-app.jsx
@@ -1,5 +1,6 @@
 // @flow
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import styled from '@emotion/styled';
 import { DragDropContext } from '../../../src';
 import initial from './data';

--- a/stories/src/multi-drag/task.jsx
+++ b/stories/src/multi-drag/task.jsx
@@ -1,5 +1,6 @@
 // @flow
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import styled from '@emotion/styled';
 import { colors } from '@atlaskit/theme';
 import { Draggable } from '../../../src';

--- a/stories/src/multiple-horizontal/quote-app.jsx
+++ b/stories/src/multiple-horizontal/quote-app.jsx
@@ -1,5 +1,6 @@
 // @flow
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import styled from '@emotion/styled';
 import { colors } from '@atlaskit/theme';
 import { DragDropContext } from '../../../src';

--- a/stories/src/multiple-vertical/quote-app.jsx
+++ b/stories/src/multiple-vertical/quote-app.jsx
@@ -1,5 +1,6 @@
 // @flow
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import styled from '@emotion/styled';
 import { colors } from '@atlaskit/theme';
 import { DragDropContext } from '../../../src';

--- a/stories/src/on-before-capture/adding-things.jsx
+++ b/stories/src/on-before-capture/adding-things.jsx
@@ -1,5 +1,6 @@
 // @flow
-import React, { useState } from 'react';
+import * as React from 'react';
+import { useState } from 'react';
 import styled from '@emotion/styled';
 import { colors } from '@atlaskit/theme';
 import type { Task } from '../types';

--- a/stories/src/portal/portal-app.jsx
+++ b/stories/src/portal/portal-app.jsx
@@ -1,5 +1,6 @@
 // @flow
-import React, { Component, type Node } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import ReactDOM from 'react-dom';
 import styled from '@emotion/styled';
 import { colors } from '@atlaskit/theme';
@@ -63,7 +64,7 @@ class PortalAwareItem extends Component<ItemProps> {
 
     const usePortal: boolean = snapshot.isDragging;
 
-    const child: Node = (
+    const child: React.Node = (
       <SimpleQuote
         ref={provided.innerRef}
         {...provided.draggableProps}

--- a/stories/src/primatives/author-item.jsx
+++ b/stories/src/primatives/author-item.jsx
@@ -1,5 +1,6 @@
 // @flow
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import styled from '@emotion/styled';
 import { colors } from '@atlaskit/theme';
 import { grid } from '../constants';

--- a/stories/src/primatives/author-list.jsx
+++ b/stories/src/primatives/author-list.jsx
@@ -1,5 +1,6 @@
 // @flow
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import styled from '@emotion/styled';
 import { colors } from '@atlaskit/theme';
 import { Droppable, Draggable } from '../../../src';

--- a/stories/src/primatives/quote-item.jsx
+++ b/stories/src/primatives/quote-item.jsx
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import styled from '@emotion/styled';
 import { colors } from '@atlaskit/theme';
 import { borderRadius, grid } from '../constants';

--- a/stories/src/primatives/quote-list.jsx
+++ b/stories/src/primatives/quote-list.jsx
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import styled from '@emotion/styled';
 import { colors } from '@atlaskit/theme';
 import { Droppable, Draggable } from '../../../src';

--- a/stories/src/programmatic/multiple-contexts.jsx
+++ b/stories/src/programmatic/multiple-contexts.jsx
@@ -1,7 +1,8 @@
 /* eslint-disable no-console */
 /* eslint-disable no-await-in-loop */
 // @flow
-import React, { useState, useEffect } from 'react';
+import * as React from 'react';
+import { useState, useEffect } from 'react';
 import styled from '@emotion/styled';
 import { useCallback } from 'use-memo-one';
 import type { Quote } from '../types';

--- a/stories/src/programmatic/runsheet.jsx
+++ b/stories/src/programmatic/runsheet.jsx
@@ -1,6 +1,7 @@
 // @flow
 /* eslint-disable no-console */
-import React, { useState, useCallback, useEffect } from 'react';
+import * as React from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import type { Quote } from '../types';
 import type {
   DropResult,

--- a/stories/src/programmatic/with-controls.jsx
+++ b/stories/src/programmatic/with-controls.jsx
@@ -1,6 +1,7 @@
 // @flow
 /* eslint-disable no-console */
-import React, { useRef, createRef, useState, useCallback } from 'react';
+import * as React from 'react';
+import { useRef, createRef, useState, useCallback } from 'react';
 import styled from '@emotion/styled';
 import type { Quote } from '../types';
 import type {

--- a/stories/src/simple/simple-mixed-spacing.jsx
+++ b/stories/src/simple/simple-mixed-spacing.jsx
@@ -2,7 +2,8 @@
 // It matches
 /* eslint-disable flowtype/require-valid-file-annotation */
 
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import { DragDropContext, Droppable, Draggable } from '../../../src';
 
 // fake data generator

--- a/stories/src/simple/simple-scrollable.jsx
+++ b/stories/src/simple/simple-scrollable.jsx
@@ -1,7 +1,8 @@
 // disabling flowtype to keep this example super simple
 /* eslint-disable flowtype/require-valid-file-annotation */
 
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { DragDropContext, Droppable, Draggable } from '../../../src';
 

--- a/stories/src/simple/simple.jsx
+++ b/stories/src/simple/simple.jsx
@@ -2,7 +2,8 @@
 // It matches
 /* eslint-disable flowtype/require-valid-file-annotation */
 
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import { DragDropContext, Droppable, Draggable } from '../../../src';
 
 // fake data generator

--- a/stories/src/table/with-clone.jsx
+++ b/stories/src/table/with-clone.jsx
@@ -1,6 +1,7 @@
 // @flow
 /* eslint-disable react/sort-comp */
-import React, { Component, Fragment, type Node } from 'react';
+import * as React from 'react';
+import { Component, Fragment } from 'react';
 import styled from '@emotion/styled';
 import { colors } from '@atlaskit/theme';
 import {
@@ -43,7 +44,7 @@ const Cell = styled.td`
 `;
 
 type TableCellProps = {|
-  children: Node,
+  children: React.Node,
   isDragOccurring: boolean,
   isDragging: boolean,
   cellId: string,
@@ -200,7 +201,7 @@ const IsDraggingContext = React.createContext<boolean>(false);
 class TableRow extends Component<TableRowProps> {
   render() {
     const { snapshot, quote, provided } = this.props;
-    const child: Node = (
+    const child: React.Node = (
       <IsDraggingContext.Consumer>
         {(isDragging: boolean) => (
           <Row

--- a/stories/src/table/with-dimension-locking.jsx
+++ b/stories/src/table/with-dimension-locking.jsx
@@ -1,6 +1,7 @@
 // @flow
 /* eslint-disable react/sort-comp */
-import React, { Component, Fragment, type Node } from 'react';
+import * as React from 'react';
+import { Component, Fragment } from 'react';
 import styled from '@emotion/styled';
 import { colors } from '@atlaskit/theme';
 import { DragDropContext, Droppable, Draggable } from '../../../src';
@@ -40,7 +41,7 @@ const Cell = styled.td`
 `;
 
 type TableCellProps = {|
-  children: Node,
+  children: React.Node,
   isDragOccurring: boolean,
 |};
 

--- a/stories/src/table/with-fixed-columns.jsx
+++ b/stories/src/table/with-fixed-columns.jsx
@@ -1,5 +1,6 @@
 // @flow
-import React, { Component, Fragment } from 'react';
+import * as React from 'react';
+import { Component, Fragment } from 'react';
 import styled from '@emotion/styled';
 import { colors } from '@atlaskit/theme';
 import { DragDropContext, Droppable, Draggable } from '../../../src';

--- a/stories/src/table/with-portal.jsx
+++ b/stories/src/table/with-portal.jsx
@@ -1,6 +1,7 @@
 // @flow
 /* eslint-disable react/sort-comp */
-import React, { Component, Fragment, type Node } from 'react';
+import * as React from 'react';
+import { Component, Fragment } from 'react';
 import ReactDOM from 'react-dom';
 import styled from '@emotion/styled';
 import { colors } from '@atlaskit/theme';
@@ -41,7 +42,7 @@ const Cell = styled.td`
 `;
 
 type TableCellProps = {|
-  children: Node,
+  children: React.Node,
   isDragOccurring: boolean,
   isDragging: boolean,
   cellId: string,
@@ -198,7 +199,7 @@ const IsDraggingContext = React.createContext<boolean>(false);
 class TableRow extends Component<TableRowProps> {
   render() {
     const { snapshot, quote, provided } = this.props;
-    const child: Node = (
+    const child: React.Node = (
       <IsDraggingContext.Consumer>
         {(isDragging: boolean) => (
           <Row

--- a/stories/src/vertical-grouped/quote-app.jsx
+++ b/stories/src/vertical-grouped/quote-app.jsx
@@ -1,5 +1,6 @@
 // @flow
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import styled from '@emotion/styled';
 import { colors } from '@atlaskit/theme';
 import { DragDropContext } from '../../../src';

--- a/stories/src/vertical-nested/quote-app.jsx
+++ b/stories/src/vertical-nested/quote-app.jsx
@@ -1,5 +1,6 @@
 // @flow
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import styled from '@emotion/styled';
 import { colors } from '@atlaskit/theme';
 import { invariant } from '../../../src/invariant';

--- a/stories/src/vertical-nested/quote-list.jsx
+++ b/stories/src/vertical-nested/quote-list.jsx
@@ -1,5 +1,6 @@
 // @flow
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import styled from '@emotion/styled';
 import { colors } from '@atlaskit/theme';
 import { Droppable, Draggable } from '../../../src';

--- a/stories/src/vertical/quote-app.jsx
+++ b/stories/src/vertical/quote-app.jsx
@@ -1,5 +1,6 @@
 // @flow
-import React, { useState } from 'react';
+import * as React from 'react';
+import { useState } from 'react';
 import styled from '@emotion/styled';
 import type { Quote } from '../types';
 import type { DropResult } from '../../../src/types';

--- a/stories/src/virtual/quote-count-chooser.jsx
+++ b/stories/src/virtual/quote-count-chooser.jsx
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { css } from '@emotion/core';
 import { colors } from '@atlaskit/theme';
 import { grid, borderRadius } from '../constants';

--- a/stories/src/virtual/react-virtualized/board.jsx
+++ b/stories/src/virtual/react-virtualized/board.jsx
@@ -1,5 +1,6 @@
 // @flow
-import React, { useReducer } from 'react';
+import * as React from 'react';
+import { useReducer } from 'react';
 import ReactDOM from 'react-dom';
 import 'react-virtualized/styles.css';
 import { List } from 'react-virtualized';

--- a/stories/src/virtual/react-virtualized/list.jsx
+++ b/stories/src/virtual/react-virtualized/list.jsx
@@ -1,5 +1,6 @@
 // @flow
-import React, { useState } from 'react';
+import * as React from 'react';
+import { useState } from 'react';
 import ReactDOM from 'react-dom';
 import 'react-virtualized/styles.css';
 import { List } from 'react-virtualized';

--- a/stories/src/virtual/react-virtualized/window-list.jsx
+++ b/stories/src/virtual/react-virtualized/window-list.jsx
@@ -1,5 +1,6 @@
 // @flow
-import React, { useState } from 'react';
+import * as React from 'react';
+import { useState } from 'react';
 import ReactDOM from 'react-dom';
 import 'react-virtualized/styles.css';
 import { WindowScroller, List } from 'react-virtualized';

--- a/stories/src/virtual/react-window/board.jsx
+++ b/stories/src/virtual/react-window/board.jsx
@@ -1,5 +1,6 @@
 // @flow
-import React, { useReducer } from 'react';
+import * as React from 'react';
+import { useReducer } from 'react';
 import { FixedSizeList as List, areEqual } from 'react-window';
 import styled from '@emotion/styled';
 import { Global, css } from '@emotion/core';

--- a/stories/src/virtual/react-window/list.jsx
+++ b/stories/src/virtual/react-window/list.jsx
@@ -1,5 +1,6 @@
 // @flow
-import React, { useState } from 'react';
+import * as React from 'react';
+import { useState } from 'react';
 import { FixedSizeList as List, areEqual } from 'react-window';
 import type { Quote } from '../../types';
 import {

--- a/test/unit/integration/accessibility/axe-audit.spec.js
+++ b/test/unit/integration/accessibility/axe-audit.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render, cleanup } from '@testing-library/react';
 import { axe, toHaveNoViolations } from 'jest-axe';
 

--- a/test/unit/integration/body-removal-before-unmount.spec.js
+++ b/test/unit/integration/body-removal-before-unmount.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import { isDragging } from './util/helpers';
 import App from './util/app';

--- a/test/unit/integration/combine-on-start.spec.js
+++ b/test/unit/integration/combine-on-start.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import * as keyCodes from '../../../src/view/key-codes';
 import type {

--- a/test/unit/integration/disable-on-start.spec.js
+++ b/test/unit/integration/disable-on-start.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { getRect } from 'css-box-model';
 import { render } from '@testing-library/react';
 import type {

--- a/test/unit/integration/drag-drop-context/check-react-version.spec.js
+++ b/test/unit/integration/drag-drop-context/check-react-version.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import checkReactVersion from '../../../../src/view/drag-drop-context/check-react-version';
 import { peerDependencies } from '../../../../package.json';
 

--- a/test/unit/integration/drag-drop-context/clashing-with-consumers-redux.spec.js
+++ b/test/unit/integration/drag-drop-context/clashing-with-consumers-redux.spec.js
@@ -1,6 +1,7 @@
 // @flow
 /* eslint-disable react/no-multi-comp */
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import { render } from '@testing-library/react';
 import { Provider, connect } from 'react-redux';
 import { createStore } from 'redux';

--- a/test/unit/integration/drag-drop-context/error-handling/error-in-react-tree.spec.js
+++ b/test/unit/integration/drag-drop-context/error-handling/error-in-react-tree.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import { invariant } from '../../../../../src/invariant';
 import App from '../../util/app';

--- a/test/unit/integration/drag-drop-context/error-handling/error-on-window.spec.js
+++ b/test/unit/integration/drag-drop-context/error-handling/error-on-window.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import { RbdInvariant } from '../../../../../src/invariant';
 import App from '../../util/app';

--- a/test/unit/integration/drag-drop-context/on-before-capture/additions.spec.js
+++ b/test/unit/integration/drag-drop-context/on-before-capture/additions.spec.js
@@ -1,5 +1,6 @@
 // @flow
-import React, { useState } from 'react';
+import * as React from 'react';
+import { useState } from 'react';
 import { render } from '@testing-library/react';
 import App from '../../util/app';
 import {

--- a/test/unit/integration/drag-drop-context/on-before-capture/removals.spec.js
+++ b/test/unit/integration/drag-drop-context/on-before-capture/removals.spec.js
@@ -1,5 +1,6 @@
 // @flow
-import React, { useState } from 'react';
+import * as React from 'react';
+import { useState } from 'react';
 import { render } from '@testing-library/react';
 import {
   Droppable,

--- a/test/unit/integration/drag-drop-context/reset-server-context.spec.js
+++ b/test/unit/integration/drag-drop-context/reset-server-context.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import DragDropContext from '../../../../src/view/drag-drop-context';
 import { resetServerContext } from '../../../../src';

--- a/test/unit/integration/drag-drop-context/unmount.spec.js
+++ b/test/unit/integration/drag-drop-context/unmount.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import DragDropContext from '../../../../src/view/drag-drop-context';
 

--- a/test/unit/integration/drag-handle/keyboard-sensor/directional-movement.spec.js
+++ b/test/unit/integration/drag-handle/keyboard-sensor/directional-movement.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { fireEvent, render, createEvent } from '@testing-library/react';
 import * as keyCodes from '../../../../../src/view/key-codes';
 import App from '../../util/app';

--- a/test/unit/integration/drag-handle/keyboard-sensor/no-click-blocking.spec.js
+++ b/test/unit/integration/drag-handle/keyboard-sensor/no-click-blocking.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render, createEvent, fireEvent } from '@testing-library/react';
 import App from '../../util/app';
 import { simpleLift, keyboard } from '../../util/controls';

--- a/test/unit/integration/drag-handle/keyboard-sensor/prevent-keyboard-scroll.spec.js
+++ b/test/unit/integration/drag-handle/keyboard-sensor/prevent-keyboard-scroll.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { createEvent, fireEvent, render } from '@testing-library/react';
 import * as keyCodes from '../../../../../src/view/key-codes';
 import App from '../../util/app';

--- a/test/unit/integration/drag-handle/keyboard-sensor/prevent-standard-keys-while-dragging.spec.js
+++ b/test/unit/integration/drag-handle/keyboard-sensor/prevent-standard-keys-while-dragging.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { createEvent, fireEvent, render } from '@testing-library/react';
 import * as keyCodes from '../../../../../src/view/key-codes';
 import App from '../../util/app';

--- a/test/unit/integration/drag-handle/keyboard-sensor/starting-a-drag.spec.js
+++ b/test/unit/integration/drag-handle/keyboard-sensor/starting-a-drag.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render, createEvent, fireEvent } from '@testing-library/react';
 import App from '../../util/app';
 import { isDragging } from '../../util/helpers';

--- a/test/unit/integration/drag-handle/keyboard-sensor/stopping-a-drag.spec.js
+++ b/test/unit/integration/drag-handle/keyboard-sensor/stopping-a-drag.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render, createEvent, fireEvent } from '@testing-library/react';
 import App from '../../util/app';
 import { getDropReason, isDragging } from '../../util/helpers';

--- a/test/unit/integration/drag-handle/mouse-sensor/cancel-while-pending.spec.js
+++ b/test/unit/integration/drag-handle/mouse-sensor/cancel-while-pending.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import { sloppyClickThreshold } from '../../../../../src/view/use-sensor-marshal/sensors/use-mouse-sensor';
 import App from '../../util/app';

--- a/test/unit/integration/drag-handle/mouse-sensor/click-blocking.spec.js
+++ b/test/unit/integration/drag-handle/mouse-sensor/click-blocking.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { createEvent, fireEvent, render } from '@testing-library/react';
 import * as keyCodes from '../../../../../src/view/key-codes';
 import { sloppyClickThreshold } from '../../../../../src/view/use-sensor-marshal/sensors/use-mouse-sensor';

--- a/test/unit/integration/drag-handle/mouse-sensor/force-press.spec.js
+++ b/test/unit/integration/drag-handle/mouse-sensor/force-press.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { mouse, simpleLift } from '../../util/controls';
 import App, { type Item } from '../../util/app';

--- a/test/unit/integration/drag-handle/mouse-sensor/prevent-standard-keys-while-dragging.spec.js
+++ b/test/unit/integration/drag-handle/mouse-sensor/prevent-standard-keys-while-dragging.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { createEvent, fireEvent, render } from '@testing-library/react';
 import * as keyCodes from '../../../../../src/view/key-codes';
 import App from '../../util/app';

--- a/test/unit/integration/drag-handle/mouse-sensor/starting-a-dragging.spec.js
+++ b/test/unit/integration/drag-handle/mouse-sensor/starting-a-dragging.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import type { Position } from 'css-box-model';
 import { render, fireEvent, createEvent } from '@testing-library/react';
 import { invariant } from '../../../../../src/invariant';

--- a/test/unit/integration/drag-handle/mouse-sensor/stopping-a-drag.spec.js
+++ b/test/unit/integration/drag-handle/mouse-sensor/stopping-a-drag.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render, createEvent, fireEvent } from '@testing-library/react';
 import App from '../../util/app';
 import { getDropReason } from '../../util/helpers';

--- a/test/unit/integration/drag-handle/sensor-marshal/click-blocking.spec.js
+++ b/test/unit/integration/drag-handle/sensor-marshal/click-blocking.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render, fireEvent, createEvent } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
 import { invariant } from '../../../../../src/invariant';

--- a/test/unit/integration/drag-handle/sensor-marshal/force-releasing-locks.spec.js
+++ b/test/unit/integration/drag-handle/sensor-marshal/force-releasing-locks.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import { invariant } from '../../../../../src/invariant';
 import type {

--- a/test/unit/integration/drag-handle/sensor-marshal/is-lock-claimed.spec.js
+++ b/test/unit/integration/drag-handle/sensor-marshal/is-lock-claimed.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import { invariant } from '../../../../../src/invariant';
 import type {

--- a/test/unit/integration/drag-handle/sensor-marshal/lock-context-isolation.spec.js
+++ b/test/unit/integration/drag-handle/sensor-marshal/lock-context-isolation.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import { invariant } from '../../../../../src/invariant';
 import type { SensorAPI, Sensor } from '../../../../../src/types';

--- a/test/unit/integration/drag-handle/sensor-marshal/move-throttling.spec.js
+++ b/test/unit/integration/drag-handle/sensor-marshal/move-throttling.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import type { Position } from 'css-box-model';
 import { render } from '@testing-library/react';
 import { invariant } from '../../../../../src/invariant';

--- a/test/unit/integration/drag-handle/sensor-marshal/no-double-lift.spec.js
+++ b/test/unit/integration/drag-handle/sensor-marshal/no-double-lift.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import { invariant } from '../../../../../src/invariant';
 import type {

--- a/test/unit/integration/drag-handle/sensor-marshal/obtaining-lock.spec.js
+++ b/test/unit/integration/drag-handle/sensor-marshal/obtaining-lock.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render, act } from '@testing-library/react';
 import { invariant } from '../../../../../src/invariant';
 import type {

--- a/test/unit/integration/drag-handle/sensor-marshal/outdated-locks.spec.js
+++ b/test/unit/integration/drag-handle/sensor-marshal/outdated-locks.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
 import { invariant } from '../../../../../src/invariant';

--- a/test/unit/integration/drag-handle/shared-behaviours/abort-on-error.spec.js
+++ b/test/unit/integration/drag-handle/shared-behaviours/abort-on-error.spec.js
@@ -1,5 +1,6 @@
 // @flow
-import React, { useState, useRef } from 'react';
+import * as React from 'react';
+import { useState, useRef } from 'react';
 import { render, act } from '@testing-library/react';
 import { invariant } from '../../../../../src/invariant';
 import { isDragging, getOffset } from '../../util/helpers';

--- a/test/unit/integration/drag-handle/shared-behaviours/cancel-while-dragging.spec.js
+++ b/test/unit/integration/drag-handle/shared-behaviours/cancel-while-dragging.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { createEvent, fireEvent, render } from '@testing-library/react';
 import * as keyCodes from '../../../../../src/view/key-codes';
 import App from '../../util/app';

--- a/test/unit/integration/drag-handle/shared-behaviours/cannot-start-when-disabled.spec.js
+++ b/test/unit/integration/drag-handle/shared-behaviours/cannot-start-when-disabled.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import { isDragging } from '../../util/helpers';
 import App, { type Item } from '../../util/app';

--- a/test/unit/integration/drag-handle/shared-behaviours/cannot-start-when-something-else-has-lock.spec.js
+++ b/test/unit/integration/drag-handle/shared-behaviours/cannot-start-when-something-else-has-lock.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import { invariant } from '../../../../../src/invariant';
 import { isDragging } from '../../util/helpers';

--- a/test/unit/integration/drag-handle/shared-behaviours/cannot-start-when-unmounted.spec.js
+++ b/test/unit/integration/drag-handle/shared-behaviours/cannot-start-when-unmounted.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import { isDragging } from '../../util/helpers';
 import App from '../../util/app';

--- a/test/unit/integration/drag-handle/shared-behaviours/cleanup.spec.js
+++ b/test/unit/integration/drag-handle/shared-behaviours/cleanup.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import { isDragging } from '../../util/helpers';
 import App from '../../util/app';

--- a/test/unit/integration/drag-handle/shared-behaviours/contenteditable.spec.js
+++ b/test/unit/integration/drag-handle/shared-behaviours/contenteditable.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import { forEachSensor, type Control, simpleLift } from '../../util/controls';
 import { isDragging } from '../../util/helpers';

--- a/test/unit/integration/drag-handle/shared-behaviours/disable-default-sensors.spec.js
+++ b/test/unit/integration/drag-handle/shared-behaviours/disable-default-sensors.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import { isDragging } from '../../util/helpers';
 import App from '../../util/app';

--- a/test/unit/integration/drag-handle/shared-behaviours/interactive-elements.spec.js
+++ b/test/unit/integration/drag-handle/shared-behaviours/interactive-elements.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import { forEachSensor, type Control, simpleLift } from '../../util/controls';
 import { isDragging } from '../../util/helpers';

--- a/test/unit/integration/drag-handle/shared-behaviours/lock-released-mid-drag.spec.js
+++ b/test/unit/integration/drag-handle/shared-behaviours/lock-released-mid-drag.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import type { SensorAPI, Sensor } from '../../../../../src/types';
 import { forEachSensor, type Control, simpleLift } from '../../util/controls';

--- a/test/unit/integration/drag-handle/shared-behaviours/lock-released-pre-drag.spec.js
+++ b/test/unit/integration/drag-handle/shared-behaviours/lock-released-pre-drag.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import type { SensorAPI, Sensor } from '../../../../../src/types';
 import { forEachSensor, type Control, simpleLift } from '../../util/controls';

--- a/test/unit/integration/drag-handle/shared-behaviours/nested-handles.spec.js
+++ b/test/unit/integration/drag-handle/shared-behaviours/nested-handles.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import { forEachSensor, type Control, simpleLift } from '../../util/controls';
 import { isDragging } from '../../util/helpers';

--- a/test/unit/integration/drag-handle/shared-behaviours/no-dragging-svgs.spec.js
+++ b/test/unit/integration/drag-handle/shared-behaviours/no-dragging-svgs.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import { invariant } from '../../../../../src/invariant';
 import { forEachSensor, type Control, simpleLift } from '../../util/controls';

--- a/test/unit/integration/drag-handle/shared-behaviours/parent-rendering-should-not-kill-drag.spec.js
+++ b/test/unit/integration/drag-handle/shared-behaviours/parent-rendering-should-not-kill-drag.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import { isDragging } from '../../util/helpers';
 import App from '../../util/app';

--- a/test/unit/integration/drag-handle/shared-behaviours/validate-controls.spec.js
+++ b/test/unit/integration/drag-handle/shared-behaviours/validate-controls.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import { isDragging, getDropReason } from '../../util/helpers';
 import App from '../../util/app';

--- a/test/unit/integration/drag-handle/touch-sensor/cancel-while-pending.spec.js
+++ b/test/unit/integration/drag-handle/touch-sensor/cancel-while-pending.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import App from '../../util/app';
 import { isDragging } from '../../util/helpers';

--- a/test/unit/integration/drag-handle/touch-sensor/click-blocking.spec.js
+++ b/test/unit/integration/drag-handle/touch-sensor/click-blocking.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { fireEvent, render, createEvent } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
 import App from '../../util/app';

--- a/test/unit/integration/drag-handle/touch-sensor/context-menu-opt-out.spec.js
+++ b/test/unit/integration/drag-handle/touch-sensor/context-menu-opt-out.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import App from '../../util/app';
 import { touch } from '../../util/controls';

--- a/test/unit/integration/drag-handle/touch-sensor/force-press.spec.js
+++ b/test/unit/integration/drag-handle/touch-sensor/force-press.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import App, { type Item } from '../../util/app';
 import { touch, simpleLift } from '../../util/controls';

--- a/test/unit/integration/drag-handle/touch-sensor/starting-a-drag.spec.js
+++ b/test/unit/integration/drag-handle/touch-sensor/starting-a-drag.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { createEvent, fireEvent, render } from '@testing-library/react';
 import App from '../../util/app';
 import { isDragging } from '../../util/helpers';

--- a/test/unit/integration/drag-handle/touch-sensor/stopping-a-drag.spec.js
+++ b/test/unit/integration/drag-handle/touch-sensor/stopping-a-drag.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render, createEvent, fireEvent } from '@testing-library/react';
 import App from '../../util/app';
 import { getDropReason } from '../../util/helpers';

--- a/test/unit/integration/drag-handle/touch-sensor/unmounted-while-pending-timer-running.spec.js
+++ b/test/unit/integration/drag-handle/touch-sensor/unmounted-while-pending-timer-running.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import App from '../../util/app';
 import { isDragging } from '../../util/helpers';

--- a/test/unit/integration/draggable/combined-with.spec.js
+++ b/test/unit/integration/draggable/combined-with.spec.js
@@ -1,6 +1,6 @@
 // @flow
 import { render } from '@testing-library/react';
-import React from 'react';
+import * as React from 'react';
 import type { DraggableStateSnapshot } from '../../../../src';
 import App, { type RenderItem } from '../util/app';
 import expandedMouse from '../util/expanded-mouse';

--- a/test/unit/integration/draggable/dragging.spec.js
+++ b/test/unit/integration/draggable/dragging.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import App, { type RenderItem } from '../util/app';
 import { type DraggableStateSnapshot } from '../../../../src';

--- a/test/unit/integration/draggable/dropping.spec.js
+++ b/test/unit/integration/draggable/dropping.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { type Position } from 'css-box-model';
 import App, { type RenderItem } from '../util/app';

--- a/test/unit/integration/draggable/moving-out-of-the-way.spec.js
+++ b/test/unit/integration/draggable/moving-out-of-the-way.spec.js
@@ -1,6 +1,6 @@
 // @flow
 import { render } from '@testing-library/react';
-import React from 'react';
+import * as React from 'react';
 import App from '../util/app';
 import expandedMouse from '../util/expanded-mouse';
 import {

--- a/test/unit/integration/draggable/portal.spec.js
+++ b/test/unit/integration/draggable/portal.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { type Node } from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import { render } from '@testing-library/react';
 import type {
@@ -22,7 +22,7 @@ const renderItem = (item: Item) => (
   provided: DraggableProvided,
   snapshot: DraggableStateSnapshot,
 ) => {
-  const child: Node = (
+  const child: React.Node = (
     <div
       ref={provided.innerRef}
       {...provided.draggableProps}

--- a/test/unit/integration/draggable/resting.spec.js
+++ b/test/unit/integration/draggable/resting.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import App, { type RenderItem, type Item } from '../util/app';
 import type { DraggableRubric } from '../../../../src';

--- a/test/unit/integration/draggable/validation.spec.js
+++ b/test/unit/integration/draggable/validation.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import {
   DragDropContext,

--- a/test/unit/integration/droppable/clone.spec.js
+++ b/test/unit/integration/droppable/clone.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import { invariant } from '../../../../src/invariant';
 import { type DraggableStateSnapshot } from '../../../../src';

--- a/test/unit/integration/droppable/placeholder.spec.js
+++ b/test/unit/integration/droppable/placeholder.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { invariant } from '../../../../src/invariant';
 import * as attributes from '../../../../src/view/data-attributes';

--- a/test/unit/integration/reorder-render-sync.spec.js
+++ b/test/unit/integration/reorder-render-sync.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { getRect } from 'css-box-model';
 // import { mount, type ReactWrapper } from 'enzyme';
 import { render, fireEvent } from '@testing-library/react';

--- a/test/unit/integration/responders-integration.spec.js
+++ b/test/unit/integration/responders-integration.spec.js
@@ -1,6 +1,6 @@
 /* eslint-disable jest/expect-expect */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { getRect, type Rect } from 'css-box-model';
 import { invariant } from '../../../src/invariant';

--- a/test/unit/integration/responders-timing.spec.js
+++ b/test/unit/integration/responders-timing.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { getRect } from 'css-box-model';
 import { render } from '@testing-library/react';
 import { invariant } from '../../../src/invariant';

--- a/test/unit/integration/server-side-rendering/client-hydration.spec.js
+++ b/test/unit/integration/server-side-rendering/client-hydration.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import ReactDOMServer from 'react-dom/server';
 import { invariant } from '../../../../src/invariant';

--- a/test/unit/integration/server-side-rendering/server-rendering.spec.js
+++ b/test/unit/integration/server-side-rendering/server-rendering.spec.js
@@ -2,7 +2,7 @@
  * @jest-environment node
  */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { renderToString, renderToStaticMarkup } from 'react-dom/server';
 import { invariant } from '../../../../src/invariant';
 import { resetServerContext } from '../../../../src';

--- a/test/unit/integration/util/app.jsx
+++ b/test/unit/integration/util/app.jsx
@@ -1,5 +1,6 @@
 // @flow
-import React, { useState, type Node } from 'react';
+import * as React from 'react';
+import { useState } from 'react';
 import {
   DragDropContext,
   Droppable,
@@ -31,7 +32,7 @@ export type RenderItem = (
   provided: DraggableProvided,
   snapshot: DraggableStateSnapshot,
   rubric: DraggableRubric,
-) => Node;
+) => React.Node;
 
 export const defaultItemRender: RenderItem = (item: Item) => (
   provided: DraggableProvided,
@@ -60,7 +61,7 @@ type Props = {|
   onDragUpdate?: Function,
   onDragEnd?: Function,
   items?: Item[],
-  anotherChild?: Node,
+  anotherChild?: React.Node,
   renderItem?: RenderItem,
 
   // droppable
@@ -126,7 +127,7 @@ export default function App(props: Props) {
       provided: DraggableProvided,
       snapshot: DraggableStateSnapshot,
       rubric: DraggableRubric,
-    ): Node {
+    ): React.Node {
       const item: Item = items[rubric.source.index];
       return render(item)(provided, snapshot, rubric);
     };

--- a/test/unit/integration/util/board.jsx
+++ b/test/unit/integration/util/board.jsx
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import type { BoxModel } from 'css-box-model';
 import { invariant } from '../../../../src/invariant';
 import * as attributes from '../../../../src/view/data-attributes';

--- a/test/unit/state/registry/use-registry.spec.js
+++ b/test/unit/state/registry/use-registry.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import type {
   Registry,

--- a/test/unit/view/animate-in-out/animate-in-out.spec.js
+++ b/test/unit/view/animate-in-out/animate-in-out.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import AnimateInOut, {
   type AnimateProvided,

--- a/test/unit/view/animate-in-out/child-rendering.spec.js
+++ b/test/unit/view/animate-in-out/child-rendering.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { render, act } from '@testing-library/react';
 import AnimateInOut, {
   type AnimateProvided,

--- a/test/unit/view/announcer.spec.js
+++ b/test/unit/view/announcer.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { type Node } from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import { invariant } from '../../../src/invariant';
 import type { Announce, ContextId } from '../../../src/types';
@@ -10,7 +10,7 @@ jest.useFakeTimers();
 
 type Props = {|
   contextId: ContextId,
-  children: (announce: Announce) => Node,
+  children: (announce: Announce) => React.Node,
 |};
 
 function WithAnnouncer(props: Props) {

--- a/test/unit/view/connected-draggable/child-render-behaviour.spec.js
+++ b/test/unit/view/connected-draggable/child-render-behaviour.spec.js
@@ -1,5 +1,6 @@
 // @flow
-import React, { Component, type Node } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import { render } from '@testing-library/react';
 import { DragDropContext } from '../../../../src';
 import { getPreset } from '../../../util/dimension';
@@ -34,7 +35,7 @@ class Person extends Component<{ name: string, provided: Provided }> {
 
 type Props = {|
   currentUser: string,
-  children: (currentUser: string, dragProvided: Provided) => Node,
+  children: (currentUser: string, dragProvided: Provided) => React.Node,
 |};
 
 function App({ currentUser, children }: Props) {

--- a/test/unit/view/connected-droppable/child-render-behaviour.spec.js
+++ b/test/unit/view/connected-droppable/child-render-behaviour.spec.js
@@ -1,5 +1,6 @@
 // @flow
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import { mount } from 'enzyme';
 import type { Provided } from '../../../../src/view/droppable/droppable-types';
 import Droppable from '../../../../src/view/droppable/connected-droppable';

--- a/test/unit/view/drag-drop-context/content-security-protection-nonce.spec.js
+++ b/test/unit/view/drag-drop-context/content-security-protection-nonce.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { mount, type ReactWrapper } from 'enzyme';
 import DragDropContext from '../../../../src/view/drag-drop-context';
 import { resetServerContext } from '../../../../src';

--- a/test/unit/view/droppable/inner-ref-validation.spec.js
+++ b/test/unit/view/droppable/inner-ref-validation.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import type { Provided } from '../../../../src/view/droppable/droppable-types';
 import mount from './util/mount';
 import { withError } from '../../../util/console';

--- a/test/unit/view/droppable/placeholder-setup-warning.spec.js
+++ b/test/unit/view/droppable/placeholder-setup-warning.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import type { ReactWrapper } from 'enzyme';
 import type { Provided } from '../../../../src/view/droppable/droppable-types';
 import {

--- a/test/unit/view/droppable/util/get-stubber.js
+++ b/test/unit/view/droppable/util/get-stubber.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import type {
   Provided,
   StateSnapshot,

--- a/test/unit/view/droppable/util/mount.js
+++ b/test/unit/view/droppable/util/mount.js
@@ -1,5 +1,6 @@
 // @flow
-import React, { useMemo } from 'react';
+import * as React from 'react';
+import { useMemo } from 'react';
 import { mount } from 'enzyme';
 import type {
   MapProps,

--- a/test/unit/view/placeholder/animated-mount.spec.js
+++ b/test/unit/view/placeholder/animated-mount.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { mount, type ReactWrapper } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 import Placeholder from './util/placeholder-with-class';

--- a/test/unit/view/placeholder/on-close.spec.js
+++ b/test/unit/view/placeholder/on-close.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { mount, type ReactWrapper } from 'enzyme';
 import Placeholder from './util/placeholder-with-class';
 import { expectIsFull } from './util/expect';

--- a/test/unit/view/placeholder/on-transition-end.spec.js
+++ b/test/unit/view/placeholder/on-transition-end.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { mount, type ReactWrapper } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 import Placeholder from './util/placeholder-with-class';

--- a/test/unit/view/placeholder/util/placeholder-with-class.js
+++ b/test/unit/view/placeholder/util/placeholder-with-class.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { WithoutMemo } from '../../../../../src/view/placeholder/placeholder';
 import type { Props } from '../../../../../src/view/placeholder/placeholder';
 

--- a/test/unit/view/style-marshal/style-marshal.spec.js
+++ b/test/unit/view/style-marshal/style-marshal.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { type Node } from 'react';
+import * as React from 'react';
 import { mount, type ReactWrapper } from 'enzyme';
 import type { ContextId } from '../../../../src/types';
 import useStyleMarshal from '../../../../src/view/use-style-marshal';
@@ -15,7 +15,7 @@ const getMock = () => jest.fn().mockImplementation(() => null);
 type Props = {|
   contextId: ContextId,
   nonce?: string,
-  children: (marshal: StyleMarshal) => Node,
+  children: (marshal: StyleMarshal) => React.Node,
 |};
 
 function WithMarshal(props: Props) {

--- a/test/unit/view/use-draggable-publisher.spec.js
+++ b/test/unit/view/use-draggable-publisher.spec.js
@@ -1,5 +1,6 @@
 // @flow
-import React, { useRef, useCallback } from 'react';
+import * as React from 'react';
+import { useRef, useCallback } from 'react';
 import { type Spacing, type Rect } from 'css-box-model';
 import { mount, type ReactWrapper } from 'enzyme';
 import { useMemo } from 'use-memo-one';

--- a/test/unit/view/use-droppable-publisher/forced-scroll.spec.js
+++ b/test/unit/view/use-droppable-publisher/forced-scroll.spec.js
@@ -1,6 +1,6 @@
 // @flow
 import { mount } from 'enzyme';
-import React from 'react';
+import * as React from 'react';
 import { invariant } from '../../../../src/invariant';
 import type { DimensionMarshal } from '../../../../src/state/dimension-marshal/dimension-marshal-types';
 import { getMarshalStub } from '../../../util/dimension-marshal';

--- a/test/unit/view/use-droppable-publisher/is-combined-enabled-change.spec.js
+++ b/test/unit/view/use-droppable-publisher/is-combined-enabled-change.spec.js
@@ -1,6 +1,6 @@
 // @flow
 import { mount } from 'enzyme';
-import React from 'react';
+import * as React from 'react';
 import type { DimensionMarshal } from '../../../../src/state/dimension-marshal/dimension-marshal-types';
 import { getMarshalStub } from '../../../util/dimension-marshal';
 import { setViewport } from '../../../util/viewport';

--- a/test/unit/view/use-droppable-publisher/is-enabled-change.spec.js
+++ b/test/unit/view/use-droppable-publisher/is-enabled-change.spec.js
@@ -1,6 +1,6 @@
 // @flow
 import { mount } from 'enzyme';
-import React from 'react';
+import * as React from 'react';
 import type { DimensionMarshal } from '../../../../src/state/dimension-marshal/dimension-marshal-types';
 import { getMarshalStub } from '../../../util/dimension-marshal';
 import { setViewport } from '../../../util/viewport';

--- a/test/unit/view/use-droppable-publisher/publishing.spec.js
+++ b/test/unit/view/use-droppable-publisher/publishing.spec.js
@@ -1,7 +1,7 @@
 // @flow
 import { type Position } from 'css-box-model';
 import { mount, type ReactWrapper } from 'enzyme';
-import React from 'react';
+import * as React from 'react';
 import { invariant } from '../../../../src/invariant';
 import type { DroppableDimension, ScrollSize } from '../../../../src/types';
 import { negate } from '../../../../src/state/position';

--- a/test/unit/view/use-droppable-publisher/recollection.spec.js
+++ b/test/unit/view/use-droppable-publisher/recollection.spec.js
@@ -1,7 +1,7 @@
 // @flow
 import type { Position } from 'css-box-model';
 import { mount } from 'enzyme';
-import React from 'react';
+import * as React from 'react';
 import { invariant } from '../../../../src/invariant';
 import type { DimensionMarshal } from '../../../../src/state/dimension-marshal/dimension-marshal-types';
 import type { DroppableDimension } from '../../../../src/types';

--- a/test/unit/view/use-droppable-publisher/registration.spec.js
+++ b/test/unit/view/use-droppable-publisher/registration.spec.js
@@ -1,7 +1,7 @@
 // @flow
 /* eslint-disable react/no-multi-comp */
 import { mount } from 'enzyme';
-import React from 'react';
+import * as React from 'react';
 import type { DroppableDescriptor } from '../../../../src/types';
 import forceUpdate from '../../../util/force-update';
 import { preset, ScrollableItem, WithAppContext } from './util/shared';

--- a/test/unit/view/use-droppable-publisher/scroll-watching.spec.js
+++ b/test/unit/view/use-droppable-publisher/scroll-watching.spec.js
@@ -1,6 +1,6 @@
 // @flow
 import { mount } from 'enzyme';
-import React from 'react';
+import * as React from 'react';
 import { type Position } from 'css-box-model';
 import { invariant } from '../../../../src/invariant';
 import type { DimensionMarshal } from '../../../../src/state/dimension-marshal/dimension-marshal-types';

--- a/test/unit/view/use-droppable-publisher/util/shared.js
+++ b/test/unit/view/use-droppable-publisher/util/shared.js
@@ -1,7 +1,8 @@
 // @flow
 /* eslint-disable react/no-multi-comp */
 import { createBox, type Spacing, type BoxModel } from 'css-box-model';
-import React, { useMemo, type Node } from 'react';
+import * as React from 'react';
+import { useMemo } from 'react';
 import useDroppablePublisher from '../../../../../src/view/use-droppable-publisher/use-droppable-publisher';
 import { getComputedSpacing, getPreset } from '../../../../util/dimension';
 import { type DimensionMarshal } from '../../../../../src/state/dimension-marshal/dimension-marshal-types';
@@ -77,7 +78,7 @@ export const descriptor: DroppableDescriptor = preset.home.descriptor;
 type WithAppContextProps = {|
   marshal?: DimensionMarshal,
   registry: Registry,
-  children: Node,
+  children: React.Node,
 |};
 
 const focusMarshal = {


### PR DESCRIPTION
Ref https://github.com/facebook/react/pull/18102

Also migrated from `import { type Node } from 'react';` to `React.Node`
as more explicit because `Node` is also DOM type and may conflict when
import is forgotted.