### PR TITLE
Support payload field inside Droppable

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,25 +1,25 @@
 {
   "dist/react-beautiful-dnd.js": {
-    "bundled": 364998,
-    "minified": 133574,
-    "gzipped": 39437
+    "bundled": 365267,
+    "minified": 133730,
+    "gzipped": 39528
   },
   "dist/react-beautiful-dnd.min.js": {
-    "bundled": 306810,
-    "minified": 108365,
-    "gzipped": 31340
+    "bundled": 307035,
+    "minified": 108499,
+    "gzipped": 31392
   },
   "dist/react-beautiful-dnd.esm.js": {
-    "bundled": 240910,
-    "minified": 125371,
-    "gzipped": 32650,
+    "bundled": 241091,
+    "minified": 125515,
+    "gzipped": 32693,
     "treeshaked": {
       "rollup": {
-        "code": 21121,
+        "code": 21149,
         "import_statements": 503
       },
       "webpack": {
-        "code": 24005
+        "code": 24033
       }
     }
   }

--- a/src/state/middleware/drop/drop-middleware.js
+++ b/src/state/middleware/drop/drop-middleware.js
@@ -90,6 +90,7 @@ export default ({ getState, dispatch }: MiddlewareStore) => (
   const source: DraggableLocation = {
     index: critical.draggable.index,
     droppableId: critical.droppable.id,
+    payload: critical.draggable.payload,
   };
 
   const result: DropResult = {

--- a/src/types.js
+++ b/src/types.js
@@ -23,6 +23,7 @@ export type DraggableDescriptor = {|
   // This is technically redundant but it avoids
   // needing to look up a parent droppable just to get its type
   type: TypeId,
+  payload?: any,
 |};
 
 export type DraggableOptions = {|
@@ -152,6 +153,7 @@ export type DroppableDimension = {|
 export type DraggableLocation = {|
   droppableId: DroppableId,
   index: number,
+  payload?: ?any,
 |};
 
 export type DraggableIdMap = {

--- a/src/view/draggable/draggable-types.js
+++ b/src/view/draggable/draggable-types.js
@@ -167,6 +167,7 @@ export type PublicOwnProps = {|
   isDragDisabled?: boolean,
   disableInteractiveElementBlocking?: boolean,
   shouldRespectForcePress?: boolean,
+  payload?: any,
 |};
 
 export type PrivateOwnProps = {|

--- a/src/view/draggable/draggable.jsx
+++ b/src/view/draggable/draggable.jsx
@@ -43,8 +43,9 @@ export default function Draggable(props: Props) {
       index: props.index,
       type,
       droppableId,
+      payload: props.payload,
     }),
-    [props.draggableId, props.index, type, droppableId],
+    [props.draggableId, props.index, props.payload, type, droppableId],
   );
 
   // props


### PR DESCRIPTION
Hey I love this library! 

In this PR I'm adding a payload that can be passed to `Draggable` component and then show up in `DropResult` when onDragEnd is triggered. I have two applications with shared DragDropContext and want to share some data between them by dragging and dropping items. This solution will simplify some custom data sharing and not having to keep a separate state and then doing lookups through `draggableId`.

Fixes: #1806