### PR TITLE
Remove pure: true, for react-redux 8 compatibility

### DIFF
--- a/src/view/draggable/connected-draggable.js
+++ b/src/view/draggable/connected-draggable.js
@@ -360,8 +360,6 @@ const ConnectedDraggable = connect(
   {
     // Using our own context for the store to avoid clashing with consumers
     context: StoreContext,
-    // Default value, but being really clear
-    pure: true,
     // When pure, compares the result of mapStateToProps to its previous value.
     // Default value: shallowEqual
     // Switching to a strictEqual as we return a memoized object on changes

--- a/src/view/droppable/connected-droppable.js
+++ b/src/view/droppable/connected-droppable.js
@@ -266,8 +266,6 @@ const ConnectedDroppable: typeof DroppableType = connect(
   {
     // Ensuring our context does not clash with consumers
     context: StoreContext,
-    // pure: true is default value, but being really clear
-    pure: true,
     // When pure, compares the result of mapStateToProps to its previous value.
     // Default value: shallowEqual
     // Switching to a strictEqual as we return a memoized object on changes


### PR DESCRIPTION
When using react-redux 8.0.0-alpha.1 with rbd, you get the following error:

`'The 'pure' option has been removed. 'connect' is now always a "pure/memoized" component'`

Given that `pure: true` was the default before, removing this option ensures that rbd works with react-redux 7 & 8.