### PR TITLE
Rename use-touch-sensor default export to useTouchSensor

### DIFF
--- a/src/view/use-sensor-marshal/sensors/use-touch-sensor.js
+++ b/src/view/use-sensor-marshal/sensors/use-touch-sensor.js
@@ -243,7 +243,7 @@ function getHandleBindings({
   ];
 }
 
-export default function useMouseSensor(api: SensorAPI) {
+export default function useTouchSensor(api: SensorAPI) {
   const phaseRef = useRef<Phase>(idle);
   const unbindEventsRef = useRef<() => void>(noop);
 


### PR DESCRIPTION
This is not super important but found it misleading that the default exported function name was not matching the actual file name 🙂