### PR TITLE
Adds name to store for devtools

### DIFF
--- a/src/state/create-store.js
+++ b/src/state/create-store.js
@@ -27,7 +27,9 @@ const composeEnhancers =
   process.env.NODE_ENV !== 'production' &&
   typeof window !== 'undefined' &&
   window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
-    ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
+    ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
+        name: 'react-beautiful-dnd',
+      })
     : compose;
 
 type Args = {|


### PR DESCRIPTION
**What:** Adds a name to the store for redux devtools

**Why:** Without a specified name redux devtools will display the document title.  This could be a little confusing if there are multiple libraries that, like this one, use redux devtools.  I think it would be helpful to specify a name.  This would make it immediately obvious to developers.