### PR TITLE
Fixed typo on documentation

### DIFF
--- a/docs/guides/reparenting.md
+++ b/docs/guides/reparenting.md
@@ -130,6 +130,6 @@ If you are doing drag and drop reordering within a `<table>` we have created a p
 
 ## Performance ⚠️
 
-Keep in mind that anything that is reparented will be rendered from scratch. So you do not want to be moving large component trees into a `portal`: otherwise you will experience large UI jank. We do not using reparenting out of the box because of this performance drawback.
+Keep in mind that anything that is reparented will be rendered from scratch. So you do not want to be moving large component trees into a `portal`: otherwise you will experience large UI jank. We do not recommend using reparenting out of the box because of this performance drawback.
 
 [← Back to documentation](/README.md#documentation-)


### PR DESCRIPTION
The last line says ```We do not using reparenting out of the box because of this performance drawback.``` while it should be ```We do not recommend using reparenting out of the box because of this performance drawback.```