### PR TITLE
Supporting use in shadow roots

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,18 +1,18 @@
 {
   "dist/react-beautiful-dnd.js": {
-    "bundled": 364998,
-    "minified": 133574,
-    "gzipped": 39437
+    "bundled": 366336,
+    "minified": 133967,
+    "gzipped": 39652
   },
   "dist/react-beautiful-dnd.min.js": {
-    "bundled": 306810,
-    "minified": 108365,
-    "gzipped": 31340
+    "bundled": 308197,
+    "minified": 108795,
+    "gzipped": 31547
   },
   "dist/react-beautiful-dnd.esm.js": {
-    "bundled": 240910,
-    "minified": 125371,
-    "gzipped": 32650,
+    "bundled": 242065,
+    "minified": 125885,
+    "gzipped": 32813,
     "treeshaked": {
       "rollup": {
         "code": 21121,

--- a/docs/api/drag-drop-context.md
+++ b/docs/api/drag-drop-context.md
@@ -35,6 +35,7 @@ type Props = {|
 - `nonce`: Used for strict content security policy setups. See our [content security policy guide](/docs/guides/content-security-policy.md)
 - `sensors`: Used to pass in your own `sensor`s for a `<DragDropContext />`. See our [sensor api documentation](/docs/sensors/sensor-api.md)
 - `enableDefaultSensors`: Whether or not the default sensors ([mouse](/docs/sensors/mouse.md), [keyboard](/docs/sensors/keyboard.md), and [touch](/docs/sensors/touch.md)) are enabled. You can also import them separately as `useMouseSensor`, `useKeyboardSensor`, or `useTouchSensor` and reuse just some of them via `sensors` prop. See our [sensor api documentation](/docs/sensors/sensor-api.md)
+- `stylesInsertionPoint`: Specify the DOM node where to append styles. This is useful when used inside shadowRoots like web components. If not specified it will use document's head.
 
 > See our [type guide](/docs/guides/types.md) for more details
 

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "raf-stub": "3.0.0",
     "react": "16.13.1",
     "react-dom": "16.13.1",
+    "react-shadow-dom-retarget-events": "1.1.0",
     "react-test-renderer": "16.13.1",
     "react-virtualized": "9.21.2",
     "react-window": "1.8.6",

--- a/src/native-with-fallback.js
+++ b/src/native-with-fallback.js
@@ -28,7 +28,7 @@ export function values<T>(map: Map<T>): T[] {
 }
 
 // Could also extend to pass index and list
-type PredicateFn<T> = (value: T) => boolean;
+export type PredicateFn<T> = (value: T) => boolean;
 
 // TODO: swap order
 export function findIndex<T>(

--- a/src/view/drag-drop-context/app.jsx
+++ b/src/view/drag-drop-context/app.jsx
@@ -63,6 +63,7 @@ export type Props = {|
 
   // screen reader
   dragHandleUsageInstructions: string,
+  stylesInsertionPoint?: ?HTMLElement,
 |};
 
 const createResponders = (props: Props): Responders => ({
@@ -107,7 +108,11 @@ export default function App(props: Props) {
     contextId,
     text: dragHandleUsageInstructions,
   });
-  const styleMarshal: StyleMarshal = useStyleMarshal(contextId, nonce);
+  const styleMarshal: StyleMarshal = useStyleMarshal(
+    contextId,
+    nonce,
+    props.stylesInsertionPoint,
+  );
 
   const lazyDispatch: (Action) => void = useCallback((action: Action): void => {
     getStore(lazyStoreRef).dispatch(action);

--- a/src/view/drag-drop-context/drag-drop-context.jsx
+++ b/src/view/drag-drop-context/drag-drop-context.jsx
@@ -21,6 +21,8 @@ type Props = {|
   // See our [sensor api](/docs/sensors/sensor-api.md)
   sensors?: Sensor[],
   enableDefaultSensors?: ?boolean,
+  // Allows customizing the element to add the stylesheets to e.g. when being used in a ShadowRoot
+  stylesInsertionPoint?: ?HTMLElement,
 |};
 
 // Reset any context that gets persisted across server side renders
@@ -51,6 +53,7 @@ export default function DragDropContext(props: Props) {
           onDragStart={props.onDragStart}
           onDragUpdate={props.onDragUpdate}
           onDragEnd={props.onDragEnd}
+          stylesInsertionPoint={props.stylesInsertionPoint}
         >
           {props.children}
         </App>

--- a/src/view/draggable/get-style.js
+++ b/src/view/draggable/get-style.js
@@ -97,7 +97,7 @@ function getDraggingStyle(dragging: DraggingMapProps): DraggingStyle {
 function getSecondaryStyle(secondary: SecondaryMapProps): NotDraggingStyle {
   return {
     transform: transforms.moveTo(secondary.offset),
-    // transition style is applied in the head
+    // transition style is applied in the head or stylesInsertionPoint
     transition: secondary.shouldAnimateDisplacement ? null : 'none',
   };
 }

--- a/src/view/draggable/use-validation.js
+++ b/src/view/draggable/use-validation.js
@@ -46,7 +46,7 @@ export function useValidation(
     // When not enabled there is no drag handle props
     if (props.isEnabled) {
       invariant(
-        findDragHandle(contextId, id),
+        findDragHandle(contextId, id, getRef()),
         `${prefix(id)} Unable to find drag handle`,
       );
     }

--- a/src/view/get-elements/find-drag-handle.js
+++ b/src/view/get-elements/find-drag-handle.js
@@ -1,26 +1,24 @@
 // @flow
+import { queryElements } from './query-elements';
 import type { DraggableId, ContextId } from '../../types';
 import { dragHandle as dragHandleAttr } from '../data-attributes';
 import { warning } from '../../dev-warning';
-import { find, toArray } from '../../native-with-fallback';
 import isHtmlElement from '../is-type-of-element/is-html-element';
 
 export default function findDragHandle(
   contextId: ContextId,
   draggableId: DraggableId,
+  ref: ?HTMLElement,
 ): ?HTMLElement {
   // cannot create a selector with the draggable id as it might not be a valid attribute selector
   const selector: string = `[${dragHandleAttr.contextId}="${contextId}"]`;
-  const possible: Element[] = toArray(document.querySelectorAll(selector));
-
-  if (!possible.length) {
-    warning(`Unable to find any drag handles in the context "${contextId}"`);
-    return null;
-  }
-
-  const handle: ?Element = find(possible, (el: Element): boolean => {
-    return el.getAttribute(dragHandleAttr.draggableId) === draggableId;
-  });
+  const handle: ?Element = queryElements(
+    ref,
+    selector,
+    (el: Element): boolean => {
+      return el.getAttribute(dragHandleAttr.draggableId) === draggableId;
+    },
+  );
 
   if (!handle) {
     warning(

--- a/src/view/get-elements/find-draggable.js
+++ b/src/view/get-elements/find-draggable.js
@@ -1,21 +1,24 @@
 // @flow
+import { queryElements } from './query-elements';
 import type { DraggableId, ContextId } from '../../types';
 import * as attributes from '../data-attributes';
-import { find, toArray } from '../../native-with-fallback';
 import { warning } from '../../dev-warning';
 import isHtmlElement from '../is-type-of-element/is-html-element';
 
 export default function findDraggable(
   contextId: ContextId,
   draggableId: DraggableId,
+  ref: ?Node,
 ): ?HTMLElement {
   // cannot create a selector with the draggable id as it might not be a valid attribute selector
   const selector: string = `[${attributes.draggable.contextId}="${contextId}"]`;
-  const possible: Element[] = toArray(document.querySelectorAll(selector));
-
-  const draggable: ?Element = find(possible, (el: Element): boolean => {
-    return el.getAttribute(attributes.draggable.id) === draggableId;
-  });
+  const draggable: ?Element = queryElements(
+    ref,
+    selector,
+    (el: Element): boolean => {
+      return el.getAttribute(attributes.draggable.id) === draggableId;
+    },
+  );
 
   if (!draggable) {
     return null;

--- a/src/view/get-elements/query-elements.js
+++ b/src/view/get-elements/query-elements.js
@@ -1,0 +1,42 @@
+// @flow
+import { find, toArray } from '../../native-with-fallback';
+import type { PredicateFn } from '../../native-with-fallback';
+
+// declaring composedPath manually, seems it is not defined on Event yet
+type EventWithComposedPath = Event & {
+  composedPath?: () => HTMLElement[],
+};
+
+export function getEventTarget(event: EventWithComposedPath): ?EventTarget {
+  const target = event.composedPath && event.composedPath()[0];
+  return target || event.target;
+}
+
+export function getEventTargetRoot(event: ?EventWithComposedPath): Node {
+  const source = event && event.composedPath && event.composedPath()[0];
+  const root = source && source.getRootNode();
+  return root || document;
+}
+
+export function queryElements(
+  ref: ?Node,
+  selector: string,
+  filterFn: PredicateFn<Element>,
+): ?Element {
+  const rootNode: any = ref && ref.getRootNode();
+  const documentOrShadowRoot: ShadowRoot | Document =
+    rootNode && rootNode.querySelectorAll ? rootNode : document;
+  const possible = toArray(documentOrShadowRoot.querySelectorAll(selector));
+  const filtered = find(possible, filterFn);
+
+  // in case nothing was found in this document/shadowRoot we recursievly try the parent document(Fragment) given
+  // by the host property. This is needed in case the the draggable/droppable itself contains a shadow root
+  if (!filtered && documentOrShadowRoot.host) {
+    return queryElements(
+      ((documentOrShadowRoot: any).host: ShadowRoot),
+      selector,
+      filterFn,
+    );
+  }
+  return filtered;
+}

--- a/src/view/use-sensor-marshal/closest.js
+++ b/src/view/use-sensor-marshal/closest.js
@@ -40,11 +40,25 @@ function closestPonyfill(el: ?Element, selector: string) {
   return closestPonyfill(el.parentElement, selector);
 }
 
-export default function closest(el: Element, selector: string): ?Element {
+function closestImpl(el: Element, selector: string): ?Element {
   // Using native closest for maximum speed where we can
   if (el.closest) {
     return el.closest(selector);
   }
   // ie11: damn you!
   return closestPonyfill(el, selector);
+}
+
+export default function closest(el: ?Element, selector: string): ?Element {
+  if (!el || el === document || el === window) {
+    return null;
+  }
+  const found = closestImpl(el, selector);
+
+  if (found) {
+    return found;
+  }
+
+  const root: ShadowRoot = (el.getRootNode(): any);
+  return closest(root.host, selector);
 }

--- a/src/view/use-sensor-marshal/find-closest-draggable-id-from-event.js
+++ b/src/view/use-sensor-marshal/find-closest-draggable-id-from-event.js
@@ -4,6 +4,7 @@ import * as attributes from '../data-attributes';
 import isElement from '../is-type-of-element/is-element';
 import isHtmlElement from '../is-type-of-element/is-html-element';
 import closest from './closest';
+import { getEventTarget } from '../get-elements/query-elements';
 import { warning } from '../../dev-warning';
 
 function getSelector(contextId: ContextId): string {
@@ -14,7 +15,7 @@ function findClosestDragHandleFromEvent(
   contextId: ContextId,
   event: Event,
 ): ?HTMLElement {
-  const target: ?EventTarget = event.target;
+  const target: ?EventTarget = getEventTarget(event);
 
   if (!isElement(target)) {
     warning('event.target must be a Element');

--- a/src/view/use-sensor-marshal/is-event-in-interactive-element.js
+++ b/src/view/use-sensor-marshal/is-event-in-interactive-element.js
@@ -1,5 +1,6 @@
 // @flow
 import isHtmlElement from '../is-type-of-element/is-html-element';
+import { getEventTarget } from '../get-elements/query-elements';
 
 export type TagNameMap = {
   [tagName: string]: true,
@@ -56,7 +57,7 @@ export default function isEventInInteractiveElement(
   draggable: Element,
   event: Event,
 ): boolean {
-  const target: EventTarget = event.target;
+  const target: ?EventTarget = getEventTarget(event);
 
   if (!isHtmlElement(target)) {
     return false;

--- a/src/view/use-sensor-marshal/use-sensor-marshal.js
+++ b/src/view/use-sensor-marshal/use-sensor-marshal.js
@@ -48,6 +48,7 @@ import { noop } from '../../empty';
 import findClosestDraggableIdFromEvent from './find-closest-draggable-id-from-event';
 import findDraggable from '../get-elements/find-draggable';
 import bindEvents from '../event-bindings/bind-events';
+import { getEventTargetRoot } from '../get-elements/query-elements';
 
 function preventDefault(event: Event) {
   event.preventDefault();
@@ -172,7 +173,11 @@ function tryStart({
   }
 
   const entry: DraggableEntry = registry.draggable.getById(draggableId);
-  const el: ?HTMLElement = findDraggable(contextId, entry.descriptor.id);
+  const el: ?HTMLElement = findDraggable(
+    contextId,
+    entry.descriptor.id,
+    getEventTargetRoot(sourceEvent),
+  );
 
   if (!el) {
     warning(`Unable to find draggable element with id: ${draggableId}`);

--- a/src/view/use-style-marshal/get-styles.js
+++ b/src/view/use-style-marshal/get-styles.js
@@ -144,7 +144,7 @@ export default (contextId: ContextId): Styles => {
   // we do not want the browser to have behaviors we do not expect
 
   const body: Rule = {
-    selector: 'body',
+    selector: 'body, :host',
     styles: {
       dragging: `
         cursor: grabbing;

--- a/src/view/use-style-marshal/use-style-marshal.js
+++ b/src/view/use-style-marshal/use-style-marshal.js
@@ -9,10 +9,11 @@ import getStyles, { type Styles } from './get-styles';
 import { prefix } from '../data-attributes';
 import useLayoutEffect from '../use-isomorphic-layout-effect';
 
-const getHead = (): HTMLHeadElement => {
-  const head: ?HTMLHeadElement = document.querySelector('head');
-  invariant(head, 'Cannot find the head to append a style to');
-  return head;
+const getStylesRoot = (stylesInsertionPoint: ?HTMLElement): HTMLElement => {
+  const stylesRoot: ?HTMLElement =
+    stylesInsertionPoint || document.querySelector('head');
+  invariant(stylesRoot, 'Cannot find the head or root to append a style to');
+  return stylesRoot;
 };
 
 const createStyleEl = (nonce?: string): HTMLStyleElement => {
@@ -24,7 +25,11 @@ const createStyleEl = (nonce?: string): HTMLStyleElement => {
   return el;
 };
 
-export default function useStyleMarshal(contextId: ContextId, nonce?: string) {
+export default function useStyleMarshal(
+  contextId: ContextId,
+  nonce?: string,
+  stylesInsertionPoint?: ?HTMLElement,
+) {
   const styles: Styles = useMemo(() => getStyles(contextId), [contextId]);
   const alwaysRef = useRef<?HTMLStyleElement>(null);
   const dynamicRef = useRef<?HTMLStyleElement>(null);
@@ -63,9 +68,10 @@ export default function useStyleMarshal(contextId: ContextId, nonce?: string) {
     always.setAttribute(`${prefix}-always`, contextId);
     dynamic.setAttribute(`${prefix}-dynamic`, contextId);
 
-    // add style tags to head
-    getHead().appendChild(always);
-    getHead().appendChild(dynamic);
+    // add style tags to styles root
+    const stylesRoot = getStylesRoot(stylesInsertionPoint);
+    stylesRoot.appendChild(always);
+    stylesRoot.appendChild(dynamic);
 
     // set initial style
     setAlwaysStyle(styles.always);
@@ -75,7 +81,7 @@ export default function useStyleMarshal(contextId: ContextId, nonce?: string) {
       const remove = (ref) => {
         const current: ?HTMLStyleElement = ref.current;
         invariant(current, 'Cannot unmount ref as it is not set');
-        getHead().removeChild(current);
+        stylesRoot.removeChild(current);
         ref.current = null;
       };
 
@@ -89,6 +95,7 @@ export default function useStyleMarshal(contextId: ContextId, nonce?: string) {
     styles.always,
     styles.resting,
     contextId,
+    stylesInsertionPoint,
   ]);
 
   const dragging = useCallback(() => setDynamicStyle(styles.dragging), [

--- a/stories/60-shadow-roots.stories.js
+++ b/stories/60-shadow-roots.stories.js
@@ -1,0 +1,34 @@
+// @flow
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import Simple from './src/simple/simple';
+import SimpleWithScroll from './src/simple/simple-scrollable';
+import WithMixedSpacing from './src/simple/simple-mixed-spacing';
+import {
+  inShadowRoot,
+  inNestedShadowRoot,
+} from './src/shadow-root/inside-shadow-root';
+import SimpleWithShadowRoot from './src/shadow-root/simple-with-shadow-root';
+import InteractiveElementsApp from './src/interactive-elements/interactive-elements-app';
+
+storiesOf('Shadow Root', module)
+  .add('Super Simple - vertical list', () => inShadowRoot(<Simple />))
+  .add('Super Simple - vertical list (nested shadow root)', () =>
+    inNestedShadowRoot(<Simple />),
+  )
+  .add('Super Simple - vertical list with scroll (overflow: auto)', () =>
+    inShadowRoot(<SimpleWithScroll overflow="auto" />),
+  )
+  .add('Super Simple - vertical list with scroll (overflow: scroll)', () =>
+    inShadowRoot(<SimpleWithScroll overflow="scroll" />),
+  )
+  .add('Super Simple - with mixed spacing', () =>
+    inShadowRoot(<WithMixedSpacing />),
+  )
+  .add('nested interactive elements - stress test (without styles)', () =>
+    inShadowRoot(<InteractiveElementsApp />),
+  )
+  .add(
+    'Super Simple - vertical list (with draggables containing shadowRoots)',
+    () => <SimpleWithShadowRoot />,
+  );

--- a/stories/src/interactive-elements/interactive-elements-app.jsx
+++ b/stories/src/interactive-elements/interactive-elements-app.jsx
@@ -10,6 +10,7 @@ import type {
   DroppableProvided,
   DraggableProvided,
 } from '../../../src';
+import { ShadowRootContext } from '../shadow-root/inside-shadow-root';
 
 type ItemType = {|
   id: string,
@@ -202,51 +203,58 @@ export default class InteractiveElementsApp extends React.Component<*, State> {
     const { canDragInteractiveElements } = this.state;
 
     return (
-      <DragDropContext onDragEnd={this.onDragEnd}>
-        <Container>
-          <Droppable droppableId="droppable">
-            {(droppableProvided: DroppableProvided) => (
-              <List
-                ref={droppableProvided.innerRef}
-                {...droppableProvided.droppableProps}
-              >
-                {this.state.items.map((item: ItemType, index: number) => (
-                  <Draggable
-                    key={item.id}
-                    draggableId={item.id}
-                    disableInteractiveElementBlocking={
-                      canDragInteractiveElements
-                    }
-                    index={index}
+      <ShadowRootContext.Consumer>
+        {(stylesRoot) => (
+          <DragDropContext
+            onDragEnd={this.onDragEnd}
+            stylesInsertionPoint={stylesRoot}
+          >
+            <Container>
+              <Droppable droppableId="droppable">
+                {(droppableProvided: DroppableProvided) => (
+                  <List
+                    ref={droppableProvided.innerRef}
+                    {...droppableProvided.droppableProps}
                   >
-                    {(draggableProvided: DraggableProvided) => (
-                      <Item
-                        ref={draggableProvided.innerRef}
-                        {...draggableProvided.draggableProps}
-                        {...draggableProvided.dragHandleProps}
+                    {this.state.items.map((item: ItemType, index: number) => (
+                      <Draggable
+                        key={item.id}
+                        draggableId={item.id}
+                        disableInteractiveElementBlocking={
+                          canDragInteractiveElements
+                        }
+                        index={index}
                       >
-                        {item.component}
-                      </Item>
-                    )}
-                  </Draggable>
-                ))}
-                {droppableProvided.placeholder}
-              </List>
-            )}
-          </Droppable>
-          <Controls>
-            <p>
-              Dragging from interactive elements is{' '}
-              <Status isEnabled={canDragInteractiveElements}>
-                {canDragInteractiveElements ? 'enabled' : 'disabled'}
-              </Status>
-            </p>
-            <button type="button" onClick={this.toggleBlocking}>
-              toggle
-            </button>
-          </Controls>
-        </Container>
-      </DragDropContext>
+                        {(draggableProvided: DraggableProvided) => (
+                          <Item
+                            ref={draggableProvided.innerRef}
+                            {...draggableProvided.draggableProps}
+                            {...draggableProvided.dragHandleProps}
+                          >
+                            {item.component}
+                          </Item>
+                        )}
+                      </Draggable>
+                    ))}
+                    {droppableProvided.placeholder}
+                  </List>
+                )}
+              </Droppable>
+              <Controls>
+                <p>
+                  Dragging from interactive elements is{' '}
+                  <Status isEnabled={canDragInteractiveElements}>
+                    {canDragInteractiveElements ? 'enabled' : 'disabled'}
+                  </Status>
+                </p>
+                <button type="button" onClick={this.toggleBlocking}>
+                  toggle
+                </button>
+              </Controls>
+            </Container>
+          </DragDropContext>
+        )}
+      </ShadowRootContext.Consumer>
     );
   }
 }

--- a/stories/src/shadow-root/inside-shadow-root.jsx
+++ b/stories/src/shadow-root/inside-shadow-root.jsx
@@ -1,0 +1,98 @@
+// @flow
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import retargetEvents from 'react-shadow-dom-retarget-events';
+
+export const ShadowRootContext = React.createContext<?HTMLElement>(null);
+
+class MyCustomElement extends HTMLElement {
+  content: React.Node;
+  root: ShadowRoot;
+  appContainer: HTMLElement;
+
+  mountComponent() {
+    if (!this.appContainer) {
+      this.root = this.attachShadow({ mode: 'open' });
+      this.appContainer = document.createElement('div');
+      this.root.appendChild(this.appContainer);
+    }
+
+    if (this.content) {
+      ReactDOM.render(
+        <ShadowRootContext.Provider value={this.appContainer}>
+          {this.content}
+        </ShadowRootContext.Provider>,
+        this.appContainer,
+      );
+
+      // needed for React versions before 17
+      retargetEvents(this.root);
+    }
+  }
+
+  unmountComponent() {
+    if (this.appContainer) {
+      ReactDOM.unmountComponentAtNode(this.appContainer);
+    }
+  }
+
+  setContent(content: React.Node) {
+    this.content = content;
+    this.updateComponent();
+  }
+
+  updateComponent() {
+    this.unmountComponent();
+    this.mountComponent();
+  }
+
+  connectedCallback() {
+    this.mountComponent();
+  }
+
+  disconnectedCallback() {
+    this.unmountComponent();
+  }
+}
+
+customElements.define('my-custom-element', MyCustomElement);
+
+class CompoundCustomElement extends HTMLElement {
+  childComponent: MyCustomElement;
+  root: ShadowRoot;
+
+  constructor() {
+    super();
+    this.root = this.attachShadow({ mode: 'open' });
+    this.childComponent = (document.createElement('my-custom-element'): any);
+    this.root.appendChild(this.childComponent);
+  }
+}
+
+customElements.define('compound-custom-element', CompoundCustomElement);
+
+export function inShadowRoot(child: React.Node) {
+  return (
+    <my-custom-element
+      // $FlowFixMe - flow can neither infer nor cast the type of the custom element
+      ref={(node: ?MyCustomElement) => {
+        if (node) {
+          node.setContent(child);
+        }
+      }}
+    />
+  );
+}
+
+export function inNestedShadowRoot(child: React.Node) {
+  return (
+    <compound-custom-element
+      // $FlowFixMe - flow can neither infer nor cast the type of the custom element
+      ref={(node: ?CompoundCustomElement) => {
+        if (node) {
+          node.childComponent.setContent(child);
+        }
+      }}
+    />
+  );
+}

--- a/stories/src/shadow-root/simple-with-shadow-root.jsx
+++ b/stories/src/shadow-root/simple-with-shadow-root.jsx
@@ -1,10 +1,9 @@
 // disabling flowtype to keep this example super simple
-// It matches
 /* eslint-disable flowtype/require-valid-file-annotation */
 
 import React, { Component } from 'react';
 import { DragDropContext, Droppable, Draggable } from '../../../src';
-import { ShadowRootContext } from '../shadow-root/inside-shadow-root';
+import { ShadowRootContext } from './inside-shadow-root';
 
 // fake data generator
 const getItems = (count) =>
@@ -25,6 +24,8 @@ const reorder = (list, startIndex, endIndex) => {
 const grid = 8;
 
 const getItemStyle = (isDragging, draggableStyle) => ({
+  display: 'block',
+
   // some basic styles to make the items look a bit nicer
   userSelect: 'none',
   padding: grid * 2,
@@ -42,6 +43,23 @@ const getListStyle = (isDraggingOver) => ({
   padding: grid,
   width: 250,
 });
+
+class SomeCustomElement extends HTMLElement {
+  childComponent;
+
+  constructor() {
+    super();
+    const root = this.attachShadow({ mode: 'open' });
+    this.childComponent = document.createElement('div');
+    root.appendChild(this.childComponent);
+  }
+
+  connectedCallback() {
+    this.childComponent.textContent = this.getAttribute('content');
+  }
+}
+
+customElements.define('some-custom-element', SomeCustomElement);
 
 export default class App extends Component {
   constructor(props, context) {
@@ -93,17 +111,17 @@ export default class App extends Component {
                       index={index}
                     >
                       {(draggableProvided, draggableSnapshot) => (
-                        <div
+                        <some-custom-element
                           ref={draggableProvided.innerRef}
                           {...draggableProvided.draggableProps}
                           {...draggableProvided.dragHandleProps}
                           style={getItemStyle(
                             draggableSnapshot.isDragging,
                             draggableProvided.draggableProps.style,
+                            false,
                           )}
-                        >
-                          {item.content}
-                        </div>
+                          content={item.content}
+                        />
                       )}
                     </Draggable>
                   ))}

--- a/stories/src/simple/simple-mixed-spacing.jsx
+++ b/stories/src/simple/simple-mixed-spacing.jsx
@@ -4,6 +4,7 @@
 
 import React, { Component } from 'react';
 import { DragDropContext, Droppable, Draggable } from '../../../src';
+import { ShadowRootContext } from '../shadow-root/inside-shadow-root';
 
 // fake data generator
 const getItems = (count) =>
@@ -84,42 +85,53 @@ export default class App extends Component {
   // But in this example everything is just done in one place for simplicity
   render() {
     return (
-      <DragDropContext onDragEnd={this.onDragEnd}>
-        <Droppable droppableId="droppable">
-          {(droppableProvided) => (
-            <div
-              ref={droppableProvided.innerRef}
-              style={{
-                width: 250,
-                background: 'lightblue',
+      <ShadowRootContext.Consumer>
+        {(stylesRoot) => (
+          <DragDropContext
+            onDragEnd={this.onDragEnd}
+            stylesInsertionPoint={stylesRoot}
+          >
+            <Droppable droppableId="droppable">
+              {(droppableProvided) => (
+                <div
+                  ref={droppableProvided.innerRef}
+                  style={{
+                    width: 250,
+                    background: 'lightblue',
 
-                ...withAssortedSpacing(),
-                // no margin collapsing
-                marginTop: 0,
-              }}
-            >
-              {this.state.items.map((item, index) => (
-                <Draggable key={item.id} draggableId={item.id} index={index}>
-                  {(draggableProvided, draggableSnapshot) => (
-                    <div
-                      ref={draggableProvided.innerRef}
-                      {...draggableProvided.draggableProps}
-                      {...draggableProvided.dragHandleProps}
-                      style={getItemStyle(
-                        draggableSnapshot.isDragging,
-                        draggableProvided.draggableProps.style,
-                      )}
+                    ...withAssortedSpacing(),
+                    // no margin collapsing
+                    marginTop: 0,
+                  }}
+                >
+                  {this.state.items.map((item, index) => (
+                    <Draggable
+                      key={item.id}
+                      draggableId={item.id}
+                      index={index}
                     >
-                      {item.content}
-                    </div>
-                  )}
-                </Draggable>
-              ))}
-              {droppableProvided.placeholder}
-            </div>
-          )}
-        </Droppable>
-      </DragDropContext>
+                      {(draggableProvided, draggableSnapshot) => (
+                        <div
+                          ref={draggableProvided.innerRef}
+                          {...draggableProvided.draggableProps}
+                          {...draggableProvided.dragHandleProps}
+                          style={getItemStyle(
+                            draggableSnapshot.isDragging,
+                            draggableProvided.draggableProps.style,
+                          )}
+                        >
+                          {item.content}
+                        </div>
+                      )}
+                    </Draggable>
+                  ))}
+                  {droppableProvided.placeholder}
+                </div>
+              )}
+            </Droppable>
+          </DragDropContext>
+        )}
+      </ShadowRootContext.Consumer>
     );
   }
 }

--- a/stories/src/simple/simple-scrollable.jsx
+++ b/stories/src/simple/simple-scrollable.jsx
@@ -4,6 +4,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { DragDropContext, Droppable, Draggable } from '../../../src';
+import { ShadowRootContext } from '../shadow-root/inside-shadow-root';
 
 // fake data generator
 const getItems = (count) =>
@@ -84,42 +85,53 @@ export default class App extends Component {
   // But in this example everything is just done in one place for simplicity
   render() {
     return (
-      <DragDropContext onDragEnd={this.onDragEnd}>
-        <Droppable droppableId="droppable">
-          {(droppableProvided, droppableSnapshot) => (
-            <div
-              ref={droppableProvided.innerRef}
-              style={getListStyle(
-                droppableSnapshot.isDraggingOver,
-                this.props.overflow,
-              )}
-              onScroll={(e) =>
-                // eslint-disable-next-line no-console
-                console.log('current scrollTop', e.currentTarget.scrollTop)
-              }
-            >
-              {this.state.items.map((item, index) => (
-                <Draggable key={item.id} draggableId={item.id} index={index}>
-                  {(draggableProvided, draggableSnapshot) => (
-                    <div
-                      ref={draggableProvided.innerRef}
-                      {...draggableProvided.draggableProps}
-                      {...draggableProvided.dragHandleProps}
-                      style={getItemStyle(
-                        draggableSnapshot.isDragging,
-                        draggableProvided.draggableProps.style,
-                      )}
-                    >
-                      {item.content}
-                    </div>
+      <ShadowRootContext.Consumer>
+        {(stylesRoot) => (
+          <DragDropContext
+            onDragEnd={this.onDragEnd}
+            stylesInsertionPoint={stylesRoot}
+          >
+            <Droppable droppableId="droppable">
+              {(droppableProvided, droppableSnapshot) => (
+                <div
+                  ref={droppableProvided.innerRef}
+                  style={getListStyle(
+                    droppableSnapshot.isDraggingOver,
+                    this.props.overflow,
                   )}
-                </Draggable>
-              ))}
-              {droppableProvided.placeholder}
-            </div>
-          )}
-        </Droppable>
-      </DragDropContext>
+                  onScroll={(e) =>
+                    // eslint-disable-next-line no-console
+                    console.log('current scrollTop', e.currentTarget.scrollTop)
+                  }
+                >
+                  {this.state.items.map((item, index) => (
+                    <Draggable
+                      key={item.id}
+                      draggableId={item.id}
+                      index={index}
+                    >
+                      {(draggableProvided, draggableSnapshot) => (
+                        <div
+                          ref={draggableProvided.innerRef}
+                          {...draggableProvided.draggableProps}
+                          {...draggableProvided.dragHandleProps}
+                          style={getItemStyle(
+                            draggableSnapshot.isDragging,
+                            draggableProvided.draggableProps.style,
+                          )}
+                        >
+                          {item.content}
+                        </div>
+                      )}
+                    </Draggable>
+                  ))}
+                  {droppableProvided.placeholder}
+                </div>
+              )}
+            </Droppable>
+          </DragDropContext>
+        )}
+      </ShadowRootContext.Consumer>
     );
   }
 }

--- a/test/unit/view/drag-drop-context/styles-insertion-point.spec.js
+++ b/test/unit/view/drag-drop-context/styles-insertion-point.spec.js
@@ -1,0 +1,92 @@
+// @flow
+import React from 'react';
+import { mount, type ReactWrapper } from 'enzyme';
+import { prefix } from '../../../../src/view/data-attributes';
+import DragDropContext from '../../../../src/view/drag-drop-context';
+import { resetServerContext } from '../../../../src';
+import type { ContextId } from '../../../../src/types';
+
+const getDynamicStyleTagSelector = (contextId: ContextId) =>
+  `style[${prefix}-dynamic="${contextId}"]`;
+
+const getAlwaysStyleTagSelector = (contextId: ContextId) =>
+  `style[${prefix}-always="${contextId}"]`;
+
+it('should append styles to head stylesInsertionPoint is not specified', () => {
+  const contextId: ContextId = '0';
+  const dynamicSelector: string = getDynamicStyleTagSelector(contextId);
+  const alwaysSelector: string = getAlwaysStyleTagSelector(contextId);
+
+  resetServerContext();
+  const wrapper: ReactWrapper<*> = mount(
+    <DragDropContext onDragEnd={() => {}}>{null}</DragDropContext>,
+  );
+
+  // styles should be created in head
+  const head = document.head;
+  expect(head).toBeDefined();
+  if (!head) {
+    return;
+  }
+  expect(head.querySelector(alwaysSelector)).toBeInstanceOf(HTMLStyleElement);
+  expect(head.querySelector(dynamicSelector)).toBeInstanceOf(HTMLStyleElement);
+
+  wrapper.unmount();
+});
+
+it('should append styles to head if stylesInsertionPoint is undefined', () => {
+  const contextId: ContextId = '0';
+  const dynamicSelector: string = getDynamicStyleTagSelector(contextId);
+  const alwaysSelector: string = getAlwaysStyleTagSelector(contextId);
+
+  resetServerContext();
+  const wrapper: ReactWrapper<*> = mount(
+    <DragDropContext stylesInsertionPoint={undefined} onDragEnd={() => {}}>
+      {null}
+    </DragDropContext>,
+  );
+
+  // styles should be created in head
+  const head = document.head;
+  expect(head).toBeDefined();
+  if (!head) {
+    return;
+  }
+  expect(head.querySelector(alwaysSelector)).toBeInstanceOf(HTMLStyleElement);
+  expect(head.querySelector(dynamicSelector)).toBeInstanceOf(HTMLStyleElement);
+
+  wrapper.unmount();
+});
+
+it('should append styles to stylesInsertionPoint', () => {
+  const contextId: ContextId = '0';
+  const dynamicSelector: string = getDynamicStyleTagSelector(contextId);
+  const alwaysSelector: string = getAlwaysStyleTagSelector(contextId);
+
+  const stylesRootWrapper = mount(<div />);
+  const stylesRoot = stylesRootWrapper.getDOMNode();
+  expect(stylesRoot).toBeInstanceOf(HTMLDivElement);
+
+  resetServerContext();
+  const wrapper: ReactWrapper<*> = mount(
+    <DragDropContext stylesInsertionPoint={stylesRoot} onDragEnd={() => {}}>
+      {null}
+    </DragDropContext>,
+  );
+
+  // styles should be created in styles root
+  expect(stylesRoot.querySelector(alwaysSelector)).toBeInstanceOf(
+    HTMLStyleElement,
+  );
+  expect(stylesRoot.querySelector(dynamicSelector)).toBeInstanceOf(
+    HTMLStyleElement,
+  );
+
+  wrapper.unmount();
+
+  // styles should be removed from styles root
+  expect(stylesRoot.querySelector(alwaysSelector)).toBeFalsy();
+  expect(stylesRoot.querySelector(dynamicSelector)).toBeFalsy();
+
+  stylesRootWrapper.unmount();
+});

--- a/test/unit/view/get-elements/query-elements.spec.js
+++ b/test/unit/view/get-elements/query-elements.spec.js
@@ -1,0 +1,79 @@
+// @flow
+import React from 'react';
+import { mount } from 'enzyme';
+import { queryElements } from '../../../../src/view/get-elements/query-elements';
+
+const first = jest.fn(() => true);
+const none = jest.fn(() => false);
+
+it('should find element in document', () => {
+  const wrapper = mount(
+    <div>
+      <div id="inner" />
+    </div>,
+  );
+  const container = wrapper.getDOMNode();
+  const result = queryElements(container, '#inner', first);
+  expect(result).toBe(container.firstChild);
+  expect(first).toHaveBeenCalled();
+  wrapper.unmount();
+});
+
+it('should find element in shadow root', () => {
+  const wrapper = mount(<div />);
+  const container = wrapper.getDOMNode();
+  const root = container.attachShadow({ mode: 'open' });
+
+  const target = document.createElement('div');
+  target.id = 'inner';
+  root.appendChild(target);
+
+  const result = queryElements(root, '#inner', first);
+  expect(result).toBe(target);
+  wrapper.unmount();
+});
+
+it('should find element in nested shadow root', () => {
+  const wrapper = mount(<div />);
+  const container = wrapper.getDOMNode();
+
+  const outerShadow = container.attachShadow({ mode: 'open' });
+  const outerDiv = document.createElement('div');
+  outerShadow.appendChild(outerDiv);
+
+  const root = outerDiv.attachShadow({ mode: 'open' });
+  const target = document.createElement('div');
+  target.id = 'inner';
+  root.appendChild(target);
+
+  const result = queryElements(root, '#inner', first);
+  expect(result).toBe(target);
+  wrapper.unmount();
+});
+
+it('should find element in parent root outside of shadow root', () => {
+  const wrapper = mount(<div id="outer" />);
+  const container = wrapper.getDOMNode();
+  const root = container.attachShadow({ mode: 'open' });
+
+  const inner = document.createElement('div');
+  inner.id = 'inner';
+  root.appendChild(inner);
+
+  const result = queryElements(root, '#outer', first);
+  expect(result).toBe(container);
+  wrapper.unmount();
+});
+
+it('should return undefined if element not found', () => {
+  const wrapper = mount(
+    <div>
+      <div id="inner" />
+    </div>,
+  );
+  const container = wrapper.getDOMNode();
+  const result = queryElements(container, '#inner', none);
+  expect(result).not.toBeDefined();
+  expect(none).toHaveBeenCalled();
+  wrapper.unmount();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -11942,6 +11942,11 @@ react-redux@^7.2.0:
     prop-types "^15.7.2"
     react-is "^16.9.0"
 
+react-shadow-dom-retarget-events@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-shadow-dom-retarget-events/-/react-shadow-dom-retarget-events-1.1.0.tgz#ffe3a9dc4e6287b5239e863d0e5f1e392de0410a"
+  integrity sha512-hI/naZ8fUARf5He4PpvQtqhs/VWoocfg3ULeCOE3ccWiXGEsFpshlx2iB1XNtm2SFDdvZYoSo25a8JViYdAcgQ==
+
 react-sizeme@^2.6.7:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/react-sizeme/-/react-sizeme-2.6.12.tgz#ed207be5476f4a85bf364e92042520499455453e"


### PR DESCRIPTION
This commit addresses #1659 and allows use of RBD inside shadow roots e.g. in
Web Components. It does not cover drag&drop between different shadow roots.

The following changes were needed:

- To find the event target nested inside a shadow root we use composedPath
  instead of event.target (since event.target points just to the shadow root
  host).
- To find draggables/droppablesInstead we use query selectors on root node of
  the event source instead of the document. This is encapsulated in a new
  central place (src/view/get-elements/query-elements.js).
- Shadow roots isolate stylesheets, means global styles do not bleed into the
  shadow root. Built-in styles need to be added to the shadow root. This can be
  done by allows consumers to specify the DOM location as a
  stylesInsertionPoint prop on the DragDropContext. Similar approach is taken
  by JSS (see https://cssinjs.org/jss-api?v=v10.6.0#setup-jss-instance).
