### PR TITLE
React 19 support: Migrate away from `defaultProps`

### DIFF
--- a/src/view/droppable/connected-droppable.js
+++ b/src/view/droppable/connected-droppable.js
@@ -19,7 +19,6 @@ import type {
 import type {
   MapProps,
   OwnProps,
-  DefaultProps,
   Selector,
   DispatchProps,
   StateSnapshot,
@@ -227,22 +226,6 @@ const mapDispatchToProps: DispatchProps = {
   updateViewportMaxScroll: updateViewportMaxScrollAction,
 };
 
-function getBody(): HTMLElement {
-  invariant(document.body, 'document.body is not ready');
-  return document.body;
-}
-
-const defaultProps = ({
-  mode: 'standard',
-  type: 'DEFAULT',
-  direction: 'vertical',
-  isDropDisabled: false,
-  isCombineEnabled: false,
-  ignoreContainerClipping: false,
-  renderClone: null,
-  getContainerForClone: getBody,
-}: DefaultProps);
-
 // Abstract class allows to specify props and defaults to component.
 // All other ways give any or do not let add default props.
 // eslint-disable-next-line
@@ -274,7 +257,5 @@ const ConnectedDroppable: typeof DroppableType = connect(
     areStatePropsEqual: isStrictEqual,
   },
 )(Droppable);
-
-ConnectedDroppable.defaultProps = defaultProps;
 
 export default ConnectedDroppable;

--- a/src/view/droppable/droppable.jsx
+++ b/src/view/droppable/droppable.jsx
@@ -4,7 +4,7 @@ import { useMemo, useCallback } from 'use-memo-one';
 import React, { useRef, useContext, type Node } from 'react';
 import { invariant } from '../../invariant';
 import type { DraggableId } from '../../types';
-import type { Props, Provided } from './droppable-types';
+import type { DefaultProps, Props, Provided } from './droppable-types';
 import useDroppablePublisher from '../use-droppable-publisher';
 import Placeholder from '../placeholder';
 import AppContext, { type AppContextValue } from '../context/app-context';
@@ -23,7 +23,24 @@ import AnimateInOut, {
 } from '../animate-in-out/animate-in-out';
 import { PrivateDraggable } from '../draggable/draggable-api';
 
-export default function Droppable(props: Props) {
+function getBody(): HTMLElement {
+  invariant(document.body, 'document.body is not ready');
+  return document.body;
+}
+
+export default function Droppable(passedProps: Props) {
+  const defaultProps: DefaultProps = {
+    mode: 'standard',
+    type: 'DEFAULT',
+    direction: 'vertical',
+    isDropDisabled: false,
+    isCombineEnabled: false,
+    ignoreContainerClipping: false,
+    renderClone: null,
+    getContainerForClone: getBody,
+  };
+  const props = { ...defaultProps, ...passedProps };
+
   const appContext: ?AppContextValue = useContext<?AppContextValue>(AppContext);
   invariant(appContext, 'Could not find app context');
   const { contextId, isMovementAllowed } = appContext;


### PR DESCRIPTION
Hi! Love the library ❤️ 

This PR migrates away from using `defaultProps` in `connected-droppable` and moves the default prop logic into `droppable` itself. This is because [React 19 is removing support for `defaultProps` in functional components](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-proptypes-and-defaultprops).

I've seen the maintenance notice in the repo and totally understand if you don't want to go forward with merging/releasing this. But I thought I'd raise it anyway since the scope of the changes is quite small and without it the library will no longer work for projects using React 19 without a custom npm/yarn patch applied on top. 

Fixes https://github.com/atlassian/react-beautiful-dnd/issues/2563
Fixes https://github.com/atlassian/react-beautiful-dnd/issues/2576