### PR TITLE
Upgrade react-redux to 7.2.0

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "dist/react-beautiful-dnd.js": {
-    "bundled": 364497,
-    "minified": 133470,
-    "gzipped": 39473
+    "bundled": 364529,
+    "minified": 133329,
+    "gzipped": 39400
   },
   "dist/react-beautiful-dnd.min.js": {
-    "bundled": 307976,
-    "minified": 109369,
-    "gzipped": 31806
+    "bundled": 306380,
+    "minified": 108154,
+    "gzipped": 31336
   },
   "dist/react-beautiful-dnd.esm.js": {
     "bundled": 240875,

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "css-box-model": "^1.2.0",
     "memoize-one": "^5.1.1",
     "raf-schd": "^4.0.2",
-    "react-redux": "^7.1.1",
+    "react-redux": "^7.2.0",
     "redux": "^4.0.4",
     "use-memo-one": "^1.1.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10187,14 +10187,13 @@ react-popper@^1.3.6:
     typed-styles "^0.0.7"
     warning "^4.0.2"
 
-react-redux@^7.1.1:
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.1.3.tgz#717a3d7bbe3a1b2d535c94885ce04cdc5a33fc79"
-  integrity sha512-uI1wca+ECG9RoVkWQFF4jDMqmaw0/qnvaSvOoL/GA4dNxf6LoV8sUAcNDvE5NWKs4hFpn0t6wswNQnY3f7HT3w==
+react-redux@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.0.tgz#f970f62192b3981642fec46fd0db18a074fe879d"
+  integrity sha512-EvCAZYGfOLqwV7gh849xy9/pt55rJXPwmYvI4lilPM5rUT/1NxuuN59ipdBksRVSvz0KInbPnp4IfoXJXCqiDA==
   dependencies:
     "@babel/runtime" "^7.5.5"
     hoist-non-react-statics "^3.3.0"
-    invariant "^2.2.4"
     loose-envify "^1.4.0"
     prop-types "^15.7.2"
     react-is "^16.9.0"


### PR DESCRIPTION
7.1 had some annoying issues like memory leaks, etc. (summarized in
their changelogs). I didn't find a Greenkeeper PR for this for some
reason. Currently we're just using resolutions in our project, but I
figured I might as well file an upstream fix!