### PR TITLE
Adds React 18.1+ to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,8 +145,8 @@
     "webpack": "4.42.1"
   },
   "peerDependencies": {
-    "react": "^16.8.5 || ^17.0.0",
-    "react-dom": "^16.8.5 || ^17.0.0"
+    "react": "^16.8.5 || ^17.0.0 || ^18.1.0",
+    "react-dom": "^16.8.5 || ^17.0.0 || ^18.1.0"
   },
   "license": "Apache-2.0",
   "jest-junit": {


### PR DESCRIPTION
Necessary to use the lib with React 18 through npm 7+ without --legacy-peer-deps