### PR TITLE
Fix getFurthestAway() distance calculation

### DIFF
--- a/src/state/get-droppable-over.js
+++ b/src/state/get-droppable-over.js
@@ -58,8 +58,8 @@ function getFurthestAway({
       const axis: Axis = candidate.axis;
       const target: Position = patch(
         candidate.axis.line,
-        // use the current center of the dragging item on the main axis
-        pageBorderBox.center[axis.line],
+        // use the center of the list on the main axis
+        candidate.page.borderBox.center[axis.line],
         // use the center of the list on the cross axis
         candidate.page.borderBox.center[axis.crossAxisLine],
       );


### PR DESCRIPTION
Distance should be calculated between the draggable's center and each droppable's center along the major axis.