### PR TITLE
Change netlify.com to netlify.app

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ We recommend that you don’t raise issues or pull requests, as they will not be
 
 ![quote application example](https://user-images.githubusercontent.com/2182637/53614150-efbed780-3c2c-11e9-9204-a5d2e746faca.gif)
 
-[Play with this example if you want!](https://react-beautiful-dnd.netlify.com/iframe.html?selectedKind=board&selectedStory=simple)
+[Play with this example if you want!](https://react-beautiful-dnd.netlify.app/iframe.html?selectedKind=board&selectedStory=simple)
 
 </div>
 

--- a/docs/about/examples.md
+++ b/docs/about/examples.md
@@ -4,12 +4,12 @@ See how beautiful it is for yourself!
 
 ## Viewing on a desktop
 
-[All the examples!](https://react-beautiful-dnd.netlify.com)
+[All the examples!](https://react-beautiful-dnd.netlify.app)
 
 ## Viewing on a mobile or tablet
 
-- [Simple list](https://react-beautiful-dnd.netlify.com/iframe.html?id=single-vertical-list--basic)
-- [Board](https://react-beautiful-dnd.netlify.com/iframe.html?id=board--simple) - best viewed in landscape
+- [Simple list](https://react-beautiful-dnd.netlify.app/iframe.html?id=single-vertical-list--basic)
+- [Board](https://react-beautiful-dnd.netlify.app/iframe.html?id=board--simple) - best viewed in landscape
 
 > We provide different links for touch devices as [storybook](https://github.com/storybooks/storybook) runs examples in an iframe which can result in a strange auto scroll experience
 

--- a/docs/guides/reparenting.md
+++ b/docs/guides/reparenting.md
@@ -126,7 +126,7 @@ getContainerForClone: () => HTMLElement,
 
 ⚠️ You are welcome to use your own `portal` solution if you want to from within your `<Draggable />`. Before we had a cloning API, reparenting needed to be done by using your own portal. It is now recommended that you use the cloning API.
 
-We have created a [working example](https://react-beautiful-dnd.netlify.com/?selectedKind=Portals&selectedStory=Using%20your%20own%20portal&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel) that uses `ReactDOM.createPortal` directly to guide you. You can view the [source here](https://github.com/atlassian/react-beautiful-dnd/blob/master/stories/11-portal.stories.js).
+We have created a [working example](https://react-beautiful-dnd.netlify.app/?selectedKind=Portals&selectedStory=Using%20your%20own%20portal&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel) that uses `ReactDOM.createPortal` directly to guide you. You can view the [source here](https://github.com/atlassian/react-beautiful-dnd/blob/master/stories/11-portal.stories.js).
 
 If you are doing drag and drop reordering within a `<table>` we have created a portal section inside our [table guide](/docs/patterns/tables.md)
 

--- a/docs/patterns/multi-drag.md
+++ b/docs/patterns/multi-drag.md
@@ -4,7 +4,7 @@
 
 Dragging multiple `<Draggable />`s at once (multi drag) is currently a pattern that needs to be built on top of `react-beautiful-dnd`. We have not included the interaction into the library itself. This is done because a multi drag experience introduces a lot of concepts, decisions and opinions. We have done a lot of work to ensure there is a standard base of [dom event management](/docs/guides/how-we-use-dom-events.md) to build on.
 
-We have created a [reference application](https://react-beautiful-dnd.netlify.com/?path=/story/multi-drag--pattern) ([source](/stories/src/multi-drag)) which implements this multi drag pattern. The application is fairly basic and does not handle performance in large lists well. As such, there is are [a few performance recommendations](#performance) that we suggest you also add on to our reference application if you want to support lists greater than 50 in size.
+We have created a [reference application](https://react-beautiful-dnd.netlify.app/?path=/story/multi-drag--pattern) ([source](/stories/src/multi-drag)) which implements this multi drag pattern. The application is fairly basic and does not handle performance in large lists well. As such, there is are [a few performance recommendations](#performance) that we suggest you also add on to our reference application if you want to support lists greater than 50 in size.
 
 ![multi drag demo](https://user-images.githubusercontent.com/2182637/37322724-7843a218-26d3-11e8-9ebb-8d5853387bb3.gif)
 

--- a/docs/patterns/tables.md
+++ b/docs/patterns/tables.md
@@ -24,7 +24,7 @@ In order to use this strategy the widths of your columns need to be fixed - that
 
 The only thing you need to do is set `display: table` on a `<Draggable />` row while it is dragging.
 
-[See example code here](https://react-beautiful-dnd.netlify.com/?selectedKind=Tables&selectedStory=with%20fixed%20width%20columns&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel)
+[See example code here](https://react-beautiful-dnd.netlify.app/?selectedKind=Tables&selectedStory=with%20fixed%20width%20columns&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel)
 
 Some users have experienced issues using the `table-layout` and `display: table` approach. Specifically, that approach of fixed layouts doesn't keep the styling once an element is being dragged. An alternative is to not set `table-layout` or `display: table` when `<Draggable />` is dragging, but rather just set the `width` of each `<td>` permanently. This avoids the need to use any event responders. E.g. in the `<Draggable />`, set each `<td>` to `width: 100px` with inline styling or css. This approach can be found in the [Code Sandbox here](https://codesandbox.io/s/vertical-list-s9rx5?fontsize=14&hidenavigation=1&theme=dark)
 
@@ -41,7 +41,7 @@ This has poor performance characteristics at scale as it requires:
 
 For tables with less than 50 rows this should approach be fine!
 
-[See example code here](https://react-beautiful-dnd.netlify.com/?selectedKind=Tables&selectedStory=with%20dimension%20locking&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel)
+[See example code here](https://react-beautiful-dnd.netlify.app/?selectedKind=Tables&selectedStory=with%20dimension%20locking&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel)
 
 ## Advanced: reparenting
 
@@ -67,8 +67,8 @@ It seems like the only way to get things working is to:
 
 This gets a little complicated - so we created some examples to show you how this technique works:
 
-- [With our cloning API](https://react-beautiful-dnd.netlify.com/?path=/story/tables--with-clone)
-- [With your own portal](https://react-beautiful-dnd.netlify.com/?path=/story/tables--with-portal)
+- [With our cloning API](https://react-beautiful-dnd.netlify.app/?path=/story/tables--with-clone)
+- [With your own portal](https://react-beautiful-dnd.netlify.app/?path=/story/tables--with-portal)
 
 You're welcome!
 

--- a/docs/patterns/virtual-lists.md
+++ b/docs/patterns/virtual-lists.md
@@ -27,16 +27,16 @@ Please raise a pull request if you would like to add examples for other virtuali
 
 ### [`react-window`](https://github.com/bvaughn/react-window)
 
-- [List](https://react-beautiful-dnd.netlify.com/?path=/story/virtual-react-window--list) ([source](/stories/src/virtual/react-window/list.jsx))
-- [Board](https://react-beautiful-dnd.netlify.com/?path=/story/virtual-react-window--board) ([source](/stories/src/virtual/react-window/board.jsx))
+- [List](https://react-beautiful-dnd.netlify.app/?path=/story/virtual-react-window--list) ([source](/stories/src/virtual/react-window/list.jsx))
+- [Board](https://react-beautiful-dnd.netlify.app/?path=/story/virtual-react-window--board) ([source](/stories/src/virtual/react-window/board.jsx))
 - [Basic list on `codesandbox.io`](https://codesandbox.io/s/simple-virtual-list-dark-c6wqc)
 - [Basic board on `codesandbox.io`](https://codesandbox.io/s/simple-virtual-list-board-vgvzt)
 
 ### [`react-virtualized`](https://github.com/bvaughn/react-virtualized)
 
-- [List](https://react-beautiful-dnd.netlify.com/?path=/story/virtual-react-virtualized--list) ([source](/stories/src/virtual/react-virtualized/list.jsx))
-- [Board](https://react-beautiful-dnd.netlify.com/?path=/story/virtual-react-virtualized--board) ([source](/stories/src/virtual/react-virtualized/board.jsx))
-- [List](https://react-beautiful-dnd.netlify.com/?path=/story/virtual-react-virtualized--window-list) with [`WindowScroller`](https://github.com/bvaughn/react-virtualized/blob/master/docs/WindowScroller.md) ([source](/stories/src/virtual/react-virtualized/window-list.jsx))
+- [List](https://react-beautiful-dnd.netlify.app/?path=/story/virtual-react-virtualized--list) ([source](/stories/src/virtual/react-virtualized/list.jsx))
+- [Board](https://react-beautiful-dnd.netlify.app/?path=/story/virtual-react-virtualized--board) ([source](/stories/src/virtual/react-virtualized/board.jsx))
+- [List](https://react-beautiful-dnd.netlify.app/?path=/story/virtual-react-virtualized--window-list) with [`WindowScroller`](https://github.com/bvaughn/react-virtualized/blob/master/docs/WindowScroller.md) ([source](/stories/src/virtual/react-virtualized/window-list.jsx))
 
 ### [`react-virtuoso`](https://github.com/petyosi/react-virtuoso)
 React Virtuoso comes with automatic item measurement out of the box.

--- a/docs/support/community-and-addons.md
+++ b/docs/support/community-and-addons.md
@@ -5,10 +5,10 @@
 - [kanban-dnd](https://kanban-dnd.glitch.me) - A Kanban style to-do list, with the ability to create custom lanes and reorder them on the fly.
 - [react-beautiful-dnd-test-utils](https://github.com/colinrcummings/react-beautiful-dnd-test-utils) - 🧤 Test utils for `react-beautiful-dnd` built with `react-testing-library`.
 - Simple Trello - A simple cloning version of Trello, using React ecosystem.
-  - [Demo](https://simple-trello.netlify.com/)
+  - [Demo](https://simple-trello.netlify.app/)
   - [Source](https://github.com/ng-hai/simple-trello)
 - 🎮 A drag'n'drop Checkers game
-  - [Demo](https://checkers-game.netlify.com/)
+  - [Demo](https://checkers-game.netlify.app/)
   - [Source](https://github.com/emanuellarini/checkers)
 - [react-kanban](https://github.com/lourenci/react-kanban) - Another Kanban/Trello board lib for React, with customizations to use in projects.
 


### PR DESCRIPTION
Change netlify.com to netlify.app due to deprecated automatic .com redirects

netlify.com urls don't work:
![image](https://github.com/user-attachments/assets/2e9e4f80-8041-402f-8c47-30da525307a1)

https://answers.netlify.com/t/deprecating-automatic-com-redirects/115442