### PR TITLE
Add opt-in behaviour to change how the droppable target is calculated

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -22,5 +22,29 @@
         "code": 24005
       }
     }
+  },
+  "dist\\react-beautiful-dnd.js": {
+    "bundled": 364336,
+    "minified": 134030,
+    "gzipped": 39692
+  },
+  "dist\\react-beautiful-dnd.min.js": {
+    "bundled": 310486,
+    "minified": 111370,
+    "gzipped": 32650
+  },
+  "dist\\react-beautiful-dnd.esm.js": {
+    "bundled": 233476,
+    "minified": 119833,
+    "gzipped": 32616,
+    "treeshaked": {
+      "rollup": {
+        "code": 21428,
+        "import_statements": 503
+      },
+      "webpack": {
+        "code": 24311
+      }
+    }
   }
 }

--- a/src/state/get-drag-impact/index.js
+++ b/src/state/get-drag-impact/index.js
@@ -28,7 +28,7 @@ type Args = {|
   viewport: Viewport,
   afterCritical: LiftEffect,
   currentSelection: Position,
-  calculateDroppableUsingCursorPosition: Boolean,
+  calculateDroppableUsingCursorPosition: boolean,
 |};
 
 export default ({

--- a/src/state/get-drag-impact/index.js
+++ b/src/state/get-drag-impact/index.js
@@ -27,6 +27,8 @@ type Args = {|
   previousImpact: DragImpact,
   viewport: Viewport,
   afterCritical: LiftEffect,
+  currentSelection: Position,
+  calculateDroppableUsingCursorPosition: Boolean,
 |};
 
 export default ({
@@ -37,6 +39,8 @@ export default ({
   previousImpact,
   viewport,
   afterCritical,
+  currentSelection,
+  calculateDroppableUsingCursorPosition,
 }: Args): DragImpact => {
   const pageBorderBox: Rect = offsetRectByPosition(
     draggable.page.borderBox,
@@ -45,8 +49,10 @@ export default ({
 
   const destinationId: ?DroppableId = getDroppableOver({
     pageBorderBox,
+    currentSelection,
     draggable,
     droppables,
+    calculateDroppableUsingCursorPosition,
   });
 
   // not dragging over anything

--- a/src/state/get-droppable-over.js
+++ b/src/state/get-droppable-over.js
@@ -23,10 +23,6 @@ function getHasOverlap(first: Rect, second: Rect): boolean {
   );
 }
 
-function pointerIsContainedWithin(box: Rect, pointer: Position): boolean {
-  return isWithin(box.top, box.bottom)(pointer.y) && isWithin(box.left, box.right)(pointer.x);
-}
-
 type Args = {|
   pageBorderBox: Rect,
   draggable: DraggableDimension,

--- a/src/state/get-droppable-over.js
+++ b/src/state/get-droppable-over.js
@@ -43,9 +43,7 @@ type GetFurthestArgs = {|
 |};
 
 type GetClosestToCursorArgs = {|
-  pageBorderBox: Rect,
   currentSelection: Position,
-  draggable: DraggableDimension,
   candidates: DroppableDimension[],
 |};
 

--- a/src/state/post-reducer/when-moving/update.js
+++ b/src/state/post-reducer/when-moving/update.js
@@ -91,7 +91,7 @@ export default ({
       viewport,
       afterCritical: state.afterCritical,
       currentSelection: state.current.page.selection,
-      calculateDroppableUsingCursorPosition: true
+      calculateDroppableUsingCursorPosition: state.critical.draggable.dropTargetCalculationMode === 'pointer'
     });
 
   const withUpdatedPlaceholders: DroppableDimensionMap = recomputePlaceholders({

--- a/src/state/post-reducer/when-moving/update.js
+++ b/src/state/post-reducer/when-moving/update.js
@@ -90,6 +90,8 @@ export default ({
       previousImpact: state.impact,
       viewport,
       afterCritical: state.afterCritical,
+      currentSelection: state.current.page.selection,
+      calculateDroppableUsingCursorPosition: true
     });
 
   const withUpdatedPlaceholders: DroppableDimensionMap = recomputePlaceholders({

--- a/src/state/publish-while-dragging-in-virtual/index.js
+++ b/src/state/publish-while-dragging-in-virtual/index.js
@@ -117,6 +117,7 @@ export default ({
     previousImpact,
     viewport: state.viewport,
     afterCritical,
+    
   });
 
   timings.finish(timingsKey);

--- a/src/view/draggable/draggable-types.js
+++ b/src/view/draggable/draggable-types.js
@@ -43,6 +43,7 @@ export type NotDraggingStyle = {|
 |};
 
 export type DraggableStyle = DraggingStyle | NotDraggingStyle;
+export type DroppableTargetCalculationMode = 'box' | 'pointer';
 
 export type ZIndexOptions = {|
   dragging: number,
@@ -164,6 +165,7 @@ export type PublicOwnProps = {|
   children: ChildrenFn,
 
   // optional own props
+  dropTargetCalculationMode?: DroppableTargetCalculationMode
   isDragDisabled?: boolean,
   disableInteractiveElementBlocking?: boolean,
   shouldRespectForcePress?: boolean,

--- a/src/view/draggable/draggable.jsx
+++ b/src/view/draggable/draggable.jsx
@@ -43,8 +43,9 @@ export default function Draggable(props: Props) {
       index: props.index,
       type,
       droppableId,
+      dropTargetCalculationMode: props.dropTargetCalculationMode,
     }),
-    [props.draggableId, props.index, type, droppableId],
+    [props.draggableId, props.index, type, droppableId, props.dropTargetCalculationMode],
   );
 
   // props

--- a/src/view/draggable/draggable.jsx
+++ b/src/view/draggable/draggable.jsx
@@ -52,6 +52,7 @@ export default function Draggable(props: Props) {
     // ownProps
     children,
     draggableId,
+    dropTargetCalculationMode,
     isEnabled,
     shouldRespectForcePress,
     canDragInteractiveElements,
@@ -87,6 +88,7 @@ export default function Draggable(props: Props) {
       }),
       [
         descriptor,
+        dropTargetCalculationMode,
         registry,
         getRef,
         canDragInteractiveElements,

--- a/test/unit/state/get-droppable-over/preferencing.spec.js
+++ b/test/unit/state/get-droppable-over/preferencing.spec.js
@@ -81,62 +81,136 @@ const draggable: DraggableDimension = getDraggableDimension({
   borderBox: droppableOrigin.client.borderBox,
 });
 
-/**
- * In this case we're hovering over all three lists.
- * We expect that the furthest away active element is returned.
- */
-it('should prefer the furthest away droppable when multiple lists are hit', () => {
-  const offset = getOffsetForCrossAxisEndEdge({
-    crossAxisEndEdgeOn: droppableThird.page.borderBox.center,
-    dragging: draggable.page.borderBox,
-    axis: droppableThird.axis,
+describe('box (default) behaviour', () => {
+  /**
+   * In this case we're hovering over all three lists.
+   * We expect that the furthest away active element is returned.
+   */
+  it('should prefer the furthest away droppable when multiple lists are hit', () => {
+    const offset = getOffsetForCrossAxisEndEdge({
+      crossAxisEndEdgeOn: droppableThird.page.borderBox.center,
+      dragging: draggable.page.borderBox,
+      axis: droppableThird.axis,
+    });
+
+    const pageBorderBox: Rect = offsetRectByPosition(
+      draggable.page.borderBox,
+      afterCrossAxisPoint(droppableThird.axis, offset),
+    );
+
+    const result = getDroppableOver({
+      pageBorderBox,
+      draggable,
+      droppables: toDroppableMap([
+        droppableOrigin,
+        droppableFirst,
+        droppableSecond,
+        droppableThird,
+      ]),
+    });
+
+    expect(result).toEqual(droppableThird.descriptor.id);
   });
 
-  const pageBorderBox: Rect = offsetRectByPosition(
-    draggable.page.borderBox,
-    afterCrossAxisPoint(droppableThird.axis, offset),
-  );
+  /**
+   * In this case we're hovering over the primary and secondary and lists.
+   * We expect that the furthest away active element is returned (not including the tertiary list).
+   */
+  it('should prefer the second furthest away droppable when multiple lists are hit', () => {
+    const offset = getOffsetForCrossAxisEndEdge({
+      crossAxisEndEdgeOn: droppableSecond.page.borderBox.center,
+      dragging: draggable.page.borderBox,
+      axis: droppableSecond.axis,
+    });
 
-  const result = getDroppableOver({
-    pageBorderBox,
-    draggable,
-    droppables: toDroppableMap([
-      droppableOrigin,
-      droppableFirst,
-      droppableSecond,
-      droppableThird,
-    ]),
+    const pageBorderBox: Rect = offsetRectByPosition(
+      draggable.page.borderBox,
+      afterCrossAxisPoint(droppableSecond.axis, offset),
+    );
+
+    const result = getDroppableOver({
+      pageBorderBox,
+      draggable,
+      droppables: toDroppableMap([
+        droppableOrigin,
+        droppableFirst,
+        droppableSecond,
+        droppableThird,
+      ]),
+    });
+
+    expect(result).toEqual(droppableSecond.descriptor.id);
   });
-
-  expect(result).toEqual(droppableThird.descriptor.id);
 });
 
-/**
- * In this case we're hovering over the primary and secondary and lists.
- * We expect that the furthest away active element is returned (not including the tertiary list).
- */
-it('should prefer the second furthest away droppable when multiple lists are hit', () => {
-  const offset = getOffsetForCrossAxisEndEdge({
-    crossAxisEndEdgeOn: droppableSecond.page.borderBox.center,
-    dragging: draggable.page.borderBox,
-    axis: droppableSecond.axis,
+describe('pointer behaviour', () => {
+  /**
+   * In this case we're hovering over all three lists.
+   * We expect that the furthest away active element is returned.
+   */
+  it('should prefer the droppable closest to the pointer location when three lists are hit', () => {
+    const offset = getOffsetForCrossAxisEndEdge({
+      crossAxisEndEdgeOn: droppableThird.page.borderBox.center,
+      dragging: draggable.page.borderBox,
+      axis: droppableThird.axis,
+    });
+
+    const pageBorderBox: Rect = offsetRectByPosition(
+      draggable.page.borderBox,
+      afterCrossAxisPoint(droppableThird.axis, offset),
+    );
+
+    const result = getDroppableOver({
+      pageBorderBox,
+      draggable,
+      droppables: toDroppableMap([
+        droppableOrigin,
+        droppableFirst,
+        droppableSecond,
+        droppableThird,
+      ]),
+      calculateDroppableUsingCursorPosition: true,
+      currentSelection: {
+        x: droppableThird.page.borderBox.left,
+        y: droppableThird.page.borderBox.top,
+      }
+    });
+
+    expect(result).toEqual(droppableThird.descriptor.id);
   });
 
-  const pageBorderBox: Rect = offsetRectByPosition(
-    draggable.page.borderBox,
-    afterCrossAxisPoint(droppableSecond.axis, offset),
-  );
+  /**
+   * In this case we're hovering over the primary and secondary and lists.
+   * We expect that the furthest away active element is returned (not including the tertiary list).
+   */
+  it('should prefer the droppable closes to the cursor location when multiple lists are hit even if the pointer itself is not over the droppable', () => {
+    const offset = getOffsetForCrossAxisEndEdge({
+      crossAxisEndEdgeOn: droppableSecond.page.borderBox.center,
+      dragging: draggable.page.borderBox,
+      axis: droppableSecond.axis,
+    });
 
-  const result = getDroppableOver({
-    pageBorderBox,
-    draggable,
-    droppables: toDroppableMap([
-      droppableOrigin,
-      droppableFirst,
-      droppableSecond,
-      droppableThird,
-    ]),
+    const pageBorderBox: Rect = offsetRectByPosition(
+      draggable.page.borderBox,
+      afterCrossAxisPoint(droppableSecond.axis, offset),
+    );
+
+    const result = getDroppableOver({
+      pageBorderBox,
+      draggable,
+      droppables: toDroppableMap([
+        droppableOrigin,
+        droppableFirst,
+        droppableSecond,
+        droppableThird,
+      ]),
+      calculateDroppableUsingCursorPosition: true,
+      currentSelection: {
+        x: droppableThird.page.borderBox.left,
+        y: droppableThird.page.borderBox.top,
+      }
+    });
+
+    expect(result).toEqual(droppableSecond.descriptor.id);
   });
-
-  expect(result).toEqual(droppableSecond.descriptor.id);
 });


### PR DESCRIPTION
Fixes 1734

When the droppable target is quite small in comparison to the draggable the library currently provides (in our experience) a pretty poor UX for calculating the current droppable target. This PR maybe be slightly outside the intended purpose of this library but the intention here is to use an alternative method for calculating the droppable target. 

The behaviour of finding a candidate droppable is still the same i.e. is there some overlap of the two border boxes of the draggable and droppable but instead of calculating the droppable target using a "furthest from draggable start location" it uses a "closest to pointer position" methodology. I have attempted to ensure that, as with the current implementation the targeting method does not overly favour large (or small) lists too much. I think it provides a pretty sound implementation but am definitely open to any input as I have only skimmed over the parts of the library that I needed to change and am not at all familiar with the rest of the library.

The behaviour for using the different calculation is defined on a Draggable via the use of a new prop. `dropTargetCalculationMode="box | pointer"` the default value is "box" which reflects the current behaviour and so the new behaviour is opt-in.