### PR TITLE
Adding draggableId to DraggableLocation

### DIFF
--- a/src/state/get-home-location.js
+++ b/src/state/get-home-location.js
@@ -4,4 +4,5 @@ import type { DraggableDescriptor, DraggableLocation } from '../types';
 export default (descriptor: DraggableDescriptor): DraggableLocation => ({
   index: descriptor.index,
   droppableId: descriptor.droppableId,
+  draggableId: descriptor.id,
 });

--- a/src/state/middleware/drop/drop-middleware.js
+++ b/src/state/middleware/drop/drop-middleware.js
@@ -90,6 +90,7 @@ export default ({ getState, dispatch }: MiddlewareStore) => (
   const source: DraggableLocation = {
     index: critical.draggable.index,
     droppableId: critical.droppable.id,
+    draggableId: critical.draggable.id,
   };
 
   const result: DropResult = {

--- a/src/types.js
+++ b/src/types.js
@@ -152,6 +152,7 @@ export type DroppableDimension = {|
 export type DraggableLocation = {|
   droppableId: DroppableId,
   index: number,
+  draggableId: DraggableId,
 |};
 
 export type DraggableIdMap = {


### PR DESCRIPTION
Adding ```draggableId``` to ```DraggableLocation``` (used in ```dragUpdate``` and ```dragEnd```, property - ```destination```).
#2103 