### PR TITLE
Update drop-animation.md

### DIFF
--- a/docs/guides/drop-animation.md
+++ b/docs/guides/drop-animation.md
@@ -90,6 +90,8 @@ function getStyle(style, snapshot) {
     ...style,
     // cannot be 0, but make it super tiny
     transitionDuration: `0.001s`,
+    // some browsers may still show the element for a frame
+    opacity: 0,
   };
 }
 


### PR DESCRIPTION
Even with a very low transition-duration value, the dropped element still flashes for a frame on some browsers (e.g. Firefox).
Hiding it visually fixes this.