### PR TITLE
Initial proposal to support usage in shadow roots #1659

### DIFF
--- a/src/view/drag-drop-context/app.jsx
+++ b/src/view/drag-drop-context/app.jsx
@@ -63,6 +63,7 @@ export type Props = {|
 
   // screen reader
   dragHandleUsageInstructions: string,
+  stylesInsertionPoint?: HTMLElement,
 |};
 
 const createResponders = (props: Props): Responders => ({
@@ -107,7 +108,7 @@ export default function App(props: Props) {
     contextId,
     text: dragHandleUsageInstructions,
   });
-  const styleMarshal: StyleMarshal = useStyleMarshal(contextId, nonce);
+  const styleMarshal: StyleMarshal = useStyleMarshal(contextId, nonce, props.stylesInsertionPoint);
 
   const lazyDispatch: (Action) => void = useCallback((action: Action): void => {
     getStore(lazyStoreRef).dispatch(action);

--- a/src/view/get-elements/find-drag-handle.js
+++ b/src/view/get-elements/find-drag-handle.js
@@ -8,10 +8,11 @@ import isHtmlElement from '../is-type-of-element/is-html-element';
 export default function findDragHandle(
   contextId: ContextId,
   draggableId: DraggableId,
+  documentFragment: DocumentFragment
 ): ?HTMLElement {
   // cannot create a selector with the draggable id as it might not be a valid attribute selector
   const selector: string = `[${dragHandleAttr.contextId}="${contextId}"]`;
-  const possible: Element[] = toArray(document.querySelectorAll(selector));
+  const possible: Element[] = toArray(documentFragment.querySelectorAll(selector));
 
   if (!possible.length) {
     warning(`Unable to find any drag handles in the context "${contextId}"`);

--- a/src/view/get-elements/find-draggable.js
+++ b/src/view/get-elements/find-draggable.js
@@ -8,10 +8,11 @@ import isHtmlElement from '../is-type-of-element/is-html-element';
 export default function findDraggable(
   contextId: ContextId,
   draggableId: DraggableId,
+  documentFragment: DocumentFragment,
 ): ?HTMLElement {
   // cannot create a selector with the draggable id as it might not be a valid attribute selector
   const selector: string = `[${attributes.draggable.contextId}="${contextId}"]`;
-  const possible: Element[] = toArray(document.querySelectorAll(selector));
+  const possible: Element[] = toArray(documentFragment.querySelectorAll(selector));
 
   const draggable: ?Element = find(possible, (el: Element): boolean => {
     return el.getAttribute(attributes.draggable.id) === draggableId;

--- a/src/view/use-sensor-marshal/find-closest-draggable-id-from-event.js
+++ b/src/view/use-sensor-marshal/find-closest-draggable-id-from-event.js
@@ -14,7 +14,7 @@ function findClosestDragHandleFromEvent(
   contextId: ContextId,
   event: Event,
 ): ?HTMLElement {
-  const target: ?EventTarget = event.target;
+  const target: ?EventTarget = event.composedPath ? event.composedPath()[0] : event.target;
 
   if (!isElement(target)) {
     warning('event.target must be a Element');

--- a/src/view/use-sensor-marshal/is-event-in-interactive-element.js
+++ b/src/view/use-sensor-marshal/is-event-in-interactive-element.js
@@ -56,7 +56,7 @@ export default function isEventInInteractiveElement(
   draggable: Element,
   event: Event,
 ): boolean {
-  const target: EventTarget = event.target;
+  const target: EventTarget = event.composedPath ? event.composedPath()[0] : event.target;
 
   if (!isHtmlElement(target)) {
     return false;

--- a/src/view/use-sensor-marshal/use-sensor-marshal.js
+++ b/src/view/use-sensor-marshal/use-sensor-marshal.js
@@ -171,7 +171,7 @@ function tryStart({
     return null;
   }
 
-  const entry: DraggableEntry = registry.draggable.getById(draggableId);
+  const entry: DraggableEntry = registry.draggable.getById(draggableId, sourceEvent.srcElement.shadowRoot || document);
   const el: ?HTMLElement = findDraggable(contextId, entry.descriptor.id);
 
   if (!el) {

--- a/src/view/use-style-marshal/use-style-marshal.js
+++ b/src/view/use-style-marshal/use-style-marshal.js
@@ -24,7 +24,7 @@ const createStyleEl = (nonce?: string): HTMLStyleElement => {
   return el;
 };
 
-export default function useStyleMarshal(contextId: ContextId, nonce?: string) {
+export default function useStyleMarshal(contextId: ContextId, nonce?: string, stylesInsertionPoint: HTMLElement) {
   const styles: Styles = useMemo(() => getStyles(contextId), [contextId]);
   const alwaysRef = useRef<?HTMLStyleElement>(null);
   const dynamicRef = useRef<?HTMLStyleElement>(null);
@@ -64,8 +64,8 @@ export default function useStyleMarshal(contextId: ContextId, nonce?: string) {
     dynamic.setAttribute(`${prefix}-dynamic`, contextId);
 
     // add style tags to head
-    getHead().appendChild(always);
-    getHead().appendChild(dynamic);
+    (stylesInsertionPoint || getHead()).appendChild(always);
+    (stylesInsertionPoint || getHead()).appendChild(dynamic);
 
     // set initial style
     setAlwaysStyle(styles.always);
@@ -75,7 +75,7 @@ export default function useStyleMarshal(contextId: ContextId, nonce?: string) {
       const remove = (ref) => {
         const current: ?HTMLStyleElement = ref.current;
         invariant(current, 'Cannot unmount ref as it is not set');
-        getHead().removeChild(current);
+        (stylesInsertionPoint || getHead()).removeChild(current);
         ref.current = null;
       };
 


### PR DESCRIPTION
This change is a rough and initial proposal allowing to use this
library at least within the same parent shadow root (but not cross
shadowRoots yet). It does neither cover all functionalities yet nor
is in a quality state to be merged (missing tests etc).

This requires the following aspects
- Make sure not using query selectors on document directly as those
  cannot find elements inside shadow roots. Therefore use specific DOM
  nodes to start searching other nodes
- Events are handled centrally, but event.target will reference to the
  hosting element. Therefore use event.composedPath() to get the real
  nested element for that event.
- Shadow roots isolate stylesheets, means global styles do not bleed
  into the shadow root. Therefore we need to make sure to generate the
  styles into the shadow root. As I couldn't find a way to get the
  mounted DOM node for the DragDropContext component at the point in
  time where the stylesheets are currently getting generated into the
  DOM. Therefore this changes allows consumers to specify the DOM
  location as a prop of the DragDropContext. Same approach is taken by
  JSS (see https://cssinjs.org/jss-api?v=v10.6.0#setup-jss-instance).