### PR TITLE
Fix style reflow

### DIFF
--- a/src/view/use-style-marshal/get-styles.js
+++ b/src/view/use-style-marshal/get-styles.js
@@ -107,7 +107,13 @@ export default (contextId: ContextId): Styles => {
     return {
       selector: getSelector(attributes.draggable.contextId),
       styles: {
-        dragging: transition,
+        dragging: `
+          ${transition}
+          user-select: none;
+          -webkit-user-select: none;
+          -moz-user-select: none;
+          -ms-user-select: none;
+        `,
         dropAnimating: transition,
         userCancel: transition,
       },
@@ -149,10 +155,6 @@ export default (contextId: ContextId): Styles => {
       dragging: `
         cursor: grabbing;
         cursor: -webkit-grabbing;
-        user-select: none;
-        -webkit-user-select: none;
-        -moz-user-select: none;
-        -ms-user-select: none;
         overflow-anchor: none;
       `,
     },


### PR DESCRIPTION
Changing `user-select` on the `body` element forces a style reflow for all elements in the body, this fixes that by only applying the `user-select: none` to the draggable element, this has the same intended effect.

You can see here in the MDN docs for `user-select` that clicking on an element with `user-select: none` and trying to highlight any other text by dragging around does not highlight any other text.

https://developer.mozilla.org/en-US/docs/Web/CSS/user-select#result


Fixes: #1850