### PR TITLE
Allow drag for elements with `contenteditable="plaintext-only"`

### DIFF
--- a/src/view/use-sensor-marshal/is-event-in-interactive-element.js
+++ b/src/view/use-sensor-marshal/is-event-in-interactive-element.js
@@ -35,11 +35,11 @@ function isAnInteractiveElement(parent: Element, current: ?Element) {
     return true;
   }
 
-  // contenteditable="true" or contenteditable="" are valid ways
+  // contenteditable="true", contenteditable="" and contenteditable="plaintext-only" are valid ways
   // of creating a contenteditable container
   // https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contenteditable
   const attribute: ?string = current.getAttribute('contenteditable');
-  if (attribute === 'true' || attribute === '') {
+  if (attribute === 'true' || attribute === '' || attribute === "plaintext-only") {
     return true;
   }
 


### PR DESCRIPTION
This PR extends the `isAnInteractiveElement` function to include elements with `contenteditable="plaintext-only"` which is defined in [the spec](https://w3c.github.io/contentEditable/#plaintext_only_state) and supported by all browsers except Firefox (where support [is planned](https://bugzilla.mozilla.org/show_bug.cgi?id=1291467)).

It simply adds another condition to the existing check.

I've not added an additional test, as the existing tests in `test/unit/integration/drag-handle/shared-behaviours/contenteditable.spec.js` only check elements defined as `<div contenteditable />` and not `<div contenteditable="true" />`, so I wasn't sure if the project aims to cover each and every variant. If additional tests are desired please let me know. 