### PR TITLE
Make available `DroppableChildrenFn` type

### DIFF
--- a/docs/api/droppable.md
+++ b/docs/api/droppable.md
@@ -36,7 +36,7 @@ type Props = {|
   ignoreContainerClipping?: boolean,
   renderClone?: DraggableChildrenFn,
   getContainerForClone?: () => HTMLElement,
-  children: (DroppableProvided, DroppableStateSnapshot) => Node,
+  children: DroppableChildrenFn,
 |};
 
 type DroppableMode = 'standard' | 'virtual';
@@ -70,6 +70,13 @@ The `React` children of a `<Droppable />` must be a function that returns a [`Re
     /*...*/
   })}
 </Droppable>
+```
+
+```js
+type DroppableChildrenFn = (
+  DroppableProvided,
+  DroppableStateSnapshot,
+) => Node;
 ```
 
 The function is provided with two arguments:

--- a/docs/guides/types.md
+++ b/docs/guides/types.md
@@ -132,6 +132,10 @@ type DroppableStateSnapshot = {|
   draggingFromThisWith: ?DraggableId,
   isUsingPlaceholder: boolean,
 |};
+type DroppableChildrenFn = (
+  DroppableProvided,
+  DroppableStateSnapshot,
+) => Node;
 ```
 
 ### Draggable
@@ -164,7 +168,6 @@ type DraggableChildrenFn = (
   DraggableStateSnapshot,
   DraggableRubric,
 ) => Node | null;
-|};
 type DraggableStyle = DraggingStyle | NotDraggingStyle;
 type DraggingStyle = {|
   position: 'fixed',

--- a/src/index.js
+++ b/src/index.js
@@ -51,6 +51,7 @@ export type {
   Provided as DroppableProvided,
   StateSnapshot as DroppableStateSnapshot,
   DroppableProps,
+  DroppableChildrenFn,
 } from './view/droppable/droppable-types';
 
 // Draggable types
@@ -63,5 +64,5 @@ export type {
   DraggableStyle,
   DraggingStyle,
   NotDraggingStyle,
-  ChildrenFn as DraggableChildrenFn,
+  DraggableChildrenFn,
 } from './view/draggable/draggable-types';

--- a/src/view/draggable/draggable-types.js
+++ b/src/view/draggable/draggable-types.js
@@ -152,7 +152,7 @@ export type MapProps = {|
   // secondary: ?SecondaryMapProps,
 |};
 
-export type ChildrenFn = (
+export type DraggableChildrenFn = (
   Provided,
   StateSnapshot,
   DraggableRubric,
@@ -161,7 +161,7 @@ export type ChildrenFn = (
 export type PublicOwnProps = {|
   draggableId: DraggableId,
   index: number,
-  children: ChildrenFn,
+  children: DraggableChildrenFn,
 
   // optional own props
   isDragDisabled?: boolean,

--- a/src/view/droppable/droppable-types.js
+++ b/src/view/droppable/droppable-types.js
@@ -11,10 +11,10 @@ import type {
   DraggableRubric,
   DroppableMode,
 } from '../../types';
-import type { ChildrenFn } from '../draggable/draggable-types';
+import type { DraggableChildrenFn } from '../draggable/draggable-types';
 import { updateViewportMaxScroll } from '../../state/action-creators';
 
-export type DraggableChildrenFn = ChildrenFn;
+export type DraggableChildrenFn;
 
 export type DroppableProps = {|
   // used for shared global styles
@@ -73,9 +73,14 @@ export type DispatchProps = {|
   updateViewportMaxScroll: typeof updateViewportMaxScroll,
 |};
 
+export type DroppableChildrenFn = (
+  Provided,
+  StateSnapshot,
+) => Node;
+
 export type OwnProps = {|
   ...DefaultProps,
-  children: (Provided, StateSnapshot) => Node,
+  children: DroppableChildrenFn,
   droppableId: DroppableId,
   renderClone: ?DraggableChildrenFn,
 |};


### PR DESCRIPTION
Add a type to help people using `react-beautiful-dnd` in a TypeScript project.