### PR TITLE
Experimental grid support

### DIFF
--- a/src/state/axis.js
+++ b/src/state/axis.js
@@ -1,5 +1,5 @@
 // @flow
-import type { HorizontalAxis, VerticalAxis } from '../types';
+import type { HorizontalAxis, VerticalAxis, GridAxis } from '../types';
 
 export const vertical: VerticalAxis = {
   direction: 'vertical',
@@ -15,6 +15,19 @@ export const vertical: VerticalAxis = {
 
 export const horizontal: HorizontalAxis = {
   direction: 'horizontal',
+  line: 'x',
+  crossAxisLine: 'y',
+  start: 'left',
+  end: 'right',
+  size: 'width',
+  crossAxisStart: 'top',
+  crossAxisEnd: 'bottom',
+  crossAxisSize: 'height',
+};
+
+export const grid: GridAxis = {
+  direction: 'horizontal',
+  grid: true,
   line: 'x',
   crossAxisLine: 'y',
   start: 'left',

--- a/src/state/droppable/get-droppable.js
+++ b/src/state/droppable/get-droppable.js
@@ -8,7 +8,7 @@ import type {
   DroppableSubject,
   ScrollSize,
 } from '../../types';
-import { vertical, horizontal } from '../axis';
+import { vertical, horizontal, grid } from '../axis';
 import { origin } from '../position';
 import getMaxScroll from '../get-max-scroll';
 import getSubject from './util/get-subject';
@@ -26,7 +26,7 @@ type Args = {|
   isEnabled: boolean,
   isCombineEnabled: boolean,
   isFixedOnPage: boolean,
-  direction: 'vertical' | 'horizontal',
+  direction: 'vertical' | 'horizontal' | 'grid',
   client: BoxModel,
   // is null when in a fixed container
   page: BoxModel,
@@ -76,7 +76,7 @@ export default ({
     };
   })();
 
-  const axis: Axis = direction === 'vertical' ? vertical : horizontal;
+  const axis: Axis = direction === 'vertical' ? vertical : direction === 'grid' ? grid : horizontal;
 
   const subject: DroppableSubject = getSubject({
     page,

--- a/src/state/get-drag-impact/get-reorder-impact.js
+++ b/src/state/get-drag-impact/get-reorder-impact.js
@@ -18,6 +18,7 @@ import { find } from '../../native-with-fallback';
 import getDidStartAfterCritical from '../did-start-after-critical';
 import calculateReorderImpact from '../calculate-drag-impact/calculate-reorder-impact';
 import getIsDisplaced from '../get-is-displaced';
+import { horizontal, vertical } from '../axis';
 
 type Args = {|
   pageBorderBoxWithDroppableScroll: Rect,
@@ -52,14 +53,14 @@ function atIndex({ draggable, closest, inHomeList }: AtIndexArgs): ?number {
 }
 
 export default ({
-  pageBorderBoxWithDroppableScroll: targetRect,
-  draggable,
-  destination,
-  insideDestination,
-  last,
-  viewport,
-  afterCritical,
-}: Args): DragImpact => {
+                  pageBorderBoxWithDroppableScroll: targetRect,
+                  draggable,
+                  destination,
+                  insideDestination,
+                  last,
+                  viewport,
+                  afterCritical,
+                }: Args): DragImpact => {
   const axis: Axis = destination.axis;
   const displacedBy: DisplacedBy = getDisplacedBy(
     destination.axis,
@@ -69,6 +70,11 @@ export default ({
 
   const targetStart: number = targetRect[axis.start];
   const targetEnd: number = targetRect[axis.end];
+
+  //mod-start
+  const uprightAxis = axis.direction === 'horizontal' ? vertical : horizontal;
+  const uprightAxisBoundStart: number = targetRect[uprightAxis.start];
+  //mod-end
 
   const withoutDragging: DraggableDimension[] = removeDraggableFromList(
     draggable,
@@ -80,6 +86,15 @@ export default ({
     (child: DraggableDimension): boolean => {
       const id: DraggableId = child.descriptor.id;
       const childCenter: number = child.page.borderBox.center[axis.line];
+
+      //mod-start
+      if(axis.grid) {
+        const uprightChildCenter: number = child.page.borderBox.center[uprightAxis.line];
+
+        if (!(uprightAxisBoundStart < uprightChildCenter))
+          return false;
+      }
+      //mod-end
 
       const didStartAfterCritical: boolean = getDidStartAfterCritical(
         id,

--- a/src/types.js
+++ b/src/types.js
@@ -31,7 +31,7 @@ export type DraggableOptions = {|
   isEnabled: boolean,
 |};
 
-export type Direction = 'horizontal' | 'vertical';
+export type Direction = 'horizontal' | 'vertical' | 'grid';
 
 export type VerticalAxis = {|
   direction: 'vertical',
@@ -57,7 +57,20 @@ export type HorizontalAxis = {|
   crossAxisSize: 'height',
 |};
 
-export type Axis = VerticalAxis | HorizontalAxis;
+export type GridAxis = {|
+  direction: 'horizontal',
+  grid: true,
+  line: 'x',
+  start: 'left',
+  end: 'right',
+  size: 'width',
+  crossAxisLine: 'y',
+  crossAxisStart: 'top',
+  crossAxisEnd: 'bottom',
+  crossAxisSize: 'height',
+|};
+
+export type Axis = VerticalAxis | HorizontalAxis | GridAxis;
 
 export type ScrollSize = {|
   scrollHeight: number,

--- a/src/view/draggable/connected-draggable.js
+++ b/src/view/draggable/connected-draggable.js
@@ -310,7 +310,7 @@ function getSecondarySelector(): TrySelect {
     const displaced = impact.displaced.all;
     const index = displaced.indexOf(ownProps.draggableId);
 
-    if (index > -1 && displaced.length > index + 1) {
+    if (index > -1 && displaced.length > index + 1 && impact.displaced.visible[ownProps.draggableId]) {
       const ownDimensions = dims[ownProps.draggableId].client.borderBox;
 
       if (index > 0) {

--- a/src/view/draggable/draggable.jsx
+++ b/src/view/draggable/draggable.jsx
@@ -96,8 +96,8 @@ export default function Draggable(props: Props) {
     );
     useDraggablePublisher(forPublisher);
   }
-  /* eslint-enable react-hooks/rules-of-hooks */
 
+  /* eslint-enable react-hooks/rules-of-hooks */
   const dragHandleProps: ?DragHandleProps = useMemo(
     () =>
       isEnabled

--- a/stories/2-single-horizontal.stories.js
+++ b/stories/2-single-horizontal.stories.js
@@ -6,7 +6,7 @@ import AuthorApp from './src/horizontal/author-app';
 import { quotes, getQuotes } from './src/data';
 import type { Quote } from './src/types';
 
-const bigData: Quote[] = getQuotes(30);
+const bigData: Quote[] = getQuotes(20);
 
 const WideWindow = styled.div`
   width: 120vw;

--- a/stories/src/horizontal/author-app.jsx
+++ b/stories/src/horizontal/author-app.jsx
@@ -22,6 +22,9 @@ type State = {|
 const Root = styled.div`
   padding: ${grid}px;
   background: ${colors.B50};
+  display: flex;
+    flex-direction: row;
+    justify-content: center;
 `;
 
 export default class AuthorApp extends Component<Props, State> {

--- a/stories/src/primatives/author-item.jsx
+++ b/stories/src/primatives/author-item.jsx
@@ -13,6 +13,7 @@ const Avatar = styled.img`
   border-radius: 50%;
   flex-shrink: 0;
   margin-right: ${grid}px;
+  margin-bottom: ${grid}px;
   border-color: ${({ isDragging }) => (isDragging ? colors.G50 : colors.N0)};
   border-style: solid;
   border-width: ${grid}px;

--- a/stories/src/primatives/author-list.jsx
+++ b/stories/src/primatives/author-list.jsx
@@ -14,6 +14,7 @@ import type {
 } from '../../../src';
 
 const Wrapper = styled.div`
+  max-width:420px;
   background-color: ${({ isDraggingOver }) =>
     isDraggingOver ? colors.B50 : colors.B75};
   display: flex;
@@ -25,6 +26,8 @@ const Wrapper = styled.div`
 `;
 
 const DropZone = styled.div`
+max-width:420px;
+flex-wrap:wrap;
   display: flex;
 
   /*
@@ -34,14 +37,14 @@ const DropZone = styled.div`
   align-items: start;
 
   /* stop the list collapsing when empty */
-  min-width: 600px;
+  /*min-width: 600px;*/
 
   /* stop the list collapsing when it has no items */
   min-height: 60px;
 `;
 
 const ScrollContainer = styled.div`
-  overflow: auto;
+  /*overflow: hidden;*/
 `;
 
 // $ExpectError - not sure why
@@ -101,7 +104,7 @@ export default class AuthorList extends Component<Props> {
       <Droppable
         droppableId={listId}
         type={listType}
-        direction="horizontal"
+        direction="grid"
         isCombineEnabled={isCombineEnabled}
       >
         {(


### PR DESCRIPTION
I was aware that this is a long unsupported feature, so I decided to step up and offer my hacking skills to make this happen.
With some minor changes and adding a new direction option - "grid", I believe I got very close.

This Is where I'm at right now:
![480p](https://user-images.githubusercontent.com/29354117/96104002-fd4bd280-0ee0-11eb-9e84-949b12e3458c.gif)

The solution is based on the better flex-wrap grid with a single droppable rather then having multiple droppables to serve as rows. Of course this is merely a POC, even though performance is great there are some bugs and weird movements, so I was hoping for some help to try and make it production ready or an official feature.

The modded version can be found at [https://github.com/NadavCohen/react-beautiful-dnd](https://github.com/NadavCohen/react-beautiful-dnd)

I edited the "single horizontal list" entries in the storybook for demonstration.