### PR TITLE
fix: mark react-redux as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,8 @@
   },
   "peerDependencies": {
     "react": "^16.8.5 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^16.8.5 || ^17.0.0 || ^18.0.0"
+    "react-dom": "^16.8.5 || ^17.0.0 || ^18.0.0",
+    "react-redux": "^7.2.0"
   },
   "license": "Apache-2.0",
   "jest-junit": {


### PR DESCRIPTION
Related to #2488.

Removing the dependency entirely would be a breaking change. Instead, we list the dependency as a peerDependency on top of the existing dependency.

At least in Yarn, this means when resolving the dependency, Yarn will first try to satisfy the peer, and if the peer is missing, it will install the dependency as a direct dependency as a fallback.

A peer dependency is required to ensure react-beautiful-dnd uses the same react-redux version as the rest of the application. As it's written at the moment, using a technology like Yarn PnP might result in multiple instances of react-redux, especially if the consumer is attempting to use a newer react-redux version.