### PR TITLE
slight change on "Simple DnD between two lists"

### DIFF
--- a/docs/about/examples.md
+++ b/docs/about/examples.md
@@ -20,7 +20,7 @@ We have created some basic examples on `codesandbox` for you to play with direct
 - [Simple vertical list](https://codesandbox.io/s/k260nyxq9v)
 - [Simple horizontal list](https://codesandbox.io/s/mmrp44okvj)
 - [Using with function components](https://codesandbox.io/s/zqwz5n5p9x)
-- [Simple DnD between two lists](https://codesandbox.io/s/ql08j35j3q) - _Community made_
+- [Simple DnD between two lists](https://codesandbox.io/s/893fji) - _Community made_
 - [Simple DnD between a dynamic number of lists (with function components) and ability to delete items](https://codesandbox.io/s/-w5szl) - _Community made_
 
 [← Back to documentation](/README.md#documentation-)


### PR DESCRIPTION
the original one has errors

```
ModuleNotFoundError
Could not find module in path: '@babel/runtime/7.0.0-beta.52/helpers/esm/inheritsLoose' relative to '/node_modules/react-redux/es/components/Provider.js'
```

I only changed the versions in package.json to the one that doesn't have errors