### PR TITLE
Adding axis lock

### DIFF
--- a/src/animation.js
+++ b/src/animation.js
@@ -53,8 +53,22 @@ export const transitions = {
   placeholder: `height ${outOfTheWayTiming}, width ${outOfTheWayTiming}, margin ${outOfTheWayTiming}`,
 };
 
-const moveTo = (offset: Position): ?string =>
-  isEqual(offset, origin) ? null : `translate(${offset.x}px, ${offset.y}px)`;
+const clamp = (value:number, min:number, max:number) =>
+  value > max ? max : value < min ? min : value;
+
+const moveTo = (offset: Position, lockedAxis?:DraggableLockedAxis): ?string => {
+  if(isEqual(offset, origin)) return null;
+  else if(!lockedAxis) return `translate(${offset.x}px, ${offset.y}px)`;
+  else if(!lockedAxis.allowedDeviation || lockedAxis.allowedDeviation === 0) {
+    //Locked rigidly to an axis
+    if(lockedAxis.axis === 'x') return `translate(0px, ${offset.y}px)`;
+    else return `translate(${offset.x}px, 0px)`;
+  } else {
+    //Locked loosely to an axis
+    if(lockedAxis.axis === 'x') return `translate(${clamp(offset.x, -lockedAxis.allowedDeviation, lockedAxis.allowedDeviation)}px, ${offset.y}px)`;
+    else return `translate(${offset.x}px, ${clamp(offset.y, -lockedAxis.allowedDeviation, lockedAxis.allowedDeviation)}px)`;
+  }
+}
 
 export const transforms = {
   moveTo,

--- a/src/types.js
+++ b/src/types.js
@@ -158,6 +158,11 @@ export type DraggableIdMap = {
   [id: DraggableId]: true,
 };
 
+export type DraggableLockedAxis = {
+  axis: `x` | `y`,
+  allowedDeviation?:number,
+}
+
 export type DroppableIdMap = {
   [id: DroppableId]: true,
 };

--- a/src/view/draggable/draggable-types.js
+++ b/src/view/draggable/draggable-types.js
@@ -167,6 +167,8 @@ export type PublicOwnProps = {|
   isDragDisabled?: boolean,
   disableInteractiveElementBlocking?: boolean,
   shouldRespectForcePress?: boolean,
+  lockedAxis?:'x'|'y',
+  allowedDeviation?:number,
 |};
 
 export type PrivateOwnProps = {|

--- a/src/view/draggable/draggable.jsx
+++ b/src/view/draggable/draggable.jsx
@@ -137,7 +137,12 @@ export default function Draggable(props: Props) {
   );
 
   const provided: Provided = useMemo(() => {
-    const style: DraggableStyle = getStyle(mapped);
+    const style: DraggableStyle =
+      getStyle(
+        mapped,
+        props.lockedAxis ? {axis:props.lockedAxis, allowedDeviation:props.allowedDeviation}
+          : null
+      );
     const onTransitionEnd =
       mapped.type === 'DRAGGING' && mapped.dropping ? onMoveEnd : null;
 

--- a/src/view/draggable/get-style.js
+++ b/src/view/draggable/get-style.js
@@ -102,8 +102,8 @@ function getSecondaryStyle(secondary: SecondaryMapProps): NotDraggingStyle {
   };
 }
 
-export default function getStyle(mapped: MappedProps): DraggableStyle {
+export default function getStyle(mapped: MappedProps, lockedAxis?:DraggableLockedAxis): DraggableStyle {
   return mapped.type === 'DRAGGING'
-    ? getDraggingStyle(mapped)
-    : getSecondaryStyle(mapped);
+    ? getDraggingStyle(mapped, lockedAxis)
+    : getSecondaryStyle(mapped, lockedAxis);
 }


### PR DESCRIPTION
Fixes #538

`lockedAxis` and `allowedDeviation` properties on `<Draggable />` restricting dragging to one axis but permitting some movement in the blocked axis.

The main counter point was that this library is meant to feel physical so outright blocking movement in one axis feels like you are interacting with software as not many physical things are "on rails". However sometimes you do just need to lock movement to one axis but given some allowed deviation along the blocked axis (for instance 40px deviation allows -40px to +40px along the blocked axis).

There is a slight problem that I've seen on previous external solutions where keyboard controls are forgotten about, locked axis shouldn't be used as an alternative to `type`.